### PR TITLE
Switch Service request to a generic

### DIFF
--- a/tower-add-origin/Cargo.toml
+++ b/tower-add-origin/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 [dependencies]
 futures = "0.1"
 http = "0.1"
-tower-service = { git = "https://github.com/tower-rs/tower", branch = "generic-request" }
+tower-service = { git = "https://github.com/tower-rs/tower" }
 
 [dev-dependencies]
-tower-mock = { git = "https://github.com/tower-rs/tower", branch = "generic-request" }
+tower-mock = { git = "https://github.com/tower-rs/tower" }

--- a/tower-add-origin/Cargo.toml
+++ b/tower-add-origin/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 [dependencies]
 futures = "0.1"
 http = "0.1"
-tower-service = { git = "https://github.com/tower-rs/tower", branch = "eliza/generic-service" }
+tower-service = { git = "https://github.com/tower-rs/tower", branch = "generic-request" }
 
 [dev-dependencies]
-tower-mock = { git = "https://github.com/tower-rs/tower" }
+tower-mock = { git = "https://github.com/tower-rs/tower", branch = "generic-request" }

--- a/tower-add-origin/Cargo.toml
+++ b/tower-add-origin/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 [dependencies]
 futures = "0.1"
 http = "0.1"
-tower-service = { git = "https://github.com/tower-rs/tower" }
+tower-service = { git = "https://github.com/tower-rs/tower", branch = "eliza/generic-service" }
 
 [dev-dependencies]
 tower-mock = { git = "https://github.com/tower-rs/tower" }

--- a/tower-add-origin/src/lib.rs
+++ b/tower-add-origin/src/lib.rs
@@ -65,10 +65,9 @@ impl<T> AddOrigin<T> {
     }
 }
 
-impl<T, B> Service for AddOrigin<T>
-where T: Service<Request = Request<B>>,
+impl<T, B> Service<Request<B>> for AddOrigin<T>
+where T: Service<Request<B>>,
 {
-    type Request = Request<B>;
     type Response = T::Response;
     type Error = T::Error;
     type Future = T::Future;
@@ -77,7 +76,7 @@ where T: Service<Request = Request<B>>,
         self.inner.poll_ready()
     }
 
-    fn call(&mut self, req: Self::Request) -> Self::Future {
+    fn call(&mut self, req: Request<B>) -> Self::Future {
         // Split the request into the head and the body.
         let (mut head, body) = req.into_parts();
 


### PR DESCRIPTION
Depends on tower-rs/tower#109.

This branch updates `tower-http` to work with the change to
`tower-service` that makes services generic over the request type.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>