### PR TITLE
Add Body::is_end_stream

### DIFF
--- a/tower-http-service/src/body.rs
+++ b/tower-http-service/src/body.rs
@@ -21,6 +21,17 @@ pub trait Body {
 
     /// Poll for an optional **single** `HeaderMap` of trailers.
     fn poll_trailers(&mut self) -> Poll<Option<HeaderMap>, Self::Error>;
+
+    /// Returns `true` when the end of stream has been reached.
+    ///
+    /// An end of stream means that both `poll_buf` and `poll_trailers` will
+    /// return `None`.
+    ///
+    /// A return value of `false` **does not** guarantee that a value will be
+    /// returend from `poll_stream` or `poll_trailers`.
+    fn is_end_stream(&self) -> bool {
+        false
+    }
 }
 
 impl<T: BufStream> Body for T {
@@ -37,5 +48,14 @@ impl<T: BufStream> Body for T {
 
     fn poll_trailers(&mut self) -> Poll<Option<HeaderMap>, Self::Error> {
         Ok(Async::Ready(None))
+    }
+
+    fn is_end_stream(&self) -> bool {
+        let size_hint = self.size_hint();
+
+        size_hint
+            .upper()
+            .map(|upper| upper == 0 && upper == size_hint.lower())
+            .unwrap_or(false)
     }
 }

--- a/tower-http-service/src/body.rs
+++ b/tower-http-service/src/body.rs
@@ -28,7 +28,7 @@ pub trait Body {
     /// return `None`.
     ///
     /// A return value of `false` **does not** guarantee that a value will be
-    /// returend from `poll_stream` or `poll_trailers`.
+    /// returned from `poll_stream` or `poll_trailers`.
     fn is_end_stream(&self) -> bool {
         false
     }

--- a/tower-http-service/tests/is_end_stream.rs
+++ b/tower-http-service/tests/is_end_stream.rs
@@ -1,0 +1,52 @@
+extern crate futures;
+extern crate tokio_buf;
+extern crate tower_http_service;
+
+use futures::Poll;
+use tokio_buf::{BufStream, SizeHint};
+use tower_http_service::Body;
+
+struct Mock {
+    size_hint: SizeHint,
+}
+
+impl BufStream for Mock {
+    type Item = ::std::io::Cursor<Vec<u8>>;
+    type Error = ();
+
+    fn poll_buf(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        unimplemented!();
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.size_hint.clone()
+    }
+}
+
+#[test]
+fn buf_stream_is_end_stream() {
+    let combos = [
+        (None, None, false),
+        (Some(123), None, false),
+        (Some(0), Some(123), false),
+        (Some(123), Some(123), false),
+        (Some(0), Some(0), true),
+    ];
+
+    for &(lower, upper, is_end_stream) in &combos {
+        let mut size_hint = SizeHint::new();
+        assert_eq!(0, size_hint.lower());
+        assert!(size_hint.upper().is_none());
+
+        if let Some(lower) = lower {
+            size_hint.set_lower(lower);
+        }
+
+        if let Some(upper) = upper {
+            size_hint.set_upper(upper);
+        }
+
+        let mock = Mock { size_hint };
+        assert_eq!(is_end_stream, mock.is_end_stream(), "size_hint = {:?}", mock.size_hint);
+    }
+}


### PR DESCRIPTION
Provides a hint indicating if the Body is done streaming. Being done
implies that the Body value will no longer yield data or trailers.

False negatives are permitted, but not false positives.