### PR TITLE
Fix request modifier build

### DIFF
--- a/tower-request-modifier/src/lib.rs
+++ b/tower-request-modifier/src/lib.rs
@@ -10,14 +10,12 @@ use std::sync::Arc;
 use tower_service::Service;
 
 /// Wraps an HTTP service, injecting authority and scheme on every request.
-pub struct RequestModifier<T, B>
-{
+pub struct RequestModifier<T, B> {
     inner: T,
     modifiers: Arc<Vec<Box<dyn Fn(Request<B>) -> Request<B> + Send + Sync>>>,
 }
 
-impl<T, B> std::fmt::Debug for RequestModifier<T, B>
-{
+impl<T, B> std::fmt::Debug for RequestModifier<T, B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         writeln!(f, "RequestModifier with {} modifiers", self.modifiers.len())
     }
@@ -44,8 +42,7 @@ pub struct BuilderError {
 
 // ===== impl RequestModifier ======
 
-impl<T, B> RequestModifier<T, B>
-{
+impl<T, B> RequestModifier<T, B> {
     /// Create a new `RequestModifier`
     pub fn new(
         inner: T,
@@ -205,8 +202,7 @@ impl<B> Builder<B> {
         self
     }
 
-    pub fn build<T>(self, inner: T) -> Result<RequestModifier<T, B>, BuilderError>
-    {
+    pub fn build<T>(self, inner: T) -> Result<RequestModifier<T, B>, BuilderError> {
         let modifiers = self.modifiers.into_iter().collect::<Result<Vec<_>, _>>()?;
         Ok(RequestModifier::new(inner, Arc::new(modifiers)))
     }

--- a/tower-request-modifier/src/lib.rs
+++ b/tower-request-modifier/src/lib.rs
@@ -11,18 +11,12 @@ use tower_service::Service;
 
 /// Wraps an HTTP service, injecting authority and scheme on every request.
 pub struct RequestModifier<T, B>
-where
-    T: Clone,
-    B: Clone,
 {
     inner: T,
     modifiers: Arc<Vec<Box<dyn Fn(Request<B>) -> Request<B> + Send + Sync>>>,
 }
 
 impl<T, B> std::fmt::Debug for RequestModifier<T, B>
-where
-    T: Clone,
-    B: Clone,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         writeln!(f, "RequestModifier with {} modifiers", self.modifiers.len())
@@ -51,9 +45,6 @@ pub struct BuilderError {
 // ===== impl RequestModifier ======
 
 impl<T, B> RequestModifier<T, B>
-where
-    T: Clone,
-    B: Clone,
 {
     /// Create a new `RequestModifier`
     pub fn new(
@@ -84,8 +75,7 @@ where
 
 impl<T, B> Service<Request<B>> for RequestModifier<T, B>
 where
-    T: Service<Request<B>> + Clone,
-    B: Clone,
+    T: Service<Request<B>>,
 {
     type Response = T::Response;
     type Error = T::Error;
@@ -109,7 +99,6 @@ where
 impl<T, B> Clone for RequestModifier<T, B>
 where
     T: Clone,
-    B: Clone,
 {
     fn clone(&self) -> Self {
         RequestModifier {
@@ -217,9 +206,6 @@ impl<B> Builder<B> {
     }
 
     pub fn build<T>(self, inner: T) -> Result<RequestModifier<T, B>, BuilderError>
-    where
-        T: Clone,
-        B: Clone,
     {
         let modifiers = self.modifiers.into_iter().collect::<Result<Vec<_>, _>>()?;
         Ok(RequestModifier::new(inner, Arc::new(modifiers)))

--- a/tower-request-modifier/src/lib.rs
+++ b/tower-request-modifier/src/lib.rs
@@ -96,7 +96,7 @@ where
 
 // ===== impl Builder ======
 
-impl<B: Default> Builder<B> {
+impl<B> Builder<B> {
     /// Return a new, default builder
     pub fn new() -> Self {
         Builder::default()


### PR DESCRIPTION
I accidentally left the `Default` restriction on `Builder`'s generic parameter. This pushed a `Default` requirement down to the request body (`BoxBody` for `tower-grpc`). This is fixed in 62b96cf81cb21870039df15c0bd5860144ef8c34.

I'm also seeing an issue where the grpc client connection (`GrpcConnection<RequestModifier<...>>` (full type below) cannot be cloned. I'm trying to figure out how to fix this but have not found a solution.

Full type of the grpc client connection:
`GrpcConnection<RequestModifier<tower_h2::client::connection::Connection<tokio_tcp::stream::TcpStream, tokio::runtime::threadpool::task_executor::TaskExecutor, tower_grpc::body::BoxBody>, tower_grpc::body::BoxBody>>`