### PR TITLE
Add MIT license to Cargo.toml

### DIFF
--- a/http-body/Cargo.toml
+++ b/http-body/Cargo.toml
@@ -2,6 +2,7 @@
 name = "http-body"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
+license = "MIT"
 
 [dependencies]
 bytes = "0.4.11"

--- a/tower-http-util/Cargo.toml
+++ b/tower-http-util/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tower-http-util"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
+license = "MIT"
 edition = "2018"
 
 [dependencies]

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tower-http"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
+license = "MIT"
 edition = "2018"
 
 [dependencies]

--- a/tower-request-modifier/Cargo.toml
+++ b/tower-request-modifier/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tower-request-modifier"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
+license = "MIT"
 
 [dependencies]
 futures = "0.1"


### PR DESCRIPTION
Found that the crates were missing specifying the license in `Cargo.toml`, so added MIT there as well just as the LICENSE file report. Hope this was the intention.

When the crates were lacking a specified license we couldn't categorize them to have a proper whitelisted license with `cargo license` in our project here at Embark that uses tower-http.