### PR TITLE
Introduce tower-http-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,5 @@ members = [
   "tower-http",
   "tower-http-util",
   "tower-request-modifier",
+  "tower-http-tls",
 ]

--- a/tower-http-tls/Cargo.toml
+++ b/tower-http-tls/Cargo.toml
@@ -20,6 +20,6 @@ http = "0.1"
 tower = "0.1"
 tokio-buf = "0.1"
 tower-hyper = { path = "../../tower-hyper" }
-# tower-http = { path = "../tower-http" }
-tower-http = { git = "https://github.com/tower-rs/tower-http" }
+tower-http = { path = "../tower-http" }
+# tower-http = { git = "https://github.com/tower-rs/tower-http" }
 hyper = "0.12"

--- a/tower-http-tls/Cargo.toml
+++ b/tower-http-tls/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "tower-http-tls"
+version = "0.1.0"
+authors = ["Lucio Franco <luciofranco14@gmail.com>"]
+
+[dependencies]
+futures = "0.1"
+tower-http-util = { path = "../tower-http-util" }
+rustls = "0.15"
+tokio-rustls = "0.10.0-alpha.2"
+tokio-tcp = "0.1"
+tokio-io = "0.1"
+tower-service = "0.2"
+webpki = "0.19"
+webpki-roots = "0.16"
+http = "0.1"
+# trust-dns = "0.16"
+
+[dev-dependencies]
+tower = "0.1"
+tokio-buf = "0.1"
+tower-hyper = { path = "../../tower-hyper" }
+# tower-http = { path = "../tower-http" }
+tower-http = { git = "https://github.com/tower-rs/tower-http" }
+hyper = "0.12"

--- a/tower-http-tls/examples/akamai.rs
+++ b/tower-http-tls/examples/akamai.rs
@@ -12,17 +12,17 @@ use tokio_buf::util::BufStreamExt;
 use tower::{MakeService, Service};
 use tower_http::BodyExt;
 use tower_http_tls::TlsConnector;
-use tower_hyper::client::{Builder, Connect};
+use tower_hyper::Connect;
 
 fn main() {
     hyper::rt::run(connect());
 }
 
 fn connect() -> impl Future<Item = (), Error = ()> {
-    let destination = "http2.akamai.com:443";
+    let destination = "https://http2.akamai.com";
 
     let connector = TlsConnector::with_root(true);
-    let mut client = Connect::new(connector, Builder::new().http2_only(true).clone());
+    let mut client = Connect::new(connector);
 
     client
         .make_service(destination)
@@ -34,18 +34,18 @@ fn connect() -> impl Future<Item = (), Error = ()> {
 
             conn.call(request)
                 .map_err(|e| eprintln!("Call Error: {}", e))
-                .and_then(|response| {
-                    println!("Response Status: {:?}", response.status());
-                    response
-                        .into_body()
-                        .into_buf_stream()
-                        .collect::<Vec<u8>>()
-                        .map(|v| String::from_utf8(v).unwrap())
-                        .map_err(|e| eprintln!("Body Error: {:?}", e))
-                })
-                .and_then(|body| {
-                    println!("Response Body: {}", body);
-                    Ok(())
-                })
+        })
+        .and_then(|response| {
+            println!("Response Status: {:?}", response.status());
+            response
+                .into_body()
+                .into_buf_stream()
+                .collect::<Vec<u8>>()
+                .map(|v| String::from_utf8(v).unwrap())
+                .map_err(|e| eprintln!("Body Error: {:?}", e))
+        })
+        .and_then(|body| {
+            println!("Response Body: {}", body);
+            Ok(())
         })
 }

--- a/tower-http-tls/examples/akamai.rs
+++ b/tower-http-tls/examples/akamai.rs
@@ -1,0 +1,51 @@
+extern crate futures;
+extern crate hyper;
+extern crate tokio_buf;
+extern crate tower;
+extern crate tower_http;
+extern crate tower_http_tls;
+extern crate tower_hyper;
+
+use futures::Future;
+use hyper::Request;
+use tokio_buf::util::BufStreamExt;
+use tower::{MakeService, Service};
+use tower_http::BodyExt;
+use tower_http_tls::TlsConnector;
+use tower_hyper::client::{Builder, Connect};
+
+fn main() {
+    hyper::rt::run(connect());
+}
+
+fn connect() -> impl Future<Item = (), Error = ()> {
+    let destination = "http2.akamai.com:443";
+
+    let connector = TlsConnector::with_root(true);
+    let mut client = Connect::new(connector, Builder::new().http2_only(true).clone());
+
+    client
+        .make_service(destination)
+        .map_err(|err| eprintln!("Connect Error {:?}", err))
+        .and_then(|mut conn| {
+            let request = Request::get("https://http2.akamai.com/")
+                .body(Vec::new())
+                .unwrap();
+
+            conn.call(request)
+                .map_err(|e| eprintln!("Call Error: {}", e))
+                .and_then(|response| {
+                    println!("Response Status: {:?}", response.status());
+                    response
+                        .into_body()
+                        .into_buf_stream()
+                        .collect::<Vec<u8>>()
+                        .map(|v| String::from_utf8(v).unwrap())
+                        .map_err(|e| eprintln!("Body Error: {:?}", e))
+                })
+                .and_then(|body| {
+                    println!("Response Body: {}", body);
+                    Ok(())
+                })
+        })
+}

--- a/tower-http-tls/src/lib.rs
+++ b/tower-http-tls/src/lib.rs
@@ -1,0 +1,130 @@
+extern crate futures;
+extern crate http;
+extern crate rustls;
+extern crate tokio_io;
+extern crate tokio_rustls;
+extern crate tokio_tcp;
+extern crate tower_http_util;
+extern crate tower_service;
+extern crate webpki;
+extern crate webpki_roots;
+
+use futures::{Future, Poll};
+use http::Version;
+use rustls::{ClientConfig, Session};
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::Arc;
+use tokio_io::{AsyncRead, AsyncWrite};
+use tokio_rustls::client::TlsStream;
+use tokio_tcp::TcpStream;
+use tower_http_util::HttpConnection;
+use tower_service::Service;
+use webpki::DNSNameRef;
+use webpki_roots::TLS_SERVER_ROOTS;
+
+const ALPN_H2: &str = "h2";
+
+pub struct TlsConnector {
+    config: Arc<ClientConfig>,
+}
+
+pub struct TlsConnection {
+    inner: TlsStream<TcpStream>,
+}
+
+impl TlsConnector {
+    pub fn new(config: ClientConfig) -> Self {
+        let config = Arc::new(config);
+        TlsConnector { config }
+    }
+
+    pub fn with_root(h2: bool) -> Self {
+        let mut config = ClientConfig::new();
+        config
+            .root_store
+            .add_server_trust_anchors(&TLS_SERVER_ROOTS);
+
+        if h2 {
+            config.alpn_protocols.push(Vec::from(&ALPN_H2[..]));
+        }
+
+        TlsConnector::new(config)
+    }
+}
+
+impl<Target> Service<Target> for TlsConnector
+where
+    Target: AsRef<str> + 'static,
+{
+    type Response = TlsConnection;
+    type Error = std::io::Error;
+    type Future = Box<Future<Item = Self::Response, Error = Self::Error> + Send + 'static>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        Ok(().into())
+    }
+
+    fn call(&mut self, target: Target) -> Self::Future {
+        let addr = target.as_ref().to_socket_addrs().unwrap().next().unwrap();
+        // TODO(lucio): how do we get a generic target that can extract the DNS from it
+        // and still provide a host:port combo to get the TcpStream?
+        let dns = DNSNameRef::try_from_ascii_str("http2.akamai.com") //(target.as_ref())
+            .unwrap()
+            .to_owned();
+        let config = self.config.clone();
+
+        let connect = TcpStream::connect(&addr)
+            .and_then(move |io| tokio_rustls::TlsConnector::from(config).connect(dns.as_ref(), io))
+            .map(TlsConnection::from);
+
+        Box::new(connect)
+    }
+}
+
+impl HttpConnection for TlsConnection {
+    fn version(&self) -> Version {
+        let (_, session) = self.inner.get_ref();
+        let negotiated_protocol = session.get_alpn_protocol();
+
+        if Some(ALPN_H2.as_bytes()) == negotiated_protocol.as_ref().map(|x| &**x) {
+            Version::HTTP_2
+        } else {
+            Version::default()
+        }
+    }
+
+    fn remote_addr(&self) -> std::io::Result<SocketAddr> {
+        let (io, _) = self.inner.get_ref();
+        io.peer_addr()
+    }
+}
+
+impl AsyncRead for TlsConnection {}
+
+impl AsyncWrite for TlsConnection {
+    fn shutdown(&mut self) -> Poll<(), std::io::Error> {
+        self.inner.shutdown()
+    }
+}
+
+impl std::io::Read for TlsConnection {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+impl std::io::Write for TlsConnection {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+impl From<TlsStream<TcpStream>> for TlsConnection {
+    fn from(inner: TlsStream<TcpStream>) -> Self {
+        TlsConnection { inner }
+    }
+}

--- a/tower-http-util/Cargo.toml
+++ b/tower-http-util/Cargo.toml
@@ -10,5 +10,7 @@ futures = "0.1.25"
 http = "0.1.16"
 http-body = { version = "0.1.0", path = "../http-body" }
 tokio-buf = "0.1.0"
+tokio-io = "0.1"
+tokio-tcp = "0.1"
 tower-service = "0.2.0"
 # bytes = "0.4.11"

--- a/tower-http-util/src/connection.rs
+++ b/tower-http-util/src/connection.rs
@@ -1,0 +1,69 @@
+//! Contains all Http Connection utilities.
+
+use futures::{Future, Poll};
+use http::Version;
+use std::net::SocketAddr;
+use tokio_io::{AsyncRead, AsyncWrite};
+use tokio_tcp::TcpStream;
+use tower_service::Service;
+
+/// A Http aware connection creator.
+pub trait HttpMakeConnection<Target>: sealed::Sealed<Target> {
+    /// The transport provided by this service that is HTTP aware.
+    type Connection: HttpConnection + AsyncRead + AsyncWrite;
+
+    /// Errors produced by the connecting service
+    type Error;
+
+    /// The future that eventually produces the transport
+    type Future: Future<Item = Self::Connection, Error = Self::Error>;
+
+    /// Returns `Ready` when it is able to make more connections.
+    fn poll_ready(&mut self) -> Poll<(), Self::Error>;
+
+    /// Connect and return a transport asynchronously
+    fn make_connection(&mut self, target: Target) -> Self::Future;
+}
+
+/// Represents a HTTP aware connection.
+pub trait HttpConnection {
+    /// Returns the version that this stream is set too.
+    fn version(&self) -> Version;
+
+    /// Returns the remote address that this connection is connected to.
+    fn remote_addr(&self) -> std::io::Result<SocketAddr>;
+}
+
+impl HttpConnection for TcpStream {
+    fn version(&self) -> Version {
+        Version::default()
+    }
+
+    fn remote_addr(&self) -> std::io::Result<SocketAddr> {
+        self.peer_addr()
+    }
+}
+
+impl<C, Target> sealed::Sealed<Target> for C where C: Service<Target> {}
+
+impl<C, Target> HttpMakeConnection<Target> for C
+where
+    C: Service<Target>,
+    C::Response: HttpConnection + AsyncRead + AsyncWrite,
+{
+    type Connection = C::Response;
+    type Error = C::Error;
+    type Future = C::Future;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        Service::poll_ready(self)
+    }
+
+    fn make_connection(&mut self, target: Target) -> Self::Future {
+        Service::call(self, target)
+    }
+}
+
+mod sealed {
+    pub trait Sealed<Target> {}
+}

--- a/tower-http-util/src/lib.rs
+++ b/tower-http-util/src/lib.rs
@@ -5,9 +5,11 @@
 //! Specialization of `tower::Service` for working with HTTP services.
 
 pub mod body;
+pub mod connection;
 pub mod service;
 
 mod sealed;
 
 pub use body::BodyExt;
+pub use connection::{HttpConnection, HttpMakeConnection};
 pub use service::HttpService;

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -1,2 +1,2 @@
 pub use http_body::Body;
-pub use tower_http_util::{BodyExt, HttpService};
+pub use tower_http_util::{BodyExt, HttpConnection, HttpMakeConnection, HttpService};


### PR DESCRIPTION
This is the initial workings of providing a `TlsConnector` for `tower-http` transports. It introduces three new things:

- `HttpConnection` which provides http based info about a connection. @seanmonstar you may know of more items to add to this trait?
- `HttpMakeConnection` is a trait alias for `MakeConnection` that produces `HttpConnection` connections.
- `TlsConnector` is a `HttpMakeConnection` impl that provides a `TlsStream` wrapper that implements `HttpConnection`.
