### PR TITLE
Extract middlewares from Embark Studios

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,100 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request: {}
+
+jobs:
+  check:
+    # Run `cargo check` first to ensure that the pushed code at least compiles.
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, 1.40.0]
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        profile: minimal
+    - name: Check
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --all --all-targets --all-features
+
+  cargo-hack:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+    - name: Install cargo-hack
+      run: |
+        curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
+    - name: cargo hack check
+      working-directory: ${{ matrix.subcrate }}
+      run: cargo hack check --each-feature --no-dev-deps --all
+
+  test-versions:
+    # Test against the stable, beta, and nightly Rust toolchains on ubuntu-latest.
+    needs: check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, beta, nightly, 1.40.0]
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        profile: minimal
+    - name: Run tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --all --all-features
+
+  style:
+    # Check style.
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        components: rustfmt
+        profile: minimal
+    - name: rustfmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
+  
+  # warnings:
+  #   # Check for any warnings. This is informational and thus is allowed to fail.
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@master
+  #   - uses: actions-rs/toolchain@v1
+  #     with:
+  #       toolchain: stable
+  #       components: clippy
+  #       profile: minimal
+  #   - name: Clippy
+  #     uses: actions-rs/clippy-check@v1
+  #     with:
+  #       token: ${{ secrets.GITHUB_TOKEN }}
+  #       args: --all --all-targets --all-features -- -D warnings
+
+  deny-check:
+    name: cargo-deny check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,8 +22,13 @@ jobs:
     - name: Check
       uses: actions-rs/cargo@v1
       with:
-        command: check
+        command: clippy
         args: --all --all-targets --all-features
+    - name: rustfmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
 
   cargo-hack:
     runs-on: ubuntu-latest
@@ -58,39 +63,6 @@ jobs:
       with:
         command: test
         args: --all --all-features
-
-  style:
-    # Check style.
-    needs: check
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        components: rustfmt
-        profile: minimal
-    - name: rustfmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
-  
-  # warnings:
-  #   # Check for any warnings. This is informational and thus is allowed to fail.
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@master
-  #   - uses: actions-rs/toolchain@v1
-  #     with:
-  #       toolchain: stable
-  #       components: clippy
-  #       profile: minimal
-  #   - name: Clippy
-  #     uses: actions-rs/clippy-check@v1
-  #     with:
-  #       token: ${{ secrets.GITHUB_TOKEN }}
-  #       args: --all --all-targets --all-features -- -D warnings
 
   deny-check:
     name: cargo-deny check

--- a/.github/workflows/patch.toml
+++ b/.github/workflows/patch.toml
@@ -1,0 +1,5 @@
+# Patch dependencies to run all tests against versions of the crate in the
+# repository.
+[patch.crates-io]
+tower-http = { path = "tower-http" }
+tower-http-examples = { path = "tower-http-examples" }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Deploy API Documentation
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Install nightly Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+      - name: Generate documentation
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --workspace --no-deps --all-features
+          # Tower uses nightly-only RustDoc features
+          toolchain: nightly
+        env:
+          # Enable the RustDoc `#[doc(cfg(...))]` attribute.
+          RUSTDOCFLAGS: --cfg docsrs
+      - name: Deploy documentation
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v1
+        with:
+          target_branch: gh-pages
+          build_dir: target/doc
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = [
+  "tower-http",
+  "tower-http-examples",
+]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@ These are the middlewares included in this crate:
 
 Middlewares uses the [`http`] crate as the HTTP interface so they're compatible with any library or framework that also uses [`http`]. For example hyper and actix.
 
+The middlewares were originally extracted from one of [@EmbarkStudios] internal projects.
+
 All middlewares are disabled by default and can be enabled using a cargo feature. The feature `full` turns on everything.
 
 [`http`]: https://crates.io/crates/http
 [sensitive]: https://docs.rs/http/latest/http/header/struct.HeaderValue.html#method.set_sensitive
 [request extensions]: https://docs.rs/http/latest/http/struct.Extensions.html
 [metrics]: https://crates.io/crates/metrics
+[@EmbarkStudios]: https://github.com/EmbarkStudios

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Tower HTTP
 
-Tower utilities for HTTP clients and servers
+Tower middlewares and utilities for HTTP clients and servers
 
-[![Build Status](https://travis-ci.org/tower-rs/tower-http.svg?branch=master)](https://travis-ci.org/tower-rs/tower-http)
+[![Build status](https://github.com/tower-rs/tower-http/workflows/CI/badge.svg)](https://github.com/tower-rs/tower-http/actions)
 
-More information about this crate can be found in the [crate documentation][dox]
+More information about this crate can be found in the [crate documentation][dox].
 
 [dox]: https://tower-rs.github.io/tower-http/tower_http
 
@@ -13,3 +13,25 @@ environment or you will regret it!** This crate is still under active
 development and there has not yet been any focus on documentation (because you
 shouldn't be using it yet!).
 
+## Middlewares
+
+These are the middlewares included in this crate:
+
+- `AddExtension`: Stick some shareable value in [request extensions].
+- `Compression`: Apply compression to responses. Uses the `Accept-Encoding` header to pick an encoding. Supports gzip, deflate, brotli, and zstd. Requires hyper because it uses `hyper::Body`.
+- `DebugEnterLeave`: Print when entering and leaving a middleware. Useful for verifying the order in which your middlewares run.
+- `Metrics`: Record high level metrics. Uses the [metrics] crate.
+- `PropagateHeader`: Propagate a header from the request to the response.
+- `SensitiveHeader`: Marks a given header as [sensitive] so it wont show up in logs.
+- `SetResponseHeader`: Set a header on the response.
+- `Trace`: High level tracing of requests and responses.
+- `WrapInSpan`: Wrap response futures in a `tracing::Span`.
+
+Middlewares uses the [`http`] crate as the HTTP interface so they're compatible with any library or framework that also uses [`http`]. For example hyper and actix.
+
+All middlewares are disabled by default and can be enabled using a cargo feature. The feature `full` turns on everything.
+
+[`http`]: https://crates.io/crates/http
+[sensitive]: https://docs.rs/http/latest/http/header/struct.HeaderValue.html#method.set_sensitive
+[request extensions]: https://docs.rs/http/latest/http/struct.Extensions.html
+[metrics]: https://crates.io/crates/metrics

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,29 @@
+[advisories]
+vulnerability = "deny"
+unmaintained = "warn"
+notice = "warn"
+ignore = []
+
+[licenses]
+unlicensed = "deny"
+allow = []
+deny = []
+copyleft = "warn"
+allow-osi-fsf-free = "either"
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "deny"
+highlight = "all"
+skip-tree = [{ name = "tower", version = ">=0.3, <=0.4" }]
+skip = [
+    # `quickcheck` and `tracing-subscriber` depend on incompatible versions of
+    # `wasi` via their dependencies on `rand` and `chrono`, respectively; we
+    # can't really fix this.
+    { name = "wasi" },
+]
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-git = []

--- a/tower-http-examples/Cargo.toml
+++ b/tower-http-examples/Cargo.toml
@@ -3,6 +3,7 @@ name = "tower-http-examples"
 version = "0.1.0"
 authors = ["David Pedersen <david.pdrsn@gmail.com>"]
 edition = "2018"
+license = "MIT"
 publish = false
 
 [dependencies]

--- a/tower-http-examples/Cargo.toml
+++ b/tower-http-examples/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tower-http-examples"
+version = "0.1.0"
+authors = ["David Pedersen <david.pdrsn@gmail.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+hyper = { version = "0.14", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.4", features = ["util"] }
+tower-http = { path = "../tower-http", features = ["full"] }
+uuid = { version = "0.8", features = ["v4"] }
+tracing = "0.1"
+tracing-subscriber = "0.2"

--- a/tower-http-examples/README.md
+++ b/tower-http-examples/README.md
@@ -1,0 +1,3 @@
+# tower-http-examples
+
+This crate contains a complete (currently work in progress) example of how to use tower-http.

--- a/tower-http-examples/src/main.rs
+++ b/tower-http-examples/src/main.rs
@@ -1,0 +1,90 @@
+#![allow(dead_code, unused_imports)]
+
+use hyper::{
+    header::{self, HeaderName, HeaderValue},
+    service::{make_service_fn, service_fn},
+    Body, Request, Response, Server,
+};
+use std::{convert::Infallible, sync::Arc};
+use tower::ServiceBuilder;
+use tower_http::{
+    add_extension::AddExtensionLayer,
+    compression::CompressionLayer,
+    metrics::MetricsLayer,
+    propagate_header::PropagateHeaderLayer,
+    sensitive_header::SensitiveHeaderLayer,
+    set_response_header::SetResponseHeaderLayer,
+    trace::TraceLayer,
+    util::{DebugEnterLeaveLayer, LayerExt},
+    wrap_in_span::WrapInSpanLayer,
+    LatencyUnit,
+};
+use uuid::Uuid;
+
+const REQUEST_ID: &str = "x-request-id";
+
+struct State {
+    thing: i32,
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let state = Arc::new(State { thing: 1337 });
+
+    let svc = ServiceBuilder::new()
+        .layer(
+            WrapInSpanLayer::new(tracing::debug_span!("example-service"))
+                .debug_enter_leave("wrap-in-span"),
+        )
+        .layer(MetricsLayer::new().debug_enter_leave("metrics"))
+        .layer(
+            TraceLayer::new()
+                .record_headers(false)
+                .latency_unit(LatencyUnit::Nanos)
+                .record_full_uri(false)
+                .debug_enter_leave("tracing"),
+        )
+        .layer(
+            SensitiveHeaderLayer::new(header::AUTHORIZATION).debug_enter_leave("sensitive-header"),
+        )
+        .layer(
+            SetResponseHeaderLayer::new(|_res: &Response<Body>| {
+                let header = HeaderName::from_static(REQUEST_ID);
+                let value = HeaderValue::from_str(&Uuid::new_v4().to_string()).unwrap();
+                (header, value)
+            })
+            .override_existing(false)
+            .debug_enter_leave("set-response-header"),
+        )
+        .layer(
+            PropagateHeaderLayer::new(HeaderName::from_static(REQUEST_ID))
+                .debug_enter_leave("request-id"),
+        )
+        .layer(CompressionLayer::new().debug_enter_leave("compression"))
+        .layer(AddExtensionLayer::new(state).debug_enter_leave("state"))
+        .service(service_fn(handle));
+
+    let make_svc = make_service_fn(|_| {
+        let svc = svc.clone();
+        async move { Ok::<_, Infallible>(svc) }
+    });
+
+    let addr = ([127, 0, 0, 1], 3000).into();
+    let server = Server::bind(&addr).serve(make_svc);
+    if let Err(err) = server.await {
+        panic!("server error: {}", err);
+    }
+}
+
+async fn handle(_req: Request<Body>) -> Result<Response<Body>, Infallible> {
+    tracing::debug!("processing request");
+
+    let mut res = Response::new(Body::from("<h1>Hello, World!</h1>"));
+
+    res.headers_mut()
+        .insert(header::CONTENT_TYPE, HeaderValue::from_static("text/html"));
+
+    Ok(res)
+}

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -1,0 +1,63 @@
+[package]
+name = "tower-http"
+description = "Tower middlewares and utilities for HTTP clients and servers"
+version = "0.1.0"
+authors = ["Tower Maintainers <team@tower-rs.com>"]
+edition = "2018"
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/tower-rs/tower-http"
+homepage = "https://github.com/tower-rs/tower-http"
+# documentation = "https://docs.rs/tower/0.1.0"
+categories = ["asynchronous", "network-programming"]
+keywords = ["io", "async", "non-blocking", "futures", "service", "http"]
+
+[dependencies]
+futures-util = "0.3"
+http = "0.2"
+http-body = "0.4"
+pin-project = "1"
+tower-layer = "0.3"
+tower-service = "0.3"
+
+# optional dependencies
+async-compression = { version = "0.3", optional = true, features = ["deflate", "gzip", "brotli", "zstd", "tokio"] }
+hyper = { version = "0.14", optional = true, default_features = false, features = ["stream"] }
+metrics-lib = { package = "metrics", version = "0.13", features = ["std"], optional = true }
+tokio-util = { version = "0.6", optional = true, default_features = false, features = ["io", "codec"] }
+tracing = { version = "0.1", optional = true }
+
+[dev-dependencies]
+futures = "0.3"
+hyper = "0.14"
+tower = "0.4"
+
+[features]
+default = []
+full = [
+    "add-extension",
+    "compression",
+    "metrics",
+    "propagate-header",
+    "sensitive-header",
+    "set-response-header",
+    "trace",
+    "util",
+    "wrap-in-span",
+]
+add-extension = []
+compression = ["async-compression", "tokio-util", "hyper"]
+metrics = ["metrics-lib"]
+propagate-header = []
+sensitive-header = []
+set-response-header = []
+trace = ["tracing"]
+util = []
+wrap-in-span = ["tracing"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.playground]
+features = ["full"]

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -52,7 +52,7 @@ propagate-header = []
 sensitive-header = []
 set-response-header = []
 trace = ["tracing"]
-util = []
+util = ["tracing"]
 wrap-in-span = ["tracing"]
 
 [package.metadata.docs.rs]

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tower-rs/tower-http"
 homepage = "https://github.com/tower-rs/tower-http"
-# documentation = "https://docs.rs/tower/0.1.0"
-categories = ["asynchronous", "network-programming"]
+documentation = "https://docs.rs/tower-http"
+categories = ["asynchronous", "network-programming", "web-programming"]
 keywords = ["io", "async", "non-blocking", "futures", "service", "http"]
 
 [dependencies]

--- a/tower-http/src/add_extension.rs
+++ b/tower-http/src/add_extension.rs
@@ -1,0 +1,51 @@
+use crate::common::*;
+
+#[derive(Clone, Copy, Debug)]
+pub struct AddExtensionLayer<T> {
+    value: T,
+}
+
+impl<T> AddExtensionLayer<T> {
+    pub fn new(value: T) -> Self {
+        AddExtensionLayer { value }
+    }
+}
+
+impl<S, T> Layer<S> for AddExtensionLayer<T>
+where
+    T: Clone,
+{
+    type Service = AddExtension<S, T>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AddExtension {
+            inner,
+            value: self.value.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct AddExtension<S, T> {
+    inner: S,
+    value: T,
+}
+
+impl<ResBody, S, T> Service<Request<ResBody>> for AddExtension<S, T>
+where
+    S: Service<Request<ResBody>>,
+    T: 'static + Clone + Send + Sync,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ResBody>) -> Self::Future {
+        req.extensions_mut().insert(self.value.clone());
+        self.inner.call(req)
+    }
+}

--- a/tower-http/src/compression.rs
+++ b/tower-http/src/compression.rs
@@ -1,0 +1,214 @@
+use crate::common::*;
+use async_compression::tokio::bufread::BrotliEncoder;
+use async_compression::tokio::bufread::DeflateEncoder;
+use async_compression::tokio::bufread::GzipEncoder;
+use async_compression::tokio::bufread::ZstdEncoder;
+use futures_util::TryStreamExt;
+use http::HeaderMap;
+use hyper::Body;
+use std::io;
+use tokio_util::{
+    codec::{BytesCodec, FramedRead},
+    io::StreamReader,
+};
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CompressionLayer {
+    _priv: (),
+}
+
+impl CompressionLayer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<S> Layer<S> for CompressionLayer {
+    type Service = Compression<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Compression { inner }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Compression<S> {
+    inner: S,
+}
+
+impl<ResBody, S> Service<Request<ResBody>> for Compression<S>
+where
+    S: Service<Request<ResBody>, Response = Response<Body>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ResBody>) -> Self::Future {
+        let encoding = parse(req.headers()).unwrap_or(Encoding::Identity);
+
+        ResponseFuture {
+            future: self.inner.call(req),
+            encoding,
+        }
+    }
+}
+
+#[pin_project]
+#[derive(Debug)]
+pub struct ResponseFuture<F> {
+    #[pin]
+    future: F,
+    encoding: Encoding,
+}
+
+impl<F, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<Response<Body>, E>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let res = ready!(this.future.poll(cx)?);
+
+        // do the encoding
+        let encoding = *this.encoding;
+        let mut res = res.map(move |body| {
+            let stream = body.map_err(|err| io::Error::new(io::ErrorKind::Other, err));
+
+            match encoding {
+                Encoding::Gzip => {
+                    let stream = FramedRead::new(
+                        GzipEncoder::new(StreamReader::new(stream)),
+                        BytesCodec::new(),
+                    );
+                    Body::wrap_stream(stream)
+                }
+                Encoding::Deflate => {
+                    let stream = FramedRead::new(
+                        DeflateEncoder::new(StreamReader::new(stream)),
+                        BytesCodec::new(),
+                    );
+                    Body::wrap_stream(stream)
+                }
+                Encoding::Brotli => {
+                    let stream = FramedRead::new(
+                        BrotliEncoder::new(StreamReader::new(stream)),
+                        BytesCodec::new(),
+                    );
+                    Body::wrap_stream(stream)
+                }
+                Encoding::Zstd => {
+                    let stream = FramedRead::new(
+                        ZstdEncoder::new(StreamReader::new(stream)),
+                        BytesCodec::new(),
+                    );
+                    Body::wrap_stream(stream)
+                }
+                Encoding::Identity => Body::wrap_stream(stream),
+            }
+        });
+
+        // update headers
+        if let Encoding::Identity = encoding {
+            // no need to mess with headers
+        } else {
+            let headers = res.headers_mut();
+            headers.append(
+                header::CONTENT_ENCODING,
+                HeaderValue::from_static(encoding.to_str()),
+            );
+            headers.remove(header::CONTENT_LENGTH);
+        }
+
+        Poll::Ready(Ok(res))
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum Encoding {
+    Gzip,
+    Deflate,
+    Brotli,
+    Zstd,
+    Identity,
+}
+
+impl Encoding {
+    fn to_str(self) -> &'static str {
+        match self {
+            Encoding::Gzip => "gzip",
+            Encoding::Deflate => "deflate",
+            Encoding::Identity => "identity",
+            Encoding::Brotli => "br",
+            Encoding::Zstd => "zstd",
+        }
+    }
+
+    fn parse(s: &str) -> Option<Encoding> {
+        match s {
+            "gzip" => Some(Encoding::Gzip),
+            "deflate" => Some(Encoding::Deflate),
+            "br" => Some(Encoding::Brotli),
+            "zstd" => Some(Encoding::Zstd),
+            "identity" => Some(Encoding::Identity),
+            _ => None,
+        }
+    }
+}
+
+// based on https://github.com/http-rs/accept-encoding
+fn parse(headers: &HeaderMap) -> Option<Encoding> {
+    let mut preferred_encoding = None;
+    let mut max_qval = 0.0;
+
+    for (encoding, qval) in encodings(headers) {
+        if (qval - 1.0f32).abs() < 0.01 {
+            preferred_encoding = Some(encoding);
+            break;
+        } else if qval > max_qval {
+            preferred_encoding = Some(encoding);
+            max_qval = qval;
+        }
+    }
+
+    preferred_encoding
+}
+
+// based on https://github.com/http-rs/accept-encoding
+fn encodings(headers: &HeaderMap) -> Vec<(Encoding, f32)> {
+    headers
+        .get_all(header::ACCEPT_ENCODING)
+        .iter()
+        .filter_map(|hval| hval.to_str().ok())
+        .flat_map(|s| s.split(',').map(str::trim))
+        .filter_map(|v| {
+            let mut v = v.splitn(2, ";q=");
+
+            let encoding = match Encoding::parse(v.next().unwrap()) {
+                Some(encoding) => encoding,
+                None => return None, // ignore unknown encodings
+            };
+
+            let qval = if let Some(qval) = v.next() {
+                let qval = match qval.parse::<f32>() {
+                    Ok(f) => f,
+                    Err(_) => return None,
+                };
+                if qval > 1.0 {
+                    return None; // q-values over 1 are unacceptable
+                }
+                qval
+            } else {
+                1.0f32
+            };
+
+            Some((encoding, qval))
+        })
+        .collect::<Vec<(Encoding, f32)>>()
+}

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -1,6 +1,5 @@
 // #![doc(html_root_url = "https://docs.rs/tower-http/0.1.0")]
 #![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
-#![cfg_attr(test, allow(clippy::float_cmp))]
 #![warn(
     clippy::all,
     clippy::dbg_macro,
@@ -36,7 +35,10 @@
 )]
 #![deny(unreachable_pub, broken_intra_doc_links, private_in_public)]
 #![forbid(unsafe_code)]
+
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(test, allow(clippy::float_cmp))]
+#![cfg_attr(test, recursion_limit="1014")]
 
 #[cfg(test)]
 mod tests;

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -86,7 +86,7 @@ pub enum LatencyUnit {
     Nanos,
 }
 
-/// You might always want to log the literal HTTP status. gRPC for example its own status and
+/// You might not always want to log the literal HTTP status. gRPC for example its own status and
 /// always uses `200 OK` even for errors.
 // TODO(david): can we come up with a better name for this?
 pub trait GetTraceStatus<T, E> {

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -35,10 +35,9 @@
 )]
 #![deny(unreachable_pub, broken_intra_doc_links, private_in_public)]
 #![forbid(unsafe_code)]
-
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
-#![cfg_attr(test, recursion_limit="1014")]
+#![cfg_attr(test, recursion_limit = "1014")]
 
 #[cfg(test)]
 mod tests;

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -1,0 +1,144 @@
+// #![doc(html_root_url = "https://docs.rs/tower-http/0.1.0")]
+#![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
+#![cfg_attr(test, allow(clippy::float_cmp))]
+#![warn(
+    clippy::all,
+    clippy::dbg_macro,
+    clippy::todo,
+    clippy::empty_enum,
+    clippy::enum_glob_use,
+    clippy::pub_enum_variant_names,
+    clippy::mem_forget,
+    clippy::unused_self,
+    clippy::filter_map_next,
+    clippy::needless_continue,
+    clippy::needless_borrow,
+    clippy::match_wildcard_for_single_variants,
+    clippy::if_let_mutex,
+    clippy::mismatched_target_os,
+    clippy::await_holding_lock,
+    clippy::match_on_vec_items,
+    clippy::imprecise_flops,
+    clippy::suboptimal_flops,
+    clippy::lossy_float_literal,
+    clippy::rest_pat_in_fully_bound_structs,
+    clippy::fn_params_excessive_bools,
+    clippy::exit,
+    clippy::inefficient_to_string,
+    clippy::linkedlist,
+    clippy::macro_use_imports,
+    clippy::option_option,
+    clippy::verbose_file_reads,
+    clippy::unnested_or_patterns,
+    rust_2018_idioms,
+    future_incompatible,
+    nonstandard_style
+)]
+#![deny(unreachable_pub, broken_intra_doc_links, private_in_public)]
+#![forbid(unsafe_code)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+#[cfg(test)]
+mod tests;
+
+use http::Response;
+
+#[cfg(feature = "sensitive-header")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sensitive-header")))]
+pub mod sensitive_header;
+
+#[cfg(feature = "propagate-header")]
+#[cfg_attr(docsrs, doc(cfg(feature = "propagate-header")))]
+pub mod propagate_header;
+
+#[cfg(feature = "set-response-header")]
+#[cfg_attr(docsrs, doc(cfg(feature = "set-response-header")))]
+pub mod set_response_header;
+
+#[cfg(feature = "wrap-in-span")]
+#[cfg_attr(docsrs, doc(cfg(feature = "wrap-in-span")))]
+pub mod wrap_in_span;
+
+#[cfg(feature = "trace")]
+#[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
+pub mod trace;
+
+#[cfg(feature = "compression")]
+#[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
+pub mod compression;
+
+#[cfg(feature = "add-extension")]
+#[cfg_attr(docsrs, doc(cfg(feature = "add-extension")))]
+pub mod add_extension;
+
+#[cfg(feature = "util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "util")))]
+pub mod util;
+
+#[cfg(feature = "metrics")]
+#[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
+pub mod metrics;
+
+#[derive(Debug, Clone, Copy)]
+pub enum LatencyUnit {
+    Millis,
+    Nanos,
+}
+
+/// You might always want to log the literal HTTP status. gRPC for example its own status and
+/// always uses `200 OK` even for errors.
+// TODO(david): can we come up with a better name for this?
+pub trait GetTraceStatus<T, E> {
+    fn trace_status(&self, result: &Result<T, E>) -> TraceStatus;
+}
+
+// TODO(david): can we come up with a better name for this?
+pub enum TraceStatus {
+    Status(u16),
+    Error,
+}
+
+#[derive(Copy, Clone)]
+pub struct GetTraceStatusFromHttpStatus;
+
+impl<B, E> GetTraceStatus<Response<B>, E> for GetTraceStatusFromHttpStatus {
+    fn trace_status(&self, result: &Result<Response<B>, E>) -> TraceStatus {
+        match result {
+            Ok(res) => TraceStatus::Status(res.status().as_u16()),
+            Err(_) => TraceStatus::Error,
+        }
+    }
+}
+
+impl<T, E, F> GetTraceStatus<T, E> for F
+where
+    F: Fn(&Result<T, E>) -> TraceStatus,
+{
+    fn trace_status(&self, result: &Result<T, E>) -> TraceStatus {
+        self(result)
+    }
+}
+
+mod common {
+    //! Common types that middleware modules use. Just so we don't have to import them all the
+    //! time.
+
+    #![allow(unreachable_pub)]
+
+    pub use futures_util::ready;
+    pub use http::{
+        header::{self, HeaderName},
+        HeaderValue, Request, Response,
+    };
+    pub use http_body::Body;
+    pub use pin_project::pin_project;
+    pub use std::future::Future;
+    pub use std::{
+        convert::Infallible,
+        marker::PhantomData,
+        pin::Pin,
+        task::{Context, Poll},
+    };
+    pub use tower_layer::Layer;
+    pub use tower_service::Service;
+}

--- a/tower-http/src/metrics.rs
+++ b/tower-http/src/metrics.rs
@@ -1,0 +1,263 @@
+use crate::{common::*, GetTraceStatus, GetTraceStatusFromHttpStatus, LatencyUnit, TraceStatus};
+use http::{Method, Version};
+use metrics::{gauge, histogram, increment_counter, SharedString};
+use metrics_lib as metrics;
+use std::{
+    sync::atomic::{AtomicU32, Ordering},
+    time::Instant,
+};
+
+#[derive(Debug)]
+pub struct MetricsLayer<T> {
+    latency_unit: LatencyUnit,
+    get_trace_status: T,
+    what_to_record: WhatToRecord,
+}
+
+impl Default for MetricsLayer<GetTraceStatusFromHttpStatus> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct WhatToRecord {
+    path: bool,
+    method: bool,
+    http_version: bool,
+    user_agent: bool,
+    status: bool,
+    latency: bool,
+}
+
+impl MetricsLayer<GetTraceStatusFromHttpStatus> {
+    pub fn new() -> Self {
+        Self {
+            latency_unit: LatencyUnit::Millis,
+            get_trace_status: GetTraceStatusFromHttpStatus,
+            what_to_record: WhatToRecord {
+                path: true,
+                method: true,
+                http_version: true,
+                user_agent: true,
+                status: true,
+                latency: true,
+            },
+        }
+    }
+
+    pub fn latency_unit(mut self, latency_unit: LatencyUnit) -> Self {
+        self.latency_unit = latency_unit;
+        self
+    }
+
+    pub fn record_path(mut self, record_path: bool) -> Self {
+        self.what_to_record.path = record_path;
+        self
+    }
+
+    pub fn record_method(mut self, record_method: bool) -> Self {
+        self.what_to_record.method = record_method;
+        self
+    }
+
+    pub fn record_http_version(mut self, record_http_version: bool) -> Self {
+        self.what_to_record.http_version = record_http_version;
+        self
+    }
+
+    pub fn record_user_agent(mut self, record_user_agent: bool) -> Self {
+        self.what_to_record.user_agent = record_user_agent;
+        self
+    }
+
+    pub fn record_status(mut self, record_status: bool) -> Self {
+        self.what_to_record.status = record_status;
+        self
+    }
+
+    pub fn record_latency(mut self, record_latency: bool) -> Self {
+        self.what_to_record.latency = record_latency;
+        self
+    }
+
+    pub fn get_trace_status<K>(self, get_trace_status: K) -> MetricsLayer<K> {
+        MetricsLayer {
+            get_trace_status,
+            latency_unit: self.latency_unit,
+            what_to_record: self.what_to_record,
+        }
+    }
+}
+
+impl<S, T> Layer<S> for MetricsLayer<T>
+where
+    T: Clone,
+{
+    type Service = Metrics<S, T>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Metrics {
+            inner,
+            latency_unit: self.latency_unit,
+            get_trace_status: self.get_trace_status.clone(),
+            what_to_record: self.what_to_record,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Metrics<S, T> {
+    inner: S,
+    latency_unit: LatencyUnit,
+    get_trace_status: T,
+    what_to_record: WhatToRecord,
+}
+
+impl<ReqBody, ResBody, S, T> Service<Request<ReqBody>> for Metrics<S, T>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    T: Clone + GetTraceStatus<S::Response, S::Error>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future, T>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let start = Instant::now();
+        InFlightRequests::increment();
+
+        let path = then(self.what_to_record.path, || req.uri().path().to_owned());
+        let method = then(self.what_to_record.method, || req.method().to_owned());
+        let http_version = then(self.what_to_record.http_version, || req.version());
+
+        let user_agent = then(self.what_to_record.user_agent, || {
+            req.headers()
+                .get(header::USER_AGENT)
+                .and_then(|value| value.to_str().ok())
+                .map(|value| value.to_owned())
+        })
+        .flatten();
+
+        ResponseFuture {
+            future: self.inner.call(req),
+            start,
+            latency_unit: self.latency_unit,
+            get_trace_status: self.get_trace_status.clone(),
+            path,
+            method,
+            http_version,
+            user_agent,
+        }
+    }
+}
+
+// when `bool::then` is stabalized we can remove this
+fn then<F, T>(cond: bool, f: F) -> Option<T>
+where
+    F: FnOnce() -> T,
+{
+    if cond {
+        Some(f())
+    } else {
+        None
+    }
+}
+
+#[pin_project]
+#[derive(Debug)]
+pub struct ResponseFuture<F, T> {
+    #[pin]
+    future: F,
+    start: Instant,
+    latency_unit: LatencyUnit,
+    get_trace_status: T,
+    path: Option<String>,
+    method: Option<Method>,
+    http_version: Option<Version>,
+    user_agent: Option<String>,
+}
+
+impl<F, ResBody, E, T> Future for ResponseFuture<F, T>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+    T: GetTraceStatus<Response<ResBody>, E>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let result = ready!(this.future.poll(cx));
+        let duration = this.start.elapsed();
+
+        let mut labels = Vec::with_capacity(5 /* the max number of labels */);
+
+        if let Some(path) = this.path.take() {
+            labels.push(("path", SharedString::from(path)));
+        }
+
+        if let Some(method) = this.method.take() {
+            labels.push(("method", SharedString::from(method.to_string())));
+        }
+
+        if let Some(http_version) = this.http_version.take() {
+            labels.push((
+                "http_version",
+                SharedString::from(format!("{:?}", http_version)),
+            ));
+        }
+
+        if let Some(user_agent) = this.user_agent.take() {
+            labels.push(("user_agent", SharedString::from(user_agent)));
+        }
+
+        match this.get_trace_status.trace_status(&result) {
+            TraceStatus::Status(status) => {
+                labels.push(("status", SharedString::from(status.to_string())));
+            }
+            TraceStatus::Error => {
+                labels.push(("status", "error".into()));
+            }
+        }
+
+        increment_counter!("http_requests_total", &labels);
+
+        match this.latency_unit {
+            LatencyUnit::Nanos => {
+                histogram!("latency_ns", duration.as_nanos() as f64, &labels);
+            }
+            LatencyUnit::Millis => {
+                histogram!("latency_ms", duration.as_millis() as f64, &labels);
+            }
+        }
+
+        let in_flight_requests = InFlightRequests::get() as f64;
+        gauge!("in_flight_requests", in_flight_requests);
+
+        InFlightRequests::decrement();
+
+        Poll::Ready(result)
+    }
+}
+
+struct InFlightRequests;
+
+static IN_FLIGHT_REQUESTS: AtomicU32 = AtomicU32::new(0);
+
+impl InFlightRequests {
+    fn get() -> u32 {
+        IN_FLIGHT_REQUESTS.load(Ordering::Relaxed)
+    }
+
+    fn increment() {
+        IN_FLIGHT_REQUESTS.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn decrement() {
+        IN_FLIGHT_REQUESTS.fetch_sub(1, Ordering::SeqCst);
+    }
+}

--- a/tower-http/src/propagate_header.rs
+++ b/tower-http/src/propagate_header.rs
@@ -1,0 +1,77 @@
+use crate::common::*;
+
+#[derive(Clone, Debug)]
+pub struct PropagateHeaderLayer {
+    header: HeaderName,
+}
+
+impl PropagateHeaderLayer {
+    pub fn new(header: HeaderName) -> Self {
+        Self { header }
+    }
+}
+
+impl<S> Layer<S> for PropagateHeaderLayer {
+    type Service = PropagateHeader<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        PropagateHeader {
+            inner,
+            header: self.header.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PropagateHeader<S> {
+    inner: S,
+    header: HeaderName,
+}
+
+impl<ReqBody, ResBody, S> Service<Request<ReqBody>> for PropagateHeader<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let value = req.headers().get(&self.header).cloned();
+
+        ResponseFuture {
+            future: self.inner.call(req),
+            header_and_value: Some(self.header.clone()).zip(value),
+        }
+    }
+}
+
+#[pin_project]
+#[derive(Debug)]
+pub struct ResponseFuture<F> {
+    #[pin]
+    future: F,
+    header_and_value: Option<(HeaderName, HeaderValue)>,
+}
+
+impl<F, ResBody, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let mut res = ready!(this.future.poll(cx)?);
+
+        if let Some((header, value)) = this.header_and_value.take() {
+            res.headers_mut().insert(header, value);
+        }
+
+        Poll::Ready(Ok(res))
+    }
+}

--- a/tower-http/src/sensitive_header.rs
+++ b/tower-http/src/sensitive_header.rs
@@ -1,0 +1,79 @@
+use crate::common::*;
+
+#[derive(Clone, Debug)]
+pub struct SensitiveHeaderLayer {
+    header: HeaderName,
+}
+
+impl SensitiveHeaderLayer {
+    pub fn new(header: HeaderName) -> Self {
+        Self { header }
+    }
+}
+
+impl<S> Layer<S> for SensitiveHeaderLayer {
+    type Service = SensitiveHeader<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        SensitiveHeader {
+            inner,
+            header: self.header.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SensitiveHeader<S> {
+    inner: S,
+    header: HeaderName,
+}
+
+impl<ReqBody, ResBody, S> Service<Request<ReqBody>> for SensitiveHeader<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        if let Some(value) = req.headers_mut().get_mut(&self.header) {
+            value.set_sensitive(true);
+        }
+
+        ResponseFuture {
+            future: self.inner.call(req),
+            header: Some(self.header.clone()),
+        }
+    }
+}
+
+#[pin_project]
+#[derive(Debug)]
+pub struct ResponseFuture<F> {
+    #[pin]
+    future: F,
+    header: Option<HeaderName>,
+}
+
+impl<F, ResBody, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let mut res = ready!(this.future.poll(cx)?);
+
+        if let Some(value) = res.headers_mut().get_mut(this.header.take().unwrap()) {
+            value.set_sensitive(true);
+        }
+
+        Poll::Ready(Ok(res))
+    }
+}

--- a/tower-http/src/set_response_header.rs
+++ b/tower-http/src/set_response_header.rs
@@ -1,11 +1,19 @@
 use crate::common::*;
+use std::fmt;
 
-// TODO(david): don't derive Debug. M is likely to be a closure
-#[derive(Debug)]
 pub struct SetResponseHeaderLayer<M, Res> {
     make: M,
     override_existing: bool,
     _marker: PhantomData<fn() -> Res>,
+}
+
+impl<M, Res> fmt::Debug for SetResponseHeaderLayer<M, Res> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SetResponseHeaderLayer")
+            .field("override_existing", &self.override_existing)
+            .field("make", &format_args!("{}", std::any::type_name::<M>()))
+            .finish()
+    }
 }
 
 impl<M, Res> SetResponseHeaderLayer<M, Res> {
@@ -54,11 +62,24 @@ where
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct SetResponseHeader<S, M> {
     inner: S,
     make: M,
     override_existing: bool,
+}
+
+impl<S, M> fmt::Debug for SetResponseHeader<S, M>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SetResponseHeaderLayer")
+            .field("inner", &self.inner)
+            .field("override_existing", &self.override_existing)
+            .field("make", &format_args!("{}", std::any::type_name::<M>()))
+            .finish()
+    }
 }
 
 impl<ReqBody, ResBody, S, M> Service<Request<ReqBody>> for SetResponseHeader<S, M>

--- a/tower-http/src/set_response_header.rs
+++ b/tower-http/src/set_response_header.rs
@@ -1,0 +1,131 @@
+use crate::common::*;
+
+// TODO(david): don't derive Debug. M is likely to be a closure
+#[derive(Debug)]
+pub struct SetResponseHeaderLayer<M, Res> {
+    make: M,
+    override_existing: bool,
+    _marker: PhantomData<fn() -> Res>,
+}
+
+impl<M, Res> SetResponseHeaderLayer<M, Res> {
+    pub fn new(make: M) -> Self
+    where
+        M: MakeHeaderPair<Res>,
+    {
+        Self {
+            make,
+            override_existing: true,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn override_existing(mut self, override_existing: bool) -> Self {
+        self.override_existing = override_existing;
+        self
+    }
+}
+
+impl<Res, S, M> Layer<S> for SetResponseHeaderLayer<M, Res>
+where
+    M: MakeHeaderPair<Res> + Clone,
+{
+    type Service = SetResponseHeader<S, M>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        SetResponseHeader {
+            inner,
+            make: self.make.clone(),
+            override_existing: self.override_existing,
+        }
+    }
+}
+
+impl<M, Res> Clone for SetResponseHeaderLayer<M, Res>
+where
+    M: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            make: self.make.clone(),
+            override_existing: self.override_existing,
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SetResponseHeader<S, M> {
+    inner: S,
+    make: M,
+    override_existing: bool,
+}
+
+impl<ReqBody, ResBody, S, M> Service<Request<ReqBody>> for SetResponseHeader<S, M>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    M: MakeHeaderPair<S::Response> + Clone,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future, M>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        ResponseFuture {
+            future: self.inner.call(req),
+            make: self.make.clone(),
+            override_existing: self.override_existing,
+        }
+    }
+}
+
+#[pin_project]
+#[derive(Debug)]
+pub struct ResponseFuture<F, M> {
+    #[pin]
+    future: F,
+    make: M,
+    override_existing: bool,
+}
+
+impl<F, ResBody, E, M> Future for ResponseFuture<F, M>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+    M: MakeHeaderPair<Response<ResBody>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let mut res = ready!(this.future.poll(cx)?);
+
+        let (header, value) = this.make.make_header_pair(&res);
+
+        if res.headers().contains_key(&header) {
+            if *this.override_existing {
+                res.headers_mut().insert(header, value);
+            }
+        } else {
+            res.headers_mut().insert(header, value);
+        }
+
+        Poll::Ready(Ok(res))
+    }
+}
+
+pub trait MakeHeaderPair<Res> {
+    fn make_header_pair(&mut self, response: &Res) -> (HeaderName, HeaderValue);
+}
+
+impl<F, Res> MakeHeaderPair<Res> for F
+where
+    F: FnMut(&Res) -> (HeaderName, HeaderValue),
+{
+    fn make_header_pair(&mut self, response: &Res) -> (HeaderName, HeaderValue) {
+        self(response)
+    }
+}

--- a/tower-http/src/tests/huge_stacks_do_compile.rs
+++ b/tower-http/src/tests/huge_stacks_do_compile.rs
@@ -1,0 +1,112 @@
+use super::EchoService;
+use crate::common::*;
+use crate::{
+    add_extension::AddExtensionLayer, compression::CompressionLayer, metrics::MetricsLayer,
+    propagate_header::PropagateHeaderLayer, sensitive_header::SensitiveHeaderLayer,
+    set_response_header::SetResponseHeaderLayer, trace::TraceLayer, wrap_in_span::WrapInSpanLayer,
+};
+use hyper::Body;
+use tower::{BoxError, ServiceBuilder};
+
+// We've seen some issues with huge service stacks not compiling so lets make sure we don't get
+// those issues.
+#[allow(dead_code)]
+fn huge_stacks_do_compile() -> impl Service<
+    Request<Body>,
+    Response = Response<Body>,
+    Error = impl Into<BoxError> + Send + Sync,
+    Future = impl Future<Output = Result<Response<Body>, impl Into<BoxError> + Send + Sync>> + Send,
+> + Clone {
+    let state: i32 = 1337;
+    let span = tracing::debug_span!("huge_stacks_do_compile");
+    let request_id_header = HeaderName::from_static("x-request-id");
+
+    ServiceBuilder::new()
+        .layer(AddExtensionLayer::new(state))
+        .layer(AddExtensionLayer::new(state))
+        .layer(AddExtensionLayer::new(state))
+        .layer(AddExtensionLayer::new(state))
+        .layer(AddExtensionLayer::new(state))
+        .layer(AddExtensionLayer::new(state))
+        .layer(AddExtensionLayer::new(state))
+        .layer(AddExtensionLayer::new(state))
+        .layer(AddExtensionLayer::new(state))
+        .layer(AddExtensionLayer::new(state))
+        .layer(CompressionLayer::new())
+        .layer(CompressionLayer::new())
+        .layer(CompressionLayer::new())
+        .layer(CompressionLayer::new())
+        .layer(CompressionLayer::new())
+        .layer(CompressionLayer::new())
+        .layer(CompressionLayer::new())
+        .layer(CompressionLayer::new())
+        .layer(CompressionLayer::new())
+        .layer(CompressionLayer::new())
+        .layer(MetricsLayer::new())
+        .layer(MetricsLayer::new())
+        .layer(MetricsLayer::new())
+        .layer(MetricsLayer::new())
+        .layer(MetricsLayer::new())
+        .layer(MetricsLayer::new())
+        .layer(MetricsLayer::new())
+        .layer(MetricsLayer::new())
+        .layer(MetricsLayer::new())
+        .layer(MetricsLayer::new())
+        .layer(PropagateHeaderLayer::new(request_id_header.clone()))
+        .layer(PropagateHeaderLayer::new(request_id_header.clone()))
+        .layer(PropagateHeaderLayer::new(request_id_header.clone()))
+        .layer(PropagateHeaderLayer::new(request_id_header.clone()))
+        .layer(PropagateHeaderLayer::new(request_id_header.clone()))
+        .layer(PropagateHeaderLayer::new(request_id_header.clone()))
+        .layer(PropagateHeaderLayer::new(request_id_header.clone()))
+        .layer(PropagateHeaderLayer::new(request_id_header.clone()))
+        .layer(PropagateHeaderLayer::new(request_id_header.clone()))
+        .layer(PropagateHeaderLayer::new(request_id_header))
+        .layer(SensitiveHeaderLayer::new(header::AUTHORIZATION))
+        .layer(SensitiveHeaderLayer::new(header::AUTHORIZATION))
+        .layer(SensitiveHeaderLayer::new(header::AUTHORIZATION))
+        .layer(SensitiveHeaderLayer::new(header::AUTHORIZATION))
+        .layer(SensitiveHeaderLayer::new(header::AUTHORIZATION))
+        .layer(SensitiveHeaderLayer::new(header::AUTHORIZATION))
+        .layer(SensitiveHeaderLayer::new(header::AUTHORIZATION))
+        .layer(SensitiveHeaderLayer::new(header::AUTHORIZATION))
+        .layer(SensitiveHeaderLayer::new(header::AUTHORIZATION))
+        .layer(SensitiveHeaderLayer::new(header::AUTHORIZATION))
+        .layer(SetResponseHeaderLayer::new(make_header_pair))
+        .layer(SetResponseHeaderLayer::new(make_header_pair))
+        .layer(SetResponseHeaderLayer::new(make_header_pair))
+        .layer(SetResponseHeaderLayer::new(make_header_pair))
+        .layer(SetResponseHeaderLayer::new(make_header_pair))
+        .layer(SetResponseHeaderLayer::new(make_header_pair))
+        .layer(SetResponseHeaderLayer::new(make_header_pair))
+        .layer(SetResponseHeaderLayer::new(make_header_pair))
+        .layer(SetResponseHeaderLayer::new(make_header_pair))
+        .layer(SetResponseHeaderLayer::new(make_header_pair))
+        .layer(TraceLayer::new())
+        .layer(TraceLayer::new())
+        .layer(TraceLayer::new())
+        .layer(TraceLayer::new())
+        .layer(TraceLayer::new())
+        .layer(TraceLayer::new())
+        .layer(TraceLayer::new())
+        .layer(TraceLayer::new())
+        .layer(TraceLayer::new())
+        .layer(TraceLayer::new())
+        .layer(WrapInSpanLayer::new(span.clone()))
+        .layer(WrapInSpanLayer::new(span.clone()))
+        .layer(WrapInSpanLayer::new(span.clone()))
+        .layer(WrapInSpanLayer::new(span.clone()))
+        .layer(WrapInSpanLayer::new(span.clone()))
+        .layer(WrapInSpanLayer::new(span.clone()))
+        .layer(WrapInSpanLayer::new(span.clone()))
+        .layer(WrapInSpanLayer::new(span.clone()))
+        .layer(WrapInSpanLayer::new(span.clone()))
+        .layer(WrapInSpanLayer::new(span))
+        .service(EchoService)
+}
+
+fn make_header_pair(_res: &Response<Body>) -> (HeaderName, HeaderValue) {
+    let header = HeaderName::from_static("x-request-id");
+    let value = HeaderValue::from_static("123");
+    (header, value)
+}

--- a/tower-http/src/tests/mod.rs
+++ b/tower-http/src/tests/mod.rs
@@ -1,0 +1,33 @@
+use crate::common::*;
+use futures::future::{ready, Ready};
+use hyper::Body;
+
+#[cfg(all(
+    feature = "add-extension",
+    feature = "compression",
+    feature = "metrics",
+    feature = "propagate-header",
+    feature = "sensitive-header",
+    feature = "set-response-header",
+    feature = "trace",
+    feature = "util",
+    feature = "wrap-in-span",
+))]
+mod huge_stacks_do_compile;
+
+#[derive(Copy, Clone)]
+struct EchoService;
+
+impl Service<Request<Body>> for EchoService {
+    type Response = Response<Body>;
+    type Error = Infallible;
+    type Future = Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        ready(Ok(Response::new(req.into_body())))
+    }
+}

--- a/tower-http/src/trace.rs
+++ b/tower-http/src/trace.rs
@@ -1,0 +1,225 @@
+use crate::LatencyUnit;
+use crate::{common::*, GetTraceStatus, GetTraceStatusFromHttpStatus, TraceStatus};
+use std::time::Instant;
+use tracing::{
+    field::{debug, display},
+    Level, Span,
+};
+
+#[derive(Clone, Debug)]
+pub struct TraceLayer<T> {
+    record_headers: bool,
+    span: Option<Span>,
+    latency_unit: LatencyUnit,
+    get_trace_status: T,
+    record_full_uri: bool,
+}
+
+impl Default for TraceLayer<GetTraceStatusFromHttpStatus> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TraceLayer<GetTraceStatusFromHttpStatus> {
+    pub fn new() -> Self {
+        Self {
+            record_headers: false,
+            span: None,
+            latency_unit: LatencyUnit::Millis,
+            get_trace_status: GetTraceStatusFromHttpStatus,
+            record_full_uri: false,
+        }
+    }
+}
+
+impl<T> TraceLayer<T> {
+    pub fn record_headers(mut self, record_headers: bool) -> Self {
+        self.record_headers = record_headers;
+        self
+    }
+
+    // TODO(david): In docs, note which fields this span must contain
+    pub fn span(mut self, span: Span) -> Self {
+        self.span = Some(span);
+        self
+    }
+
+    pub fn latency_unit(mut self, latency_unit: LatencyUnit) -> Self {
+        self.latency_unit = latency_unit;
+        self
+    }
+
+    pub fn record_full_uri(mut self, record_full_uri: bool) -> Self {
+        self.record_full_uri = record_full_uri;
+        self
+    }
+
+    pub fn get_trace_status<K>(self, get_trace_status: K) -> TraceLayer<K> {
+        TraceLayer {
+            record_headers: self.record_headers,
+            span: self.span,
+            latency_unit: self.latency_unit,
+            get_trace_status,
+            record_full_uri: self.record_full_uri,
+        }
+    }
+}
+
+impl<S, T> Layer<S> for TraceLayer<T>
+where
+    T: Clone,
+{
+    type Service = Trace<S, T>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Trace {
+            inner,
+            record_headers: self.record_headers,
+            span: self.span.clone(),
+            latency_unit: self.latency_unit,
+            get_trace_status: self.get_trace_status.clone(),
+            record_full_uri: self.record_full_uri,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Trace<S, T> {
+    inner: S,
+    record_headers: bool,
+    span: Option<Span>,
+    latency_unit: LatencyUnit,
+    get_trace_status: T,
+    record_full_uri: bool,
+}
+
+impl<S> Trace<S, GetTraceStatusFromHttpStatus> {
+    pub fn new(inner: S) -> Self {
+        Self::layer().layer(inner)
+    }
+
+    pub fn layer() -> TraceLayer<GetTraceStatusFromHttpStatus> {
+        TraceLayer::new()
+    }
+}
+
+impl<ReqBody, ResBody, S, T> Service<Request<ReqBody>> for Trace<S, T>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    T: Clone + GetTraceStatus<Response<ResBody>, S::Error>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future, T>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let start = Instant::now();
+
+        let method = req.method();
+        let path = if self.record_full_uri {
+            req.uri().to_string()
+        } else {
+            req.uri().path().to_string()
+        };
+
+        let span = if let Some(span) = &self.span {
+            let span = span.clone();
+            span.record("method", &display(method));
+            span.record("path", &display(path));
+            span
+        } else {
+            tracing::span!(
+                Level::INFO,
+                "http-request",
+                method = %method,
+                path = %path,
+                headers = tracing::field::Empty,
+            )
+        };
+
+        if self.record_headers {
+            span.record("headers", &debug(req.headers()));
+        }
+
+        let future = {
+            let _guard = span.enter();
+            tracing::info!(message = "received request");
+            self.inner.call(req)
+        };
+
+        ResponseFuture {
+            future,
+            span,
+            start,
+            latency_unit: self.latency_unit,
+            get_trace_status: self.get_trace_status.clone(),
+        }
+    }
+}
+
+#[pin_project]
+#[derive(Debug)]
+pub struct ResponseFuture<F, T> {
+    #[pin]
+    future: F,
+    span: Span,
+    start: Instant,
+    latency_unit: LatencyUnit,
+    get_trace_status: T,
+}
+
+impl<F, ResBody, E, T> Future for ResponseFuture<F, T>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+    T: GetTraceStatus<Response<ResBody>, E>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        let _guard = this.span.enter();
+
+        let result = ready!(this.future.poll(cx));
+        let time = this.start.elapsed();
+
+        match (
+            this.get_trace_status.trace_status(&result),
+            *this.latency_unit,
+        ) {
+            (TraceStatus::Status(status), LatencyUnit::Nanos) => {
+                tracing::info!(
+                    message = "completed request",
+                    status = status,
+                    latency_ns = %time.as_nanos(),
+                );
+            }
+            (TraceStatus::Status(status), LatencyUnit::Millis) => {
+                tracing::info!(
+                    message = "completed request",
+                    status = status,
+                    latency_ms = %time.as_millis(),
+                );
+            }
+            (TraceStatus::Error, LatencyUnit::Nanos) => {
+                tracing::info!(
+                    message = "request failed",
+                    latency_ns = %time.as_nanos(),
+                );
+            }
+            (TraceStatus::Error, LatencyUnit::Millis) => {
+                tracing::info!(
+                    message = "request failed",
+                    latency_ms = %time.as_millis(),
+                );
+            }
+        }
+
+        Poll::Ready(result)
+    }
+}

--- a/tower-http/src/trace.rs
+++ b/tower-http/src/trace.rs
@@ -39,7 +39,11 @@ impl<T> TraceLayer<T> {
         self
     }
 
-    // TODO(david): In docs, note which fields this span must contain
+    /// Provide a custom span. The span is expected to at least have the fields `method`, `path`,
+    /// and `headers`. If any of the fields are missing from the span they'll also be missing from
+    /// whatever output you may have configured.
+    ///
+    /// The default span uses `DEBUG` level and is called `http-request`.
     pub fn span(mut self, span: Span) -> Self {
         self.span = Some(span);
         self

--- a/tower-http/src/util/layer_ext/debug_enter_leave.rs
+++ b/tower-http/src/util/layer_ext/debug_enter_leave.rs
@@ -1,0 +1,89 @@
+use crate::common::*;
+use std::time::Instant;
+
+#[derive(Clone, Debug)]
+pub struct DebugEnterLeaveLayer<L, S> {
+    inner: L,
+    name: String,
+    _marker: PhantomData<fn() -> S>,
+}
+
+impl<L, S> DebugEnterLeaveLayer<L, S> {
+    pub(crate) fn new(inner: L, name: &str) -> Self {
+        Self {
+            inner,
+            name: name.to_string(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S, L> Layer<S> for DebugEnterLeaveLayer<L, S>
+where
+    L: Layer<S>,
+{
+    type Service = DebugEnterLeave<L::Service>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        DebugEnterLeave {
+            inner: self.inner.layer(inner),
+            name: self.name.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DebugEnterLeave<S> {
+    inner: S,
+    name: String,
+}
+
+impl<R, S> Service<R> for DebugEnterLeave<S>
+where
+    S: Service<R>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = DebugEnterLeaveResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        let start = Instant::now();
+        tracing::debug!(message = %format!("entering {}", self.name));
+
+        DebugEnterLeaveResponseFuture {
+            future: self.inner.call(req),
+            name: self.name.clone(),
+            start,
+        }
+    }
+}
+
+#[pin_project]
+#[derive(Debug)]
+pub struct DebugEnterLeaveResponseFuture<F> {
+    #[pin]
+    future: F,
+    name: String,
+    start: Instant,
+}
+
+impl<F> Future for DebugEnterLeaveResponseFuture<F>
+where
+    F: Future,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let result = ready!(this.future.poll(cx));
+        tracing::debug!(
+            message = %format!("leaving {}", this.name),
+            duration = ?this.start.elapsed(),
+        );
+        Poll::Ready(result)
+    }
+}

--- a/tower-http/src/util/layer_ext/mod.rs
+++ b/tower-http/src/util/layer_ext/mod.rs
@@ -1,0 +1,15 @@
+use crate::common::*;
+use debug_enter_leave::DebugEnterLeaveLayer;
+
+pub(crate) mod debug_enter_leave;
+
+pub trait LayerExt<S>: Layer<S> {
+    fn debug_enter_leave(self, name: &str) -> DebugEnterLeaveLayer<Self, S>
+    where
+        Self: Sized,
+    {
+        DebugEnterLeaveLayer::new(self, name)
+    }
+}
+
+impl<T, S> LayerExt<S> for T where T: Layer<S> {}

--- a/tower-http/src/util/mod.rs
+++ b/tower-http/src/util/mod.rs
@@ -1,0 +1,10 @@
+mod layer_ext;
+
+pub use self::layer_ext::{
+    debug_enter_leave::{DebugEnterLeave, DebugEnterLeaveLayer},
+    LayerExt,
+};
+
+pub mod futures {
+    pub use super::layer_ext::debug_enter_leave::DebugEnterLeaveResponseFuture;
+}

--- a/tower-http/src/wrap_in_span.rs
+++ b/tower-http/src/wrap_in_span.rs
@@ -1,0 +1,54 @@
+use crate::common::*;
+use tracing::{
+    instrument::{Instrument, Instrumented},
+    Span,
+};
+
+#[derive(Clone, Debug)]
+pub struct WrapInSpanLayer {
+    span: Span,
+}
+
+impl WrapInSpanLayer {
+    pub fn new(span: Span) -> Self {
+        Self { span }
+    }
+}
+
+impl<S> Layer<S> for WrapInSpanLayer {
+    type Service = WrapInSpan<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        WrapInSpan {
+            inner,
+            span: self.span.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct WrapInSpan<S> {
+    inner: S,
+    span: Span,
+}
+
+impl<ReqBody, ResBody, S> Service<Request<ReqBody>> for WrapInSpan<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Instrumented<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let future = {
+            let _guard = self.span.enter();
+            self.inner.call(req)
+        };
+        future.instrument(self.span.clone())
+    }
+}


### PR DESCRIPTION
- Extracts the middlewares we had written at Embark Studios.
- Setup GH actions.
- Setup cargo deny.
- Write very basic example using hyper.

Might not be feasible to have all the code reviewed in depth but feel free to tear it to shreds.

---

From the readme:

> These are the middlewares included in this crate:
> 
> - `AddExtension`: Stick some shareable value in [request extensions].
> - `Compression`: Apply compression to responses. Uses the `Accept-Encoding` header to pick an encoding. Supports gzip, deflate, brotli, and zstd. Requires hyper because it uses `hyper::Body`.
> - `DebugEnterLeave`: Print when entering and leaving a middleware. Useful for verifying the order in which your middlewares run.
> - `Metrics`: Record high level metrics. Uses the [metrics] crate.
> - `PropagateHeader`: Propagate a header from the request to the response.
> - `SensitiveHeader`: Marks a given header as [sensitive] so it wont show up in logs.
> - `SetResponseHeader`: Set a header on the response.
> - `Trace`: High level tracing of requests and responses.
> - `WrapInSpan`: Wrap response futures in a `tracing::Span`.
> 
> Middlewares uses the [`http`] crate as the HTTP interface so they're compatible with any library or framework that also uses [`http`]. For example hyper and actix.
> 
> All middlewares are disabled by default and can be enabled using a cargo feature. The feature `full` turns on everything.

[`http`]: https://crates.io/crates/http
[sensitive]: https://docs.rs/http/latest/http/header/struct.HeaderValue.html#method.set_sensitive
[request extensions]: https://docs.rs/http/latest/http/struct.Extensions.html
[metrics]: https://crates.io/crates/metrics