### PR TITLE
Add `SetSensitiveHeader` middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ shouldn't be using it yet!).
 These are the middlewares included in this crate:
 
 - `AddExtension`: Stick some shareable value in [request extensions].
+- `SensitiveHeader`: Marks a given header as [sensitive] so it wont show up in logs.
 
 Middlewares uses the [`http`] crate as the HTTP interface so they're compatible with any library or framework that also uses [`http`]. For example hyper and actix.
 
@@ -27,3 +28,4 @@ All middlewares are disabled by default and can be enabled using a cargo feature
 
 [`http`]: https://crates.io/crates/http
 [@EmbarkStudios]: https://github.com/EmbarkStudios
+[sensitive]: https://docs.rs/http/latest/http/header/struct.HeaderValue.html#method.set_sensitive

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ These are the middlewares included in this crate:
 
 - `AddExtension`: Stick some shareable value in [request extensions].
 - `SensitiveHeader`: Marks a given header as [sensitive] so it wont show up in logs.
-- `SetSensitiveHeader`: Marks a given header as [sensitive] so it wont show up in logs.
+- `SetSensitiveRequestHeader`: Marks a given request header as [sensitive].
+- `SetSensitiveResponseHeader`: Marks a given response header as [sensitive].
 
 Middlewares uses the [`http`] crate as the HTTP interface so they're compatible with any library or framework that also uses [`http`]. For example hyper and actix.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ These are the middlewares included in this crate:
 
 - `AddExtension`: Stick some shareable value in [request extensions].
 - `SensitiveHeader`: Marks a given header as [sensitive] so it wont show up in logs.
+- `SetSensitiveHeader`: Marks a given header as [sensitive] so it wont show up in logs.
 
 Middlewares uses the [`http`] crate as the HTTP interface so they're compatible with any library or framework that also uses [`http`]. For example hyper and actix.
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -32,8 +32,10 @@ tower = "0.4"
 default = []
 full = [
     "add-extension",
+    "sensitive-header",
 ]
 add-extension = []
+sensitive-header = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -41,3 +41,7 @@
 #[cfg(feature = "add-extension")]
 #[cfg_attr(docsrs, doc(cfg(feature = "add-extension")))]
 pub mod add_extension;
+
+#[cfg(feature = "sensitive-header")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sensitive-header")))]
+pub mod sensitive_header;

--- a/tower-http/src/sensitive_header.rs
+++ b/tower-http/src/sensitive_header.rs
@@ -1,0 +1,88 @@
+use futures_util::ready;
+use http::{header::HeaderName, Request, Response};
+use pin_project::pin_project;
+use std::future::Future;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower_layer::Layer;
+use tower_service::Service;
+
+#[derive(Clone, Debug)]
+pub struct SensitiveHeaderLayer {
+    header: HeaderName,
+}
+
+impl SensitiveHeaderLayer {
+    pub fn new(header: HeaderName) -> Self {
+        Self { header }
+    }
+}
+
+impl<S> Layer<S> for SensitiveHeaderLayer {
+    type Service = SensitiveHeader<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        SensitiveHeader {
+            inner,
+            header: self.header.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SensitiveHeader<S> {
+    inner: S,
+    header: HeaderName,
+}
+
+impl<ReqBody, ResBody, S> Service<Request<ReqBody>> for SensitiveHeader<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        if let Some(value) = req.headers_mut().get_mut(&self.header) {
+            value.set_sensitive(true);
+        }
+
+        ResponseFuture {
+            future: self.inner.call(req),
+            header: Some(self.header.clone()),
+        }
+    }
+}
+
+#[pin_project]
+#[derive(Debug)]
+pub struct ResponseFuture<F> {
+    #[pin]
+    future: F,
+    header: Option<HeaderName>,
+}
+
+impl<F, ResBody, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let mut res = ready!(this.future.poll(cx)?);
+
+        if let Some(value) = res.headers_mut().get_mut(this.header.take().unwrap()) {
+            value.set_sensitive(true);
+        }
+
+        Poll::Ready(Ok(res))
+    }
+}

--- a/tower-http/src/sensitive_header.rs
+++ b/tower-http/src/sensitive_header.rs
@@ -165,7 +165,7 @@ pub struct SetSensitiveResponseHeader<S> {
 }
 
 impl<S> SetSensitiveResponseHeader<S> {
-    /// Create a new [`SetSensitiveResponseHeader`].
+    /// Create a new [`SetSensitiveResponseHeader`] service.
     pub fn new(inner: S, header: HeaderName) -> Self {
         Self { inner, header }
     }

--- a/tower-http/src/sensitive_header.rs
+++ b/tower-http/src/sensitive_header.rs
@@ -10,21 +10,21 @@ use tower_layer::Layer;
 use tower_service::Service;
 
 #[derive(Clone, Debug)]
-pub struct SensitiveHeaderLayer {
+pub struct SetSensitiveHeaderLayer {
     header: HeaderName,
 }
 
-impl SensitiveHeaderLayer {
+impl SetSensitiveHeaderLayer {
     pub fn new(header: HeaderName) -> Self {
         Self { header }
     }
 }
 
-impl<S> Layer<S> for SensitiveHeaderLayer {
-    type Service = SensitiveHeader<S>;
+impl<S> Layer<S> for SetSensitiveHeaderLayer {
+    type Service = SetSensitiveHeader<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        SensitiveHeader {
+        SetSensitiveHeader {
             inner,
             header: self.header.clone(),
         }
@@ -32,12 +32,12 @@ impl<S> Layer<S> for SensitiveHeaderLayer {
 }
 
 #[derive(Clone, Debug)]
-pub struct SensitiveHeader<S> {
+pub struct SetSensitiveHeader<S> {
     inner: S,
     header: HeaderName,
 }
 
-impl<ReqBody, ResBody, S> Service<Request<ReqBody>> for SensitiveHeader<S>
+impl<ReqBody, ResBody, S> Service<Request<ReqBody>> for SetSensitiveHeader<S>
 where
     S: Service<Request<ReqBody>, Response = Response<ResBody>>,
 {

--- a/tower-http/src/sensitive_header.rs
+++ b/tower-http/src/sensitive_header.rs
@@ -15,6 +15,8 @@ use tower_service::Service;
 
 /// Mark a header as [sensitive] on both requests and responses.
 ///
+/// Produces [`SetSensitiveHeader`] services.
+///
 /// [sensitive]: https://docs.rs/http/latest/http/header/struct.HeaderValue.html#method.set_sensitive
 #[derive(Clone, Debug)]
 pub struct SetSensitiveHeaderLayer {
@@ -29,7 +31,7 @@ impl SetSensitiveHeaderLayer {
 }
 
 impl<S> Layer<S> for SetSensitiveHeaderLayer {
-    type Service = SetSensitiveRequestHeader<SetSensitiveResponseHeader<S>>;
+    type Service = SetSensitiveHeader<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
         SetSensitiveRequestHeader::new(
@@ -39,7 +41,14 @@ impl<S> Layer<S> for SetSensitiveHeaderLayer {
     }
 }
 
+/// Mark a header as [sensitive] on both requests and responses.
+///
+/// [sensitive]: https://docs.rs/http/latest/http/header/struct.HeaderValue.html#method.set_sensitive
+pub type SetSensitiveHeader<S> = SetSensitiveRequestHeader<SetSensitiveResponseHeader<S>>;
+
 /// Mark a request header as [sensitive].
+///
+/// Produces [`SetSensitiveRequestHeader`] services.
 ///
 /// [sensitive]: https://docs.rs/http/latest/http/header/struct.HeaderValue.html#method.set_sensitive
 #[derive(Clone, Debug)]
@@ -119,6 +128,8 @@ where
 }
 
 /// Mark a response header as [sensitive].
+///
+/// Produces [`SetSensitiveResponseHeader`] services.
 ///
 /// [sensitive]: https://docs.rs/http/latest/http/header/struct.HeaderValue.html#method.set_sensitive
 #[derive(Clone, Debug)]

--- a/tower-http/src/sensitive_header.rs
+++ b/tower-http/src/sensitive_header.rs
@@ -84,7 +84,7 @@ pub struct SetSensitiveRequestHeader<S> {
 }
 
 impl<S> SetSensitiveRequestHeader<S> {
-    /// Create a new [`SetSensitiveRequestHeader`].
+    /// Create a new [`SetSensitiveRequestHeader`] service.
     pub fn new(inner: S, header: HeaderName) -> Self {
         Self { inner, header }
     }

--- a/tower-http/src/sensitive_header.rs
+++ b/tower-http/src/sensitive_header.rs
@@ -45,6 +45,7 @@ where
     type Error = S::Error;
     type Future = ResponseFuture<S::Future>;
 
+    #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
     }

--- a/tower-http/src/sensitive_header.rs
+++ b/tower-http/src/sensitive_header.rs
@@ -202,7 +202,7 @@ where
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
         SetSensitiveResponseHeaderResponseFuture {
             future: self.inner.call(req),
-            header: Some(self.header.clone()),
+            header: self.header.clone(),
         }
     }
 }
@@ -213,7 +213,7 @@ where
 pub struct SetSensitiveResponseHeaderResponseFuture<F> {
     #[pin]
     future: F,
-    header: Option<HeaderName>,
+    header: HeaderName,
 }
 
 impl<F, ResBody, E> Future for SetSensitiveResponseHeaderResponseFuture<F>
@@ -226,7 +226,7 @@ where
         let this = self.project();
         let mut res = ready!(this.future.poll(cx)?);
 
-        if let Some(value) = res.headers_mut().get_mut(this.header.take().unwrap()) {
+        if let Some(value) = res.headers_mut().get_mut(&*this.header) {
             value.set_sensitive(true);
         }
 


### PR DESCRIPTION
## What it does

Calls [`HeaderValue::set_sensitive`](https://docs.rs/http/0.2.3/http/header/struct.HeaderValue.html#method.set_sensitive) for some header. Useful for example with `Authorization`.

## Things to consider for other middlewares

I haven't yet written any docs. My initial idea was to get things merged first and then do follow up PRs that add documentation. Otherwise we might spend time writing docs for something only to have it changed during review. I totally wouldn't release things without all public items having documentation.

Another thing I ran into while building things: In how many different ways should we allow users to build/customize their middlewares? I started having both `SensitiveHeaderLayer::new(header).layer(svc)` and `SensitiveHeader::new(svc, header)` for construction.

However for middlewares with lots of customization I would like a builder API a la 

```rust
MetricsLayer::default()
    .record_path_label(true)
    .record_method_label(true)
    .layer(svc)
```

But that kinda means we need to have identical builder methods for those who don't use layers and instead do `Metrics::new(svc)`. That turned into a lot of duplicate builder methods which I got a bit tired of. So I decided that layers are the only way you can wrap services in middlewares. So I stopped defining `new` methods for the services themselves. That removes a bunch of questions/decisions.

What do you think? Is that too opinionated? I personally dig layers and `ServiceBuilder` but I also understand why direct service constructors are nice.

We could have some fairly simple `macro_rules!` macros for defining builder methods but macros tend to be divisive.