### PR TITLE
Add `PropagateHeader` middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ shouldn't be using it yet!).
 
 These are the middlewares included in this crate:
 
-<!-- Other PRs will list things here -->
+- `PropagateHeader`: Propagate a header from the request to the response.
 
 Middlewares uses the [`http`] crate as the HTTP interface so they're compatible with any library or framework that also uses [`http`]. For example hyper and actix.
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -31,7 +31,9 @@ tower = "0.4"
 [features]
 default = []
 full = [
+    "propagate-header",
 ]
+propagate-header = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -37,3 +37,7 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
+
+#[cfg(feature = "propagate-header")]
+#[cfg_attr(docsrs, doc(cfg(feature = "propagate-header")))]
+pub mod propagate_header;

--- a/tower-http/src/propagate_header.rs
+++ b/tower-http/src/propagate_header.rs
@@ -41,6 +41,35 @@ impl<S> Layer<S> for PropagateHeaderLayer {
 ///
 /// So if the header is present on the request it'll be applied to the response as well. This could
 /// for example be used to propagate headers such as `X-Request-Id`.
+///
+/// # Example
+///
+/// ```rust
+/// use http::{Request, Response, header::HeaderName};
+/// use std::convert::Infallible;
+/// use tower::{Service, ServiceExt};
+/// use tower_http::propagate_header::PropagateHeader;
+///
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let echo_service = tower::service_fn(|request: Request<String>| async move {
+///     Ok::<_, Infallible>(Response::new(request.into_body()))
+/// });
+///
+/// // This will copy `x-request-id` headers on requests onto responses.
+/// let mut svc = PropagateHeader::new(echo_service, HeaderName::from_static("x-request-id"));
+///
+/// let request = Request::builder()
+///     .header("x-request-id", "1337")
+///     .body(String::new())?;
+///
+/// let response = svc.ready_and().await?.call(request).await?;
+///
+/// assert_eq!(response.headers()["x-request-id"], "1337");
+/// #
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug)]
 pub struct PropagateHeader<S> {
     inner: S,

--- a/tower-http/src/propagate_header.rs
+++ b/tower-http/src/propagate_header.rs
@@ -1,3 +1,5 @@
+//! Propagate a header from the request to the response.
+
 use futures_util::ready;
 use http::{header::HeaderName, HeaderValue, Request, Response};
 use pin_project::pin_project;
@@ -9,12 +11,16 @@ use std::{
 use tower_layer::Layer;
 use tower_service::Service;
 
+/// Layer that applies [`PropagateHeader`] which propagates headers from requests to responses.
+///
+/// See [`PropagateHeader`] for more details.
 #[derive(Clone, Debug)]
 pub struct PropagateHeaderLayer {
     header: HeaderName,
 }
 
 impl PropagateHeaderLayer {
+    /// Create a new [`PropagateHeaderLayer`].
     pub fn new(header: HeaderName) -> Self {
         Self { header }
     }
@@ -31,10 +37,21 @@ impl<S> Layer<S> for PropagateHeaderLayer {
     }
 }
 
+/// Middleware that propagates headers from requests to responses.
+///
+/// So if the header is present on the request it'll be applied to the response as well. This could
+/// for example be used to propagate headers such as `X-Request-Id`.
 #[derive(Clone, Debug)]
 pub struct PropagateHeader<S> {
     inner: S,
     header: HeaderName,
+}
+
+impl<S> PropagateHeader<S> {
+    /// Create a new [`PropagateHeader`] that propagates the given header.
+    pub fn new(inner: S, header: HeaderName) -> Self {
+        Self { inner, header }
+    }
 }
 
 impl<ReqBody, ResBody, S> Service<Request<ReqBody>> for PropagateHeader<S>
@@ -60,6 +77,7 @@ where
     }
 }
 
+/// Response future for [`PropagateHeader`].
 #[pin_project]
 #[derive(Debug)]
 pub struct ResponseFuture<F> {

--- a/tower-http/src/propagate_header.rs
+++ b/tower-http/src/propagate_header.rs
@@ -1,0 +1,87 @@
+use futures_util::ready;
+use http::{header::HeaderName, HeaderValue, Request, Response};
+use pin_project::pin_project;
+use std::future::Future;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower_layer::Layer;
+use tower_service::Service;
+
+#[derive(Clone, Debug)]
+pub struct PropagateHeaderLayer {
+    header: HeaderName,
+}
+
+impl PropagateHeaderLayer {
+    pub fn new(header: HeaderName) -> Self {
+        Self { header }
+    }
+}
+
+impl<S> Layer<S> for PropagateHeaderLayer {
+    type Service = PropagateHeader<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        PropagateHeader {
+            inner,
+            header: self.header.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PropagateHeader<S> {
+    inner: S,
+    header: HeaderName,
+}
+
+impl<ReqBody, ResBody, S> Service<Request<ReqBody>> for PropagateHeader<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let value = req.headers().get(&self.header).cloned();
+
+        ResponseFuture {
+            future: self.inner.call(req),
+            header_and_value: Some(self.header.clone()).zip(value),
+        }
+    }
+}
+
+#[pin_project]
+#[derive(Debug)]
+pub struct ResponseFuture<F> {
+    #[pin]
+    future: F,
+    header_and_value: Option<(HeaderName, HeaderValue)>,
+}
+
+impl<F, ResBody, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let mut res = ready!(this.future.poll(cx)?);
+
+        if let Some((header, value)) = this.header_and_value.take() {
+            res.headers_mut().insert(header, value);
+        }
+
+        Poll::Ready(Ok(res))
+    }
+}


### PR DESCRIPTION
Another small one. Propagate a header from the request to the response.