### PR TITLE
Add `Decompression` middleware

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -35,16 +35,14 @@ tower = "0.4"
 default = []
 full = [
     "add-extension",
-    "br",
-    "decompression",
-    "deflate",
-    "gzip",
+    "decompression-full",
 ]
 add-extension = []
-br = ["async-compression/brotli"]
 decompression = ["bytes", "tokio-util"]
-deflate = ["async-compression/zlib"]
-gzip = ["async-compression/gzip"]
+decompression-full = ["decompression-br", "decompression-deflate", "decompression-gzip"]
+decompression-br = ["async-compression/brotli", "decompression"]
+decompression-deflate = ["async-compression/zlib", "decompression"]
+decompression-gzip = ["async-compression/gzip", "decompression"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -18,7 +18,6 @@ futures-util = { version = "0.3", default_features = false, features = [] }
 http = "0.2"
 http-body = "0.4"
 pin-project = "1"
-pin-project-lite = "0.2"
 tower-layer = "0.3"
 tower-service = "0.3"
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -13,8 +13,6 @@ categories = ["asynchronous", "network-programming", "web-programming"]
 keywords = ["io", "async", "non-blocking", "futures", "service", "http"]
 
 [dependencies]
-bitflags = "1"
-bytes = "1"
 futures-core = "0.3"
 futures-util = { version = "0.3", default_features = false, features = [] }
 http = "0.2"
@@ -26,6 +24,7 @@ tower-service = "0.3"
 
 # optional dependencies
 async-compression = { version = "0.3.7", optional = true, features = ["tokio"] }
+bytes = { version = "1", optional = true }
 tokio-util = { version = "0.6.1", optional = true, features = ["codec", "io"] }
 
 [dev-dependencies]
@@ -44,7 +43,7 @@ full = [
 ]
 add-extension = []
 br = ["async-compression/brotli"]
-decompression = ["tokio-util"]
+decompression = ["bytes", "tokio-util"]
 deflate = ["async-compression/zlib"]
 gzip = ["async-compression/gzip"]
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -13,15 +13,20 @@ categories = ["asynchronous", "network-programming", "web-programming"]
 keywords = ["io", "async", "non-blocking", "futures", "service", "http"]
 
 [dependencies]
+bitflags = "1"
+bytes = "1"
+futures-core = "0.3"
 futures-util = { version = "0.3", default_features = false, features = [] }
 http = "0.2"
 http-body = "0.4"
 pin-project = "1"
+pin-project-lite = "0.2"
 tower-layer = "0.3"
 tower-service = "0.3"
 
 # optional dependencies
-# will be filled out in other PRs
+async-compression = { version = "0.3.7", optional = true, features = ["tokio"] }
+tokio-util = { version = "0.6.1", optional = true, features = ["codec", "io"] }
 
 [dev-dependencies]
 futures = "0.3"
@@ -32,8 +37,16 @@ tower = "0.4"
 default = []
 full = [
     "add-extension",
+    "br",
+    "decompression",
+    "deflate",
+    "gzip",
 ]
 add-extension = []
+br = ["async-compression/brotli"]
+decompression = ["tokio-util"]
+deflate = ["async-compression/zlib"]
+gzip = ["async-compression/gzip"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tower-http/src/decompression.rs
+++ b/tower-http/src/decompression.rs
@@ -1,0 +1,758 @@
+//! Middleware that decompresses response bodies.
+
+#![cfg_attr(
+    not(any(feature = "br", feature = "gzip", feature = "deflate")),
+    allow(unused)
+)]
+
+use std::error;
+use std::fmt::{self, Debug, Display, Formatter};
+use std::future::Future;
+use std::io;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+#[cfg(feature = "br")]
+use async_compression::tokio::bufread::BrotliDecoder;
+#[cfg(feature = "gzip")]
+use async_compression::tokio::bufread::GzipDecoder;
+#[cfg(feature = "deflate")]
+use async_compression::tokio::bufread::ZlibDecoder;
+use bitflags::bitflags;
+use bytes::{Buf, Bytes, BytesMut};
+use futures_core::{ready, Stream, TryFuture};
+use http::header::{self, HeaderValue, ACCEPT_ENCODING, CONTENT_ENCODING, CONTENT_LENGTH, RANGE};
+use http_body::Body;
+use pin_project_lite::pin_project;
+use tokio_util::codec::{BytesCodec, FramedRead};
+use tokio_util::io::StreamReader;
+
+/// Decompresses response bodies of the underlying service.
+///
+/// This adds the `Accept-Encoding` header to requests and transparently decompresses response
+/// bodies based on the `Content-Encoding` header.
+#[derive(Debug, Clone)]
+pub struct Decompress<S> {
+    inner: S,
+    accept: AcceptEncoding,
+}
+
+/// Decompresses response bodies of the underlying service.
+///
+/// This adds the `Accept-Encoding` header to requests and transparently decompresses response
+/// bodies based on the `Content-Encoding` header.
+#[derive(Debug, Default, Clone)]
+pub struct DecompressLayer {
+    accept: AcceptEncoding,
+}
+
+pin_project! {
+    /// Response future of [`Decompress`].
+    #[derive(Debug)]
+    pub struct ResponseFuture<F> {
+        #[pin]
+        inner: F,
+        accept: AcceptEncoding,
+    }
+}
+
+pin_project! {
+    /// Response body of [`Decompress`].
+    pub struct DecompressBody<B: Body> {
+        #[pin]
+        inner: BodyInner<B, B::Error>,
+    }
+}
+
+/// Error type of [`DecompressBody`].
+#[derive(Debug)]
+pub enum Error<E> {
+    /// Error from the underlying body.
+    Body(E),
+    /// Decompress error.
+    Decompress(io::Error),
+}
+
+/// A wrapper around `pin_project!` to handle `cfg` attributes on enum variants.
+macro_rules! pin_project_cfg {
+    (
+        $(#[$($attr:tt)*])*
+        enum $name:ident $(<$($typaram:ident $(: $bound:path)?),*$(,)?>)? {
+            $($body:tt)*
+        }
+    ) => {
+        // Process the variants one by one with the push-down accumulation pattern.
+        pin_project_cfg! {
+            @accum
+            #[cfg(all())]
+            [$(#[$($attr)*])* enum $name <$($($typaram $(: $bound)?),*)?>]
+            {}
+
+            $($body)*
+        }
+    };
+    // Process a variant with `cfg`.
+    (
+        @accum
+        #[cfg(all($($pred_accum:tt)*))]
+        $outer:tt
+        {$($accum:tt)*}
+
+        #[cfg($($pred:tt)*)]
+        $(#[$($variant_attr:tt)*])* $variant:ident $variant_body:tt,
+        $($rest:tt)*
+    ) => {
+        // Create two versions of the enum with `cfg($pred)` and `cfg(not($pred))`.
+        pin_project_cfg! {
+            @accum
+            #[cfg(all($($pred_accum)* $($pred)*,))]
+            $outer
+            { $($accum)* $(#[$($variant_attr)*])* $variant $variant_body, }
+            $($rest)*
+        }
+        pin_project_cfg! {
+            @accum
+            #[cfg(all($($pred_accum)* not($($pred)*),))]
+            $outer
+            {$($accum)*}
+            $($rest)*
+        }
+    };
+    // Process a variant without `cfg`.
+    (
+        @accum
+        #[cfg(all($($pred_accum:tt)*))]
+        $outer:tt
+        {$($accum:tt)*}
+
+        $(#[$($variant_attr:tt)*])* $variant:ident $variant_body:tt,
+        $($rest:tt)*
+    ) => {
+        pin_project_cfg! {
+            @accum
+            #[cfg(all($($pred_accum)*))]
+            $outer
+            {
+                $($accum)*
+                $(#[$($variant_attr)*])* $variant $variant_body,
+            }
+            $($rest)*
+        }
+    };
+    // All variants have been processed. Construct the enum.
+    (
+        @accum
+        #[$cfg:meta]
+        [$($outer:tt)*]
+        $body:tt
+    ) => {
+        #[$cfg]
+        pin_project! {
+            $($outer)* $body
+        }
+    };
+}
+
+type BodyReader<B, E> = StreamReader<Adapter<B, E>, Bytes>;
+
+pin_project_cfg! {
+    #[project = BodyInnerProj]
+    #[derive(Debug)]
+    enum BodyInner<B, E> {
+        Identity {
+            #[pin]
+            inner: B,
+            marker: PhantomData<fn() -> E>,
+        },
+        #[cfg(feature = "gzip")]
+        Gzip {
+            #[pin]
+            inner: FramedRead<GzipDecoder<BodyReader<B, E>>, BytesCodec>,
+        },
+        #[cfg(feature = "deflate")]
+        Deflate {
+            #[pin]
+            inner: FramedRead<ZlibDecoder<BodyReader<B, E>>, BytesCodec>,
+        },
+        #[cfg(feature = "br")]
+        Brotli {
+            #[pin]
+            inner: FramedRead<BrotliDecoder<BodyReader<B, E>>, BytesCodec>,
+        },
+    }
+}
+
+pin_project! {
+    /// A `TryStream<Error>` that captures the errors from the `Body` for later inspection.
+    ///
+    /// This is needed since the `io::Read` wrappers do not provide direct access to
+    /// the inner `Body::Error` values.
+    #[derive(Debug)]
+    struct Adapter<B, E> {
+        #[pin]
+        body: B,
+        error: Option<E>,
+    }
+}
+
+bitflags! {
+    struct AcceptEncoding: u8 {
+        #[cfg(feature = "gzip")]
+        const GZIP = 0b001;
+        #[cfg(feature = "deflate")]
+        const DEFLATE = 0b010;
+        #[cfg(feature = "br")]
+        const BR = 0b100;
+    }
+}
+
+impl<S> Decompress<S> {
+    /// Creates a new `Decompress` wrapping the `service`.
+    pub fn new(service: S) -> Self {
+        Decompress {
+            inner: service,
+            accept: AcceptEncoding::default(),
+        }
+    }
+
+    /// Gets a reference to the underlying service.
+    pub fn get_ref(&self) -> &S {
+        &self.inner
+    }
+
+    /// Gets a mutable reference to the underlying service.
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Consumes `self`, returning the underlying service.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+
+    /// Sets whether to request the gzip encoding.
+    #[cfg(feature = "gzip")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "gzip")))]
+    pub fn gzip(self, enable: bool) -> Self {
+        self.accept.set_gzip(enable);
+        self
+    }
+
+    /// Sets whether to request the Deflate encoding.
+    #[cfg(feature = "deflate")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "deflate")))]
+    pub fn deflate(self, enable: bool) -> Self {
+        self.accept.set_deflate(enable);
+        self
+    }
+
+    /// Sets whether to request the Brotli encoding.
+    #[cfg(feature = "br")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "br")))]
+    pub fn br(self, enable: bool) -> Self {
+        self.accept.set_br(enable);
+        self
+    }
+
+    /// Disables the gzip encoding.
+    ///
+    /// This method is available even if the `gzip` crate feature is disabled.
+    pub fn no_gzip(self) -> Self {
+        self.accept.set_gzip(false);
+        self
+    }
+
+    /// Disables the Deflate encoding.
+    ///
+    /// This method is available even if the `deflate` crate feature is disabled.
+    pub fn no_deflate(self) -> Self {
+        self.accept.set_deflate(false);
+        self
+    }
+
+    /// Disables the Brotli encoding.
+    ///
+    /// This method is available even if the `br` crate feature is disabled.
+    pub fn no_br(self) -> Self {
+        self.accept.set_br(false);
+        self
+    }
+}
+
+impl<S, ReqBody, ResBody> tower_service::Service<http::Request<ReqBody>> for Decompress<S>
+where
+    S: tower_service::Service<http::Request<ReqBody>, Response = http::Response<ResBody>>,
+    ResBody: Body,
+{
+    type Response = http::Response<DecompressBody<ResBody>>;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: http::Request<ReqBody>) -> Self::Future {
+        if !req.headers().contains_key(RANGE) {
+            if let header::Entry::Vacant(e) = req.headers_mut().entry(ACCEPT_ENCODING) {
+                if let Some(accept) = self.accept.to_header_value() {
+                    e.insert(accept);
+                }
+            }
+        }
+        ResponseFuture {
+            inner: self.inner.call(req),
+            accept: self.accept,
+        }
+    }
+}
+
+impl DecompressLayer {
+    /// Creates a new `DecompressLayer`.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Sets whether to request the gzip encoding.
+    #[cfg(feature = "gzip")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "gzip")))]
+    pub fn gzip(self, enable: bool) -> Self {
+        self.accept.set_gzip(enable);
+        self
+    }
+
+    /// Sets whether to request the Deflate encoding.
+    #[cfg(feature = "deflate")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "deflate")))]
+    pub fn deflate(self, enable: bool) -> Self {
+        self.accept.set_deflate(enable);
+        self
+    }
+
+    /// Sets whether to request the Brotli encoding.
+    #[cfg(feature = "br")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "br")))]
+    pub fn br(self, enable: bool) -> Self {
+        self.accept.set_br(enable);
+        self
+    }
+
+    /// Disables the gzip encoding.
+    ///
+    /// This method is available even if the `gzip` crate feature is disabled.
+    pub fn no_gzip(self) -> Self {
+        self.accept.set_gzip(false);
+        self
+    }
+
+    /// Disables the Deflate encoding.
+    ///
+    /// This method is available even if the `deflate` crate feature is disabled.
+    pub fn no_deflate(self) -> Self {
+        self.accept.set_deflate(false);
+        self
+    }
+
+    /// Disables the Brotli encoding.
+    ///
+    /// This method is available even if the `br` crate feature is disabled.
+    pub fn no_br(self) -> Self {
+        self.accept.set_br(false);
+        self
+    }
+}
+
+impl<S> tower_layer::Layer<S> for DecompressLayer {
+    type Service = Decompress<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        Decompress {
+            inner: service,
+            accept: self.accept,
+        }
+    }
+}
+
+impl<F, B> Future for ResponseFuture<F>
+where
+    F: TryFuture<Ok = http::Response<B>>,
+    B: Body,
+{
+    type Output = Result<http::Response<DecompressBody<B>>, F::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let res = ready!(self.as_mut().project().inner.try_poll(cx)?);
+        Poll::Ready(Ok(DecompressBody::wrap_response(res, &self.accept)))
+    }
+}
+
+impl<B> DecompressBody<B>
+where
+    B: Body,
+{
+    /// Gets a reference to the underlying body.
+    pub fn get_ref(&self) -> &B {
+        match self.inner {
+            BodyInner::Identity { ref inner, .. } => inner,
+            #[cfg(feature = "gzip")]
+            BodyInner::Gzip { ref inner } => &inner.get_ref().get_ref().get_ref().body,
+            #[cfg(feature = "deflate")]
+            BodyInner::Deflate { ref inner } => &inner.get_ref().get_ref().get_ref().body,
+            #[cfg(feature = "br")]
+            BodyInner::Brotli { ref inner } => &inner.get_ref().get_ref().get_ref().body,
+        }
+    }
+
+    /// Gets a mutable reference to the underlying body.
+    ///
+    /// It is inadvisable to directly read from the underlying body.
+    pub fn get_mut(&mut self) -> &mut B {
+        match self.inner {
+            BodyInner::Identity { ref mut inner, .. } => inner,
+            #[cfg(feature = "gzip")]
+            BodyInner::Gzip { ref mut inner } => &mut inner.get_mut().get_mut().get_mut().body,
+            #[cfg(feature = "deflate")]
+            BodyInner::Deflate { ref mut inner } => &mut inner.get_mut().get_mut().get_mut().body,
+            #[cfg(feature = "br")]
+            BodyInner::Brotli { ref mut inner } => &mut inner.get_mut().get_mut().get_mut().body,
+        }
+    }
+
+    /// Gets a pinned mutable reference to the underlying body.
+    ///
+    /// It is inadvisable to directly read from the underlying body.
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut B> {
+        match self.project().inner.project() {
+            BodyInnerProj::Identity { inner, .. } => inner,
+            #[cfg(feature = "gzip")]
+            BodyInnerProj::Gzip { inner } => {
+                inner
+                    .get_pin_mut()
+                    .get_pin_mut()
+                    .get_pin_mut()
+                    .project()
+                    .body
+            }
+            #[cfg(feature = "deflate")]
+            BodyInnerProj::Deflate { inner } => {
+                inner
+                    .get_pin_mut()
+                    .get_pin_mut()
+                    .get_pin_mut()
+                    .project()
+                    .body
+            }
+            #[cfg(feature = "br")]
+            BodyInnerProj::Brotli { inner } => {
+                inner
+                    .get_pin_mut()
+                    .get_pin_mut()
+                    .get_pin_mut()
+                    .project()
+                    .body
+            }
+        }
+    }
+
+    /// Comsumes `self`, returning the underlying body.
+    ///
+    /// Note that any leftover data in the internal buffer is lost.
+    pub fn into_inner(self) -> B {
+        match self.inner {
+            BodyInner::Identity { inner, .. } => inner,
+            #[cfg(feature = "gzip")]
+            BodyInner::Gzip { inner } => inner.into_inner().into_inner().into_inner().body,
+            #[cfg(feature = "deflate")]
+            BodyInner::Deflate { inner } => inner.into_inner().into_inner().into_inner().body,
+            #[cfg(feature = "br")]
+            BodyInner::Brotli { inner } => inner.into_inner().into_inner().into_inner().body,
+        }
+    }
+
+    #[cfg_attr(
+        not(any(feature = "br", feature = "gzip", feature = "deflate")),
+        allow(unreachable_code)
+    )]
+    fn wrap_response(res: http::Response<B>, accept: &AcceptEncoding) -> http::Response<Self> {
+        let (mut parts, body) = res.into_parts();
+        if let header::Entry::Occupied(e) = parts.headers.entry(CONTENT_ENCODING) {
+            let body = match e.get().as_bytes() {
+                #[cfg(feature = "gzip")]
+                b"gzip" if accept.gzip() => DecompressBody::gzip(body),
+                #[cfg(feature = "deflate")]
+                b"deflate" if accept.deflate() => DecompressBody::deflate(body),
+                #[cfg(feature = "br")]
+                b"br" if accept.br() => DecompressBody::br(body),
+                _ => return http::Response::from_parts(parts, DecompressBody::identity(body)),
+            };
+            e.remove();
+            parts.headers.remove(CONTENT_LENGTH);
+            http::Response::from_parts(parts, body)
+        } else {
+            http::Response::from_parts(parts, DecompressBody::identity(body))
+        }
+    }
+
+    fn identity(body: B) -> Self {
+        DecompressBody {
+            inner: BodyInner::Identity {
+                inner: body,
+                marker: PhantomData,
+            },
+        }
+    }
+
+    #[cfg(feature = "gzip")]
+    fn gzip(body: B) -> Self {
+        let read = StreamReader::new(Adapter { body, error: None });
+        let inner = FramedRead::new(GzipDecoder::new(read), BytesCodec::new());
+        DecompressBody {
+            inner: BodyInner::Gzip { inner },
+        }
+    }
+
+    #[cfg(feature = "deflate")]
+    fn deflate(body: B) -> Self {
+        let read = StreamReader::new(Adapter { body, error: None });
+        let inner = FramedRead::new(ZlibDecoder::new(read), BytesCodec::new());
+        DecompressBody {
+            inner: BodyInner::Deflate { inner },
+        }
+    }
+
+    #[cfg(feature = "br")]
+    fn br(body: B) -> Self {
+        let read = StreamReader::new(Adapter { body, error: None });
+        let inner = FramedRead::new(BrotliDecoder::new(read), BytesCodec::new());
+        DecompressBody {
+            inner: BodyInner::Brotli { inner },
+        }
+    }
+}
+
+impl<B> Body for DecompressBody<B>
+where
+    B: Body,
+{
+    type Data = Bytes;
+    type Error = Error<B::Error>;
+
+    fn poll_data(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        let (poll, inner) = match self.project().inner.project() {
+            BodyInnerProj::Identity { inner, .. } => {
+                return match ready!(inner.poll_data(cx)) {
+                    Some(Ok(mut data)) => {
+                        Poll::Ready(Some(Ok(data.copy_to_bytes(data.remaining()))))
+                    }
+                    Some(Err(e)) => Poll::Ready(Some(Err(Error::Body(e)))),
+                    None => Poll::Ready(None),
+                };
+            }
+            #[cfg(feature = "gzip")]
+            BodyInnerProj::Gzip { mut inner } => (
+                inner.as_mut().poll_next(cx),
+                inner.get_pin_mut().get_pin_mut().get_pin_mut(),
+            ),
+            #[cfg(feature = "deflate")]
+            BodyInnerProj::Deflate { mut inner } => (
+                inner.as_mut().poll_next(cx),
+                inner.get_pin_mut().get_pin_mut().get_pin_mut(),
+            ),
+            #[cfg(feature = "br")]
+            BodyInnerProj::Brotli { mut inner } => (
+                inner.as_mut().poll_next(cx),
+                inner.get_pin_mut().get_pin_mut().get_pin_mut(),
+            ),
+        };
+        match ready!(poll) {
+            // Use UFCS to help type inference when compiling with no features.
+            Some(Ok(data)) => Poll::Ready(Some(Ok(BytesMut::freeze(data)))),
+            Some(Err(e)) => Poll::Ready(Some(Err(Adapter::<B, B::Error>::project(inner)
+                .error
+                .take()
+                .map(Error::Body)
+                .unwrap_or(Error::Decompress(e))))),
+            None => Poll::Ready(None),
+        }
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
+        match self.project().inner.project() {
+            BodyInnerProj::Identity { inner, .. } => inner.poll_trailers(cx),
+            #[cfg(feature = "gzip")]
+            BodyInnerProj::Gzip { inner } => inner
+                .get_pin_mut()
+                .get_pin_mut()
+                .get_pin_mut()
+                .project()
+                .body
+                .poll_trailers(cx),
+            #[cfg(feature = "deflate")]
+            BodyInnerProj::Deflate { inner } => inner
+                .get_pin_mut()
+                .get_pin_mut()
+                .get_pin_mut()
+                .project()
+                .body
+                .poll_trailers(cx),
+            #[cfg(feature = "br")]
+            BodyInnerProj::Brotli { inner } => inner
+                .get_pin_mut()
+                .get_pin_mut()
+                .get_pin_mut()
+                .project()
+                .body
+                .poll_trailers(cx),
+        }
+        .map_err(Error::Body)
+    }
+}
+
+impl<E: Display> Display for Error<E> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match *self {
+            Error::Body(ref e) => e.fmt(f),
+            Error::Decompress(ref e) => Display::fmt(&e, f),
+        }
+    }
+}
+
+impl<E: error::Error + 'static> error::Error for Error<E> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            Error::Body(ref e) => Some(e),
+            Error::Decompress(ref e) => Some(e),
+        }
+    }
+}
+
+// Manually implement `Debug` because the `derive(Debug)` macro cannot figure out that
+// `B::Error: Debug` is required.
+impl<B> Debug for DecompressBody<B>
+where
+    B: Body + Debug,
+    B::Error: Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        #[derive(Debug)]
+        struct DecompressBody<'a, B: Body> {
+            inner: &'a BodyInner<B, B::Error>,
+        }
+        DecompressBody { inner: &self.inner }.fmt(f)
+    }
+}
+
+impl<B: Body> Stream for Adapter<B, B::Error> {
+    type Item = io::Result<Bytes>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        match ready!(this.body.poll_data(cx)) {
+            Some(Ok(mut data)) => Poll::Ready(Some(Ok(data.copy_to_bytes(data.remaining())))),
+            Some(Err(e)) => {
+                *this.error = Some(e);
+                // Return a placeholder, which should be discarded by the outer `DecompressBody`.
+                Poll::Ready(Some(Err(io::Error::from_raw_os_error(0))))
+            }
+            None => Poll::Ready(None),
+        }
+    }
+}
+
+impl AcceptEncoding {
+    fn to_header_value(&self) -> Option<HeaderValue> {
+        let accept = match (self.gzip(), self.deflate(), self.br()) {
+            (true, true, true) => "gzip,deflate,br",
+            (true, true, false) => "gzip,deflate",
+            (true, false, true) => "gzip,br",
+            (true, false, false) => "gzip",
+            (false, true, true) => "deflate,br",
+            (false, true, false) => "deflate",
+            (false, false, true) => "br",
+            (false, false, false) => return None,
+        };
+        Some(HeaderValue::from_static(accept))
+    }
+
+    fn gzip(&self) -> bool {
+        #[cfg(feature = "gzip")]
+        {
+            self.contains(AcceptEncoding::GZIP)
+        }
+        #[cfg(not(feature = "gzip"))]
+        {
+            false
+        }
+    }
+
+    fn deflate(&self) -> bool {
+        #[cfg(feature = "deflate")]
+        {
+            self.contains(AcceptEncoding::DEFLATE)
+        }
+        #[cfg(not(feature = "deflate"))]
+        {
+            false
+        }
+    }
+
+    fn br(&self) -> bool {
+        #[cfg(feature = "br")]
+        {
+            self.contains(AcceptEncoding::BR)
+        }
+        #[cfg(not(feature = "br"))]
+        {
+            false
+        }
+    }
+
+    fn set_gzip(mut self, enable: bool) -> Self {
+        #[cfg(feature = "gzip")]
+        {
+            self.set(AcceptEncoding::GZIP, enable);
+            self
+        }
+        #[cfg(not(feature = "gzip"))]
+        {
+            self
+        }
+    }
+
+    fn set_deflate(mut self, enable: bool) -> Self {
+        #[cfg(feature = "deflate")]
+        {
+            self.set(AcceptEncoding::DEFLATE, enable);
+            self
+        }
+        #[cfg(not(feature = "deflate"))]
+        {
+            self
+        }
+    }
+
+    fn set_br(mut self, enable: bool) -> Self {
+        #[cfg(feature = "br")]
+        {
+            self.set(AcceptEncoding::BR, enable);
+            self
+        }
+        #[cfg(not(feature = "br"))]
+        {
+            self
+        }
+    }
+}
+
+impl Default for AcceptEncoding {
+    fn default() -> Self {
+        AcceptEncoding::all()
+    }
+}

--- a/tower-http/src/decompression.rs
+++ b/tower-http/src/decompression.rs
@@ -629,6 +629,7 @@ impl AcceptEncoding {
         }
     }
 
+    #[cfg_attr(not(feature = "gzip"), allow(unused))]
     fn set_gzip(mut self, enable: bool) -> Self {
         #[cfg(feature = "gzip")]
         {
@@ -641,6 +642,7 @@ impl AcceptEncoding {
         }
     }
 
+    #[cfg_attr(not(feature = "deflate"), allow(unused))]
     fn set_deflate(mut self, enable: bool) -> Self {
         #[cfg(feature = "deflate")]
         {
@@ -653,6 +655,7 @@ impl AcceptEncoding {
         }
     }
 
+    #[cfg_attr(not(feature = "br"), allow(unused))]
     fn set_br(mut self, enable: bool) -> Self {
         #[cfg(feature = "br")]
         {

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -41,3 +41,6 @@
 #[cfg(feature = "add-extension")]
 #[cfg_attr(docsrs, doc(cfg(feature = "add-extension")))]
 pub mod add_extension;
+#[cfg(feature = "decompression")]
+#[cfg_attr(docsrs, doc(cfg(feature = "decompression")))]
+pub mod decompression;


### PR DESCRIPTION
This is an HTTP client middleware that sets the `Accept-Encoding` header to requests and transparently decompresses the response body based on the `Content-Encoding` header.

Originally, I was about to release it as a [library][tower-http-compression], but then I realized that #33 was going to add a compression middleware, so I thought that this should live under `tower-http` rather than a separate library.

[tower-http-compression]: https://github.com/tesaguri/tower-http-compression

Since this was developed independently of #37, there are slight differences in API design as shown below, but I'd love to resolve the inconsistencies based on feedback.

- ~This uses `pin-project-lite` because I thought it to be preferable to `pin-project` since `hyper` has recently migrated to it, but I won't insist on that if you are going to add a functionality that requires `pin-project`.~
- ~This uses a custom error type in response body to let users inspect errors from the underlying body type, but the same purpose could be achieved with `Box<dyn Error>` and downcasting as well.~ Edit: #37 has updated to use a custom error.
- No compression algorithm is enabled by default, and users have to pick crate features to make it actually work. This is to reduce compile time in some use cases.