### PR TITLE
Bring back `HttpService` trait alias

### DIFF
--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -37,3 +37,5 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
+
+pub mod service;

--- a/tower-http/src/service.rs
+++ b/tower-http/src/service.rs
@@ -1,0 +1,86 @@
+//! Types and utilities for working with `HttpService`
+
+mod as_service;
+mod into_service;
+
+pub use self::as_service::AsService;
+pub use self::into_service::IntoService;
+
+use http::{Request, Response};
+use http_body::Body;
+use std::future::Future;
+use std::task::{Context, Poll};
+use tower_service::Service;
+
+/// An HTTP service
+///
+/// This is not intended to be implemented directly. Instead, it is a trait
+/// alias of sorts. Implements the [`tower_service::Service`] trait using
+/// [`http::Request`] and [`http::Response`] types.
+pub trait HttpService<RequestBody>: sealed::Sealed<RequestBody> {
+    /// Response payload.
+    type ResponseBody: Body;
+
+    /// Errors produced by the service.
+    type Error;
+
+    /// The future response value.
+    type Future: Future<Output = Result<Response<Self::ResponseBody>, Self::Error>>;
+
+    /// Returns `Ready` when the service is able to process requests.
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
+
+    /// Process the request and return the response asynchronously.
+    fn call(&mut self, request: Request<RequestBody>) -> Self::Future;
+
+    /// Wrap the `HttpService` so that it implements `tower_service::Service`
+    /// directly.
+    ///
+    /// Since `HttpService` does not directly implement `Service`, if an
+    /// `HttpService` instance needs to be used where a `T: Service` is
+    /// required, it must be wrapped with a type that provides that
+    /// implementation. `IntoService` does this.
+    fn into_service(self) -> IntoService<Self>
+    where
+        Self: Sized,
+    {
+        IntoService::new(self)
+    }
+
+    /// Same as `into_service` but operates on an `HttpService` reference.
+    fn as_service(&mut self) -> AsService<'_, Self>
+    where
+        Self: Sized,
+    {
+        AsService::new(self)
+    }
+}
+
+impl<T, ReqBody, ResBody> HttpService<ReqBody> for T
+where
+    T: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    ResBody: Body,
+{
+    type ResponseBody = ResBody;
+    type Error = T::Error;
+    type Future = T::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Service::poll_ready(self, cx)
+    }
+
+    fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
+        Service::call(self, request)
+    }
+}
+
+impl<T, ReqBody, ResBody> sealed::Sealed<ReqBody> for T
+where
+    T: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    ResBody: Body,
+{
+}
+
+mod sealed {
+    pub trait Sealed<B> {}
+}

--- a/tower-http/src/service/as_service.rs
+++ b/tower-http/src/service/as_service.rs
@@ -1,0 +1,37 @@
+use super::HttpService;
+use http::{Request, Response};
+use std::task::{Context, Poll};
+use tower_service::Service;
+
+/// Wraps an `HttpService` reference, implementing `tower_service::Service`.
+///
+/// See [`as_service`] method documentation for more details.
+///
+/// [`as_service`]: HttpService::as_service
+#[derive(Debug)]
+pub struct AsService<'a, T> {
+    inner: &'a mut T,
+}
+
+impl<'a, T> AsService<'a, T> {
+    pub(crate) fn new(inner: &'a mut T) -> AsService<'a, T> {
+        AsService { inner }
+    }
+}
+
+impl<'a, T, ReqBody> Service<Request<ReqBody>> for AsService<'a, T>
+where
+    T: HttpService<ReqBody>,
+{
+    type Response = Response<T::ResponseBody>;
+    type Error = T::Error;
+    type Future = T::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
+        self.inner.call(request)
+    }
+}

--- a/tower-http/src/service/into_service.rs
+++ b/tower-http/src/service/into_service.rs
@@ -1,0 +1,37 @@
+use super::HttpService;
+use http::{Request, Response};
+use std::task::{Context, Poll};
+use tower_service::Service;
+
+/// Wraps an `HttpService` instance, implementing `tower_service::Service`.
+///
+/// See [`into_service`] method documentation for more details.
+///
+/// [`into_service`]: HttpService::into_service
+#[derive(Debug)]
+pub struct IntoService<T> {
+    inner: T,
+}
+
+impl<T> IntoService<T> {
+    pub(crate) fn new(inner: T) -> IntoService<T> {
+        IntoService { inner }
+    }
+}
+
+impl<T, ReqBody> Service<Request<ReqBody>> for IntoService<T>
+where
+    T: HttpService<ReqBody>,
+{
+    type Response = Response<T::ResponseBody>;
+    type Error = T::Error;
+    type Future = T::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
+        self.inner.call(request)
+    }
+}


### PR DESCRIPTION
This brings back the `HttpService` trait from the old `tower-http-util`.

With `HttpService`, you can rewrite trait bounds like this:

```rust
fn foo<S, ReqBody, ResBody>(_: S)
where
    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
    ResBody: Body,
```

to this:

```rust
fn foo<S, B>(_: S)
where
    S: HttpService<B>,
```

The code is mostly copy and pasted from 926a64f262919a559624b6b99c2f38498ec3ba38.