### PR TITLE
Add `get_ref`, `get_mut`, and `into_inner` to all middlewares

### DIFF
--- a/tower-http/src/add_extension.rs
+++ b/tower-http/src/add_extension.rs
@@ -1,6 +1,6 @@
 //! Middleware that clones a value into each request's [extensions].
 //!
-//! [request extensions]: https://docs.rs/http/latest/http/struct.Extensions.html
+//! [extensions]: https://docs.rs/http/latest/http/struct.Extensions.html
 
 use http::Request;
 use std::task::{Context, Poll};

--- a/tower-http/src/add_extension.rs
+++ b/tower-http/src/add_extension.rs
@@ -34,6 +34,10 @@ pub struct AddExtension<S, T> {
     value: T,
 }
 
+impl<S, T> AddExtension<S, T> {
+    define_inner_service_accessors!();
+}
+
 impl<ResBody, S, T> Service<Request<ResBody>> for AddExtension<S, T>
 where
     S: Service<Request<ResBody>>,

--- a/tower-http/src/compression/service.rs
+++ b/tower-http/src/compression/service.rs
@@ -25,20 +25,7 @@ impl<S> Compression<S> {
         }
     }
 
-    /// Gets a reference to the underlying service.
-    pub fn get_ref(&self) -> &S {
-        &self.inner
-    }
-
-    /// Gets a mutable reference to the underlying service.
-    pub fn get_mut(&mut self) -> &mut S {
-        &mut self.inner
-    }
-
-    /// Consumes `self`, returning the underlying service.
-    pub fn into_inner(self) -> S {
-        self.inner
-    }
+    define_inner_service_accessors!();
 
     /// Sets whether to enable the gzip encoding.
     #[cfg(feature = "compression-gzip")]

--- a/tower-http/src/decompression/service.rs
+++ b/tower-http/src/decompression/service.rs
@@ -27,20 +27,7 @@ impl<S> Decompression<S> {
         }
     }
 
-    /// Gets a reference to the underlying service.
-    pub fn get_ref(&self) -> &S {
-        &self.inner
-    }
-
-    /// Gets a mutable reference to the underlying service.
-    pub fn get_mut(&mut self) -> &mut S {
-        &mut self.inner
-    }
-
-    /// Consumes `self`, returning the underlying service.
-    pub fn into_inner(self) -> S {
-        self.inner
-    }
+    define_inner_service_accessors!();
 
     /// Sets whether to request the gzip encoding.
     #[cfg(feature = "decompression-gzip")]

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -38,6 +38,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 
+#[macro_use]
+pub(crate) mod macros;
+
 #[cfg(feature = "propagate-header")]
 #[cfg_attr(docsrs, doc(cfg(feature = "propagate-header")))]
 pub mod propagate_header;

--- a/tower-http/src/macros.rs
+++ b/tower-http/src/macros.rs
@@ -16,4 +16,3 @@ macro_rules! define_inner_service_accessors {
         }
     };
 }
-

--- a/tower-http/src/macros.rs
+++ b/tower-http/src/macros.rs
@@ -1,0 +1,19 @@
+macro_rules! define_inner_service_accessors {
+    () => {
+        /// Gets a reference to the underlying service.
+        pub fn get_ref(&self) -> &S {
+            &self.inner
+        }
+
+        /// Gets a mutable reference to the underlying service.
+        pub fn get_mut(&mut self) -> &mut S {
+            &mut self.inner
+        }
+
+        /// Consumes `self`, returning the underlying service.
+        pub fn into_inner(self) -> S {
+            self.inner
+        }
+    };
+}
+

--- a/tower-http/src/propagate_header.rs
+++ b/tower-http/src/propagate_header.rs
@@ -81,6 +81,8 @@ impl<S> PropagateHeader<S> {
     pub fn new(inner: S, header: HeaderName) -> Self {
         Self { inner, header }
     }
+
+    define_inner_service_accessors!();
 }
 
 impl<ReqBody, ResBody, S> Service<Request<ReqBody>> for PropagateHeader<S>

--- a/tower-http/src/sensitive_header.rs
+++ b/tower-http/src/sensitive_header.rs
@@ -89,20 +89,7 @@ impl<S> SetSensitiveRequestHeader<S> {
         Self { inner, header }
     }
 
-    /// Gets a reference to the underlying service.
-    pub fn get_ref(&self) -> &S {
-        &self.inner
-    }
-
-    /// Gets a mutable reference to the underlying service.
-    pub fn get_mut(&mut self) -> &mut S {
-        &mut self.inner
-    }
-
-    /// Consumes `self`, returning the underlying service.
-    pub fn into_inner(self) -> S {
-        self.inner
-    }
+    define_inner_service_accessors!();
 }
 
 impl<ReqBody, ResBody, S> Service<Request<ReqBody>> for SetSensitiveRequestHeader<S>
@@ -170,20 +157,7 @@ impl<S> SetSensitiveResponseHeader<S> {
         Self { inner, header }
     }
 
-    /// Gets a reference to the underlying service.
-    pub fn get_ref(&self) -> &S {
-        &self.inner
-    }
-
-    /// Gets a mutable reference to the underlying service.
-    pub fn get_mut(&mut self) -> &mut S {
-        &mut self.inner
-    }
-
-    /// Consumes `self`, returning the underlying service.
-    pub fn into_inner(self) -> S {
-        self.inner
-    }
+    define_inner_service_accessors!();
 }
 
 impl<ReqBody, ResBody, S> Service<Request<ReqBody>> for SetSensitiveResponseHeader<S>


### PR DESCRIPTION
Defines a little macro for hiding the boilerplate. It currently assumes the inner service type is named `S` but thats easy to fix if necessary.