### PR TITLE
Avoid using `HeaderValue::from_str`

### DIFF
--- a/tower-http/src/compression/body.rs
+++ b/tower-http/src/compression/body.rs
@@ -159,7 +159,7 @@ where
 
         parts.headers.insert(
             header::CONTENT_ENCODING,
-            HeaderValue::from_str(encoding.to_str()).unwrap(),
+            HeaderValue::from_static(encoding.to_str()),
         );
 
         http::Response::from_parts(parts, body)

--- a/tower-http/src/redirect.rs
+++ b/tower-http/src/redirect.rs
@@ -2,7 +2,7 @@
 
 use http::{header, HeaderValue, Response, StatusCode, Uri};
 use std::{
-    convert::Infallible,
+    convert::{Infallible, TryFrom},
     fmt,
     future::Future,
     marker::PhantomData,
@@ -79,7 +79,7 @@ impl<ResBody> Redirect<ResBody> {
 
         Self {
             status_code,
-            location: HeaderValue::from_str(&uri.to_string())
+            location: HeaderValue::try_from(uri.to_string())
                 .expect("URI isn't a valid header value"),
             _marker: PhantomData,
         }


### PR DESCRIPTION
This reduces the number of allocations.