### PR TITLE
Fix specification of algorithm featues of `async-compression`

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -22,7 +22,7 @@ tower-layer = "0.3"
 tower-service = "0.3"
 
 # optional dependencies
-async-compression = { version = "0.3", optional = true, features = ["deflate", "gzip", "brotli", "tokio"] }
+async-compression = { version = "0.3", optional = true, features = ["tokio"] }
 bytes = { version = "1", optional = true }
 hyper = { version = "0.14", optional = true, default_features = false, features = ["stream"] }
 tokio-util = { version = "0.6", optional = true, default_features = false, features = ["io", "codec"] }


### PR DESCRIPTION
The algorithm features are already enabled by `{de,}compression-*` features individually and should not be enabled unconditionally, as doing that spoils the whole point of the feature set.