### PR TITLE
Move "leaf services" into their own module

### DIFF
--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -173,8 +173,6 @@ pub mod sensitive_header;
 #[cfg_attr(docsrs, doc(cfg(feature = "decompression")))]
 pub mod decompression;
 
-#[cfg(feature = "redirect")]
-#[cfg_attr(docsrs, doc(cfg(feature = "redirect")))]
-pub mod redirect;
+pub mod services;
 
 mod accept_encoding;

--- a/tower-http/src/services/mod.rs
+++ b/tower-http/src/services/mod.rs
@@ -1,0 +1,16 @@
+//! [`Service`]s that return responses without wrapping other [`Service`]s.
+//!
+//! These kinds of services are also referred to as "leaf services" since they sit at the leaves of
+//! a [tree] of services.
+//!
+//! [`Service`]: https://docs.rs/tower/latest/tower/trait.Service.html
+//! [tree]: https://en.wikipedia.org/wiki/Tree_(data_structure)
+
+#[cfg(feature = "redirect")]
+#[cfg_attr(docsrs, doc(cfg(feature = "redirect")))]
+pub mod redirect;
+
+#[cfg(feature = "redirect")]
+#[cfg_attr(docsrs, doc(cfg(feature = "redirect")))]
+#[doc(inline)]
+pub use self::redirect::Redirect;

--- a/tower-http/src/services/redirect.rs
+++ b/tower-http/src/services/redirect.rs
@@ -22,7 +22,7 @@ use tower_service::Service;
 /// use http::{Request, Uri, StatusCode};
 /// use hyper::Body;
 /// use tower::{Service, ServiceExt};
-/// use tower_http::redirect::Redirect;
+/// use tower_http::services::Redirect;
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
As discussed on Discord we think it makes sense to group leaf services together in their own module as to not mix them up with middlewares. We don't think the middlewares belong in their own module since they're likely to be the most interesting part of `tower-http` and so we want them visible in the root module docs.

Suggested names of this module:

- `leaf_services` - Technically correct but not a term I expect users to be familiar with.
- `services` - Probably clearer than `leaf_services` but one could be pedantic and argue that middlewares are also services.

Out of these two I personally prefer `services`.

@tesaguri @LucioFranco @olix0r @hawkw any opinions on the module name?