### PR TITLE
Add `layer` method to all middlewares

### DIFF
--- a/tower-http/src/add_extension.rs
+++ b/tower-http/src/add_extension.rs
@@ -53,7 +53,7 @@ impl<S, T> AddExtension<S, T> {
 
     define_inner_service_accessors!();
 
-    /// Returns a new [`Layer`] that wraps services with a `AddExtensionLayer` middleware.
+    /// Returns a new [`Layer`] that wraps services with a `AddExtension` middleware.
     ///
     /// [`Layer`]: tower_layer::Layer
     pub fn layer(value: T) -> AddExtensionLayer<T> {

--- a/tower-http/src/add_extension.rs
+++ b/tower-http/src/add_extension.rs
@@ -52,6 +52,13 @@ impl<S, T> AddExtension<S, T> {
     }
 
     define_inner_service_accessors!();
+
+    /// Returns a new [`Layer`] that wraps services with a `AddExtensionLayer` middleware.
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(value: T) -> AddExtensionLayer<T> {
+        AddExtensionLayer::new(value)
+    }
 }
 
 impl<ResBody, S, T> Service<Request<ResBody>> for AddExtension<S, T>

--- a/tower-http/src/compression/service.rs
+++ b/tower-http/src/compression/service.rs
@@ -1,10 +1,9 @@
+use super::{CompressionBody, CompressionLayer, Encoding, ResponseFuture};
 use crate::accept_encoding::AcceptEncoding;
 use http::{Request, Response};
 use http_body::Body;
 use std::task::{Context, Poll};
 use tower_service::Service;
-
-use super::{CompressionBody, Encoding, ResponseFuture};
 
 /// Compress response bodies of the underlying service.
 ///
@@ -26,6 +25,13 @@ impl<S> Compression<S> {
     }
 
     define_inner_service_accessors!();
+
+    /// Returns a new [`Layer`] that wraps services with a `Compression` middleware.
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer() -> CompressionLayer {
+        CompressionLayer::new()
+    }
 
     /// Sets whether to enable the gzip encoding.
     #[cfg(feature = "compression-gzip")]

--- a/tower-http/src/decompression/service.rs
+++ b/tower-http/src/decompression/service.rs
@@ -1,4 +1,4 @@
-use super::{DecompressionBody, ResponseFuture};
+use super::{DecompressionBody, DecompressionLayer, ResponseFuture};
 use crate::accept_encoding::AcceptEncoding;
 use http::{
     header::{self, ACCEPT_ENCODING, RANGE},
@@ -28,6 +28,13 @@ impl<S> Decompression<S> {
     }
 
     define_inner_service_accessors!();
+
+    /// Returns a new [`Layer`] that wraps services with a `Decompression` middleware.
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer() -> DecompressionLayer {
+        DecompressionLayer::new()
+    }
 
     /// Sets whether to request the gzip encoding.
     #[cfg(feature = "decompression-gzip")]

--- a/tower-http/src/propagate_header.rs
+++ b/tower-http/src/propagate_header.rs
@@ -84,7 +84,7 @@ impl<S> PropagateHeader<S> {
 
     define_inner_service_accessors!();
 
-    /// Returns a new [`Layer`] that wraps services with a `PropagateHeaderLayer` middleware.
+    /// Returns a new [`Layer`] that wraps services with a `PropagateHeader` middleware.
     ///
     /// [`Layer`]: tower_layer::Layer
     pub fn layer(header: HeaderName) -> PropagateHeaderLayer {

--- a/tower-http/src/propagate_header.rs
+++ b/tower-http/src/propagate_header.rs
@@ -83,6 +83,13 @@ impl<S> PropagateHeader<S> {
     }
 
     define_inner_service_accessors!();
+
+    /// Returns a new [`Layer`] that wraps services with a `PropagateHeaderLayer` middleware.
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(header: HeaderName) -> PropagateHeaderLayer {
+        PropagateHeaderLayer::new(header)
+    }
 }
 
 impl<ReqBody, ResBody, S> Service<Request<ReqBody>> for PropagateHeader<S>

--- a/tower-http/src/sensitive_header.rs
+++ b/tower-http/src/sensitive_header.rs
@@ -166,7 +166,7 @@ impl<S> SetSensitiveResponseHeader<S> {
 
     define_inner_service_accessors!();
 
-    /// Returns a new [`Layer`] that wraps services with a `SetSensitiveResponseHeaderLayer` middleware.
+    /// Returns a new [`Layer`] that wraps services with a `SetSensitiveResponseHeader` middleware.
     ///
     /// [`Layer`]: tower_layer::Layer
     pub fn layer(header: HeaderName) -> SetSensitiveResponseHeaderLayer {

--- a/tower-http/src/sensitive_header.rs
+++ b/tower-http/src/sensitive_header.rs
@@ -90,6 +90,13 @@ impl<S> SetSensitiveRequestHeader<S> {
     }
 
     define_inner_service_accessors!();
+
+    /// Returns a new [`Layer`] that wraps services with a `SetSensitiveRequestHeader` middleware.
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(header: HeaderName) -> SetSensitiveRequestHeaderLayer {
+        SetSensitiveRequestHeaderLayer::new(header)
+    }
 }
 
 impl<ReqBody, ResBody, S> Service<Request<ReqBody>> for SetSensitiveRequestHeader<S>
@@ -158,6 +165,13 @@ impl<S> SetSensitiveResponseHeader<S> {
     }
 
     define_inner_service_accessors!();
+
+    /// Returns a new [`Layer`] that wraps services with a `SetSensitiveResponseHeaderLayer` middleware.
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(header: HeaderName) -> SetSensitiveResponseHeaderLayer {
+        SetSensitiveResponseHeaderLayer::new(header)
+    }
 }
 
 impl<ReqBody, ResBody, S> Service<Request<ReqBody>> for SetSensitiveResponseHeader<S>


### PR DESCRIPTION
As suggested by @hawkw. A small quality of life thing. Allows users to only import the service and still get access to the layer.