### PR TITLE
Add `SetRequestHeader`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ These are the middlewares included in this crate:
 - `MapResponseBody`: Apply a transformation to the response body.
 - `PropagateHeader`: Propagate a header from the request to the response.
 - `SensitiveHeader`: Marks a given header as [sensitive] so it wont show up in logs.
+- `SetRequestHeader`: Set a header on the request.
 - `SetResponseHeader`: Set a header on the response.
 - `SetSensitiveRequestHeader`: Marks a given request header as [sensitive].
 - `SetSensitiveResponseHeader`: Marks a given response header as [sensitive].

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -45,7 +45,7 @@ full = [
     "propagate-header",
     "redirect",
     "sensitive-header",
-    "set-response-header",
+    "set-header",
 ]
 
 add-extension = []
@@ -54,7 +54,7 @@ map-response-body = []
 propagate-header = []
 redirect = []
 sensitive-header = []
-set-response-header = []
+set-header = []
 
 compression = ["bytes", "tokio-util"]
 compression-br = ["async-compression/brotli", "compression"]

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -20,7 +20,7 @@
 //!     compression::CompressionLayer,
 //!     propagate_header::PropagateHeaderLayer,
 //!     sensitive_header::SetSensitiveHeaderLayer,
-//!     set_response_header::SetResponseHeaderLayer,
+//!     set_header::SetResponseHeaderLayer,
 //! };
 //! use tower::{ServiceBuilder, service_fn};
 //! use http::{Request, Response, header::{HeaderName, CONTENT_TYPE, AUTHORIZATION}};
@@ -157,9 +157,9 @@
 #[macro_use]
 pub(crate) mod macros;
 
-#[cfg(feature = "set-response-header")]
-#[cfg_attr(docsrs, doc(cfg(feature = "set-response-header")))]
-pub mod set_response_header;
+#[cfg(feature = "set-header")]
+#[cfg_attr(docsrs, doc(cfg(feature = "set-header")))]
+pub mod set_header;
 
 #[cfg(feature = "propagate-header")]
 #[cfg_attr(docsrs, doc(cfg(feature = "propagate-header")))]

--- a/tower-http/src/set_header/mod.rs
+++ b/tower-http/src/set_header/mod.rs
@@ -1,0 +1,111 @@
+//! Middlewares for setting headers on requests or responses.
+//!
+//! See [request] and [response] for more details.
+
+use http::{header::HeaderName, HeaderMap, HeaderValue, Request, Response};
+
+pub mod request;
+pub mod response;
+
+#[doc(inline)]
+pub use self::{
+    request::{SetRequestHeader, SetRequestHeaderLayer},
+    response::{SetResponseHeader, SetResponseHeaderLayer},
+};
+
+/// Trait for producing header values.
+///
+/// Used by [`SetResponseHeader`].
+///
+/// This trait is implemented for closures with the correct type signature. Typically
+/// users will not have to implement this trait for their own types.
+///
+/// It is also implemented directly for [`HeaderValue`]. When a fixed header value
+/// should be added to all responses, it can be  supplied directly to
+/// [`SetResponseHeaderLayer`].
+pub trait MakeHeaderValue<T> {
+    /// Try to create a header value from the request or response.
+    fn make_header_value(&mut self, message: &T) -> Option<HeaderValue>;
+}
+
+impl<F, T> MakeHeaderValue<T> for F
+where
+    F: FnMut(&T) -> Option<HeaderValue>,
+{
+    fn make_header_value(&mut self, message: &T) -> Option<HeaderValue> {
+        self(message)
+    }
+}
+
+impl<T> MakeHeaderValue<T> for HeaderValue {
+    fn make_header_value(&mut self, _message: &T) -> Option<HeaderValue> {
+        Some(self.clone())
+    }
+}
+
+impl<T> MakeHeaderValue<T> for Option<HeaderValue> {
+    fn make_header_value(&mut self, _message: &T) -> Option<HeaderValue> {
+        self.clone()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum InsertHeaderMode {
+    Override,
+    Append,
+    IfNotPresent,
+}
+
+impl InsertHeaderMode {
+    fn apply<T, M>(self, header_name: &HeaderName, target: &mut T, make: &mut M)
+    where
+        T: Headers,
+        M: MakeHeaderValue<T>,
+    {
+        match self {
+            InsertHeaderMode::Override => {
+                if let Some(value) = make.make_header_value(target) {
+                    target.headers_mut().insert(header_name.clone(), value);
+                }
+            }
+            InsertHeaderMode::IfNotPresent => {
+                if !target.headers().contains_key(header_name) {
+                    if let Some(value) = make.make_header_value(target) {
+                        target.headers_mut().insert(header_name.clone(), value);
+                    }
+                }
+            }
+            InsertHeaderMode::Append => {
+                if let Some(value) = make.make_header_value(target) {
+                    target.headers_mut().append(header_name.clone(), value);
+                }
+            }
+        }
+    }
+}
+
+trait Headers {
+    fn headers(&self) -> &HeaderMap;
+
+    fn headers_mut(&mut self) -> &mut HeaderMap;
+}
+
+impl<B> Headers for Request<B> {
+    fn headers(&self) -> &HeaderMap {
+        Request::headers(self)
+    }
+
+    fn headers_mut(&mut self) -> &mut HeaderMap {
+        Request::headers_mut(self)
+    }
+}
+
+impl<B> Headers for Response<B> {
+    fn headers(&self) -> &HeaderMap {
+        Response::headers(self)
+    }
+
+    fn headers_mut(&mut self) -> &mut HeaderMap {
+        Response::headers_mut(self)
+    }
+}

--- a/tower-http/src/set_header/mod.rs
+++ b/tower-http/src/set_header/mod.rs
@@ -1,4 +1,4 @@
-//! Middlewares for setting headers on requests or responses.
+//! Middlewares for setting headers on requests and responses.
 //!
 //! See [request] and [response] for more details.
 
@@ -15,14 +15,13 @@ pub use self::{
 
 /// Trait for producing header values.
 ///
-/// Used by [`SetResponseHeader`].
+/// Used by [`SetRequestHeader`] and [`SetResponseHeader`].
 ///
-/// This trait is implemented for closures with the correct type signature. Typically
-/// users will not have to implement this trait for their own types.
+/// This trait is implemented for closures with the correct type signature. Typically users will
+/// not have to implement this trait for their own types.
 ///
-/// It is also implemented directly for [`HeaderValue`]. When a fixed header value
-/// should be added to all responses, it can be  supplied directly to
-/// [`SetResponseHeaderLayer`].
+/// It is also implemented directly for [`HeaderValue`]. When a fixed header value should be added
+/// to all responses, it can be supplied directly to the middleware.
 pub trait MakeHeaderValue<T> {
     /// Try to create a header value from the request or response.
     fn make_header_value(&mut self, message: &T) -> Option<HeaderValue>;

--- a/tower-http/src/set_header/request.rs
+++ b/tower-http/src/set_header/request.rs
@@ -16,7 +16,7 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # let render_html = tower::service_fn(|_: Request<Body>| async move {
+//! # let http_client = tower::service_fn(|_: Request<Body>| async move {
 //! #     Ok::<_, std::convert::Infallible>(Response::new(Body::empty()))
 //! # });
 //! #
@@ -34,7 +34,7 @@
 //!             HeaderValue::from_static("my very cool app"),
 //!         )
 //!     )
-//!     .service(render_html);
+//!     .service(http_client);
 //!
 //! let request = Request::new(Body::empty());
 //!
@@ -54,7 +54,7 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # let render_html = tower::service_fn(|_: Request<Body>| async move {
+//! # let http_client = tower::service_fn(|_: Request<Body>| async move {
 //! #     Ok::<_, std::convert::Infallible>(Response::new(Body::empty()))
 //! # });
 //! fn date_header_value() -> HeaderValue {
@@ -75,7 +75,7 @@
 //!             }
 //!         )
 //!     )
-//!     .service(render_html);
+//!     .service(http_client);
 //!
 //! let request = Request::new(Body::empty());
 //!

--- a/tower-http/src/set_header/request.rs
+++ b/tower-http/src/set_header/request.rs
@@ -16,8 +16,8 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # let render_html = tower::service_fn(|request: Request<Body>| async move {
-//! #     Ok::<_, std::convert::Infallible>(Response::new(request.into_body()))
+//! # let render_html = tower::service_fn(|_: Request<Body>| async move {
+//! #     Ok::<_, std::convert::Infallible>(Response::new(Body::empty()))
 //! # });
 //! #
 //! let mut svc = ServiceBuilder::new()
@@ -54,8 +54,8 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # let render_html = tower::service_fn(|request: Request<Body>| async move {
-//! #     Ok::<_, std::convert::Infallible>(Response::new(Body::from("1234567890")))
+//! # let render_html = tower::service_fn(|_: Request<Body>| async move {
+//! #     Ok::<_, std::convert::Infallible>(Response::new(Body::empty()))
 //! # });
 //! fn date_header_value() -> HeaderValue {
 //!     // ...

--- a/tower-http/src/set_header/request.rs
+++ b/tower-http/src/set_header/request.rs
@@ -1,0 +1,255 @@
+//! Set a header on the request.
+//!
+//! The header value to be set may be provided as a fixed value when the
+//! middleware is constructed, or determined dynamically based on the request
+//! by a closure. See the [`MakeHeaderValue`] trait for details.
+//!
+//! # Example
+//!
+//! Setting a header from a fixed value provided when the middleware is constructed:
+//!
+//! ```
+//! use http::{Request, Response, header::{self, HeaderValue}};
+//! use tower::{Service, ServiceExt, ServiceBuilder};
+//! use tower_http::set_header::SetRequestHeaderLayer;
+//! use hyper::Body;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let render_html = tower::service_fn(|request: Request<Body>| async move {
+//! #     Ok::<_, std::convert::Infallible>(Response::new(request.into_body()))
+//! # });
+//! #
+//! let mut svc = ServiceBuilder::new()
+//!     .layer(
+//!         // Layer that sets `User-Agent: my very cool app` on requests.
+//!         //
+//!         // We have to add `::<_, Body>` since Rust cannot infer the body type when
+//!         // we don't use a closure to produce the header value.
+//!         //
+//!         // `if_not_present` will only insert the header if it does not already
+//!         // have a value.
+//!         SetRequestHeaderLayer::<_, Body>::if_not_present(
+//!             header::USER_AGENT,
+//!             HeaderValue::from_static("my very cool app"),
+//!         )
+//!     )
+//!     .service(render_html);
+//!
+//! let request = Request::new(Body::empty());
+//!
+//! let response = svc.ready_and().await?.call(request).await?;
+//! #
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Setting a header based on a value determined dynamically from the request:
+//!
+//! ```
+//! use http::{Request, Response, header::{self, HeaderValue}};
+//! use tower::{Service, ServiceExt, ServiceBuilder};
+//! use tower_http::set_header::SetRequestHeaderLayer;
+//! use hyper::Body;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let render_html = tower::service_fn(|request: Request<Body>| async move {
+//! #     Ok::<_, std::convert::Infallible>(Response::new(Body::from("1234567890")))
+//! # });
+//! fn date_header_value() -> HeaderValue {
+//!     // ...
+//!     # HeaderValue::from_static("now")
+//! }
+//!
+//! let mut svc = ServiceBuilder::new()
+//!     .layer(
+//!         // Layer that sets `Date` to the current date and time.
+//!         //
+//!         // `overriding` will insert the header and override any previous values it
+//!         // may have.
+//!         SetRequestHeaderLayer::overriding(
+//!             header::DATE,
+//!             |request: &Request<Body>| {
+//!                 Some(date_header_value())
+//!             }
+//!         )
+//!     )
+//!     .service(render_html);
+//!
+//! let request = Request::new(Body::empty());
+//!
+//! let response = svc.ready_and().await?.call(request).await?;
+//! #
+//! # Ok(())
+//! # }
+//! ```
+
+use super::{InsertHeaderMode, MakeHeaderValue};
+use http::{header::HeaderName, Request};
+use std::marker::PhantomData;
+use std::{
+    fmt,
+    task::{Context, Poll},
+};
+use tower_layer::Layer;
+use tower_service::Service;
+
+/// Layer that applies [`SetRequestHeader`] which adds a request header.
+///
+/// See [`SetRequestHeader`] for more details.
+pub struct SetRequestHeaderLayer<M, T> {
+    header_name: HeaderName,
+    make: M,
+    mode: InsertHeaderMode,
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<M, T> fmt::Debug for SetRequestHeaderLayer<M, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SetRequestHeaderLayer")
+            .field("header_name", &self.header_name)
+            .field("mode", &self.mode)
+            .field("make", &std::any::type_name::<M>())
+            .finish()
+    }
+}
+
+impl<M, T> SetRequestHeaderLayer<M, T>
+where
+    M: MakeHeaderValue<T>,
+{
+    /// Create a new [`SetRequestHeaderLayer`]. If a previous value exists for the same header, it
+    /// is removed and replaced with the new header value.
+    pub fn overriding(header_name: HeaderName, make: M) -> Self {
+        Self::new(header_name, make, InsertHeaderMode::Override)
+    }
+
+    /// Create a new [`SetRequestHeaderLayer`]. The new header is always added, preserving any
+    /// existing values. If previous values exist, the header will have multiple values.
+    pub fn appending(header_name: HeaderName, make: M) -> Self {
+        Self::new(header_name, make, InsertHeaderMode::Append)
+    }
+
+    /// Create a new [`SetRequestHeaderLayer`]. If a previous value exists for the header, the new
+    /// value is not inserted.
+    pub fn if_not_present(header_name: HeaderName, make: M) -> Self {
+        Self::new(header_name, make, InsertHeaderMode::IfNotPresent)
+    }
+
+    fn new(header_name: HeaderName, make: M, mode: InsertHeaderMode) -> Self
+    where
+        M: MakeHeaderValue<T>,
+    {
+        Self {
+            make,
+            header_name,
+            mode,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T, S, M> Layer<S> for SetRequestHeaderLayer<M, T>
+where
+    M: MakeHeaderValue<T> + Clone,
+{
+    type Service = SetRequestHeader<S, M>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        SetRequestHeader {
+            inner,
+            header_name: self.header_name.clone(),
+            make: self.make.clone(),
+            mode: self.mode,
+        }
+    }
+}
+
+impl<M, T> Clone for SetRequestHeaderLayer<M, T>
+where
+    M: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            make: self.make.clone(),
+            header_name: self.header_name.clone(),
+            mode: self.mode,
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// Middleware that sets a header on the request.
+#[derive(Clone)]
+pub struct SetRequestHeader<S, M> {
+    inner: S,
+    header_name: HeaderName,
+    make: M,
+    mode: InsertHeaderMode,
+}
+
+impl<S, M> SetRequestHeader<S, M> {
+    /// Create a new [`SetRequestHeader`]. If a previous value exists for the same header, it is
+    /// removed and replaced with the new header value.
+    pub fn overriding(inner: S, header_name: HeaderName, make: M) -> Self {
+        Self::new(inner, header_name, make, InsertHeaderMode::Override)
+    }
+
+    /// Create a new [`SetRequestHeader`]. The new header is always added, preserving any existing
+    /// values. If previous values exist, the header will have multiple values.
+    pub fn appending(inner: S, header_name: HeaderName, make: M) -> Self {
+        Self::new(inner, header_name, make, InsertHeaderMode::Append)
+    }
+
+    /// Create a new [`SetRequestHeader`]. If a previous value exists for the header, the new
+    /// value is not inserted.
+    pub fn if_not_present(inner: S, header_name: HeaderName, make: M) -> Self {
+        Self::new(inner, header_name, make, InsertHeaderMode::IfNotPresent)
+    }
+
+    fn new(inner: S, header_name: HeaderName, make: M, mode: InsertHeaderMode) -> Self {
+        Self {
+            inner,
+            header_name,
+            make,
+            mode,
+        }
+    }
+
+    define_inner_service_accessors!();
+}
+
+impl<S, M> fmt::Debug for SetRequestHeader<S, M>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SetRequestHeader")
+            .field("inner", &self.inner)
+            .field("header_name", &self.header_name)
+            .field("mode", &self.mode)
+            .field("make", &std::any::type_name::<M>())
+            .finish()
+    }
+}
+
+impl<ReqBody, S, M> Service<Request<ReqBody>> for SetRequestHeader<S, M>
+where
+    S: Service<Request<ReqBody>>,
+    M: MakeHeaderValue<Request<ReqBody>> + Clone,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        self.mode.apply(&self.header_name, &mut req, &mut self.make);
+        self.inner.call(req)
+    }
+}

--- a/tower-http/src/set_header/response.rs
+++ b/tower-http/src/set_header/response.rs
@@ -11,7 +11,7 @@
 //! ```
 //! use http::{Request, Response, header::{self, HeaderValue}};
 //! use tower::{Service, ServiceExt, ServiceBuilder};
-//! use tower_http::set_response_header::SetResponseHeaderLayer;
+//! use tower_http::set_header::SetResponseHeaderLayer;
 //! use hyper::Body;
 //!
 //! # #[tokio::main]
@@ -51,7 +51,7 @@
 //! ```
 //! use http::{Request, Response, header::{self, HeaderValue}};
 //! use tower::{Service, ServiceExt, ServiceBuilder};
-//! use tower_http::set_response_header::SetResponseHeaderLayer;
+//! use tower_http::set_header::SetResponseHeaderLayer;
 //! use hyper::Body;
 //! use http_body::Body as _; // for `Body::size_hint`
 //!
@@ -69,7 +69,7 @@
 //!         // `overriding` will insert the header and override any previous values it
 //!         // may have.
 //!         SetResponseHeaderLayer::overriding(
-//!             http::header::CONTENT_LENGTH,
+//!             header::CONTENT_LENGTH,
 //!             |response: &Response<Body>| {
 //!                 if let Some(size) = response.body().size_hint().exact() {
 //!                     // If the response body has a known size, returning `Some` will
@@ -95,8 +95,9 @@
 //! # }
 //! ```
 
+use super::{InsertHeaderMode, MakeHeaderValue};
 use futures_util::ready;
-use http::{header::HeaderName, HeaderValue, Response};
+use http::{header::HeaderName, Response};
 use pin_project::pin_project;
 use std::{
     fmt,
@@ -159,19 +160,6 @@ where
             mode,
             _marker: PhantomData,
         }
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-enum InsertHeaderMode {
-    Override,
-    Append,
-    IfNotPresent,
-}
-
-impl Default for InsertHeaderMode {
-    fn default() -> Self {
-        Self::Override
     }
 }
 
@@ -305,70 +293,16 @@ where
         let this = self.project();
         let mut res = ready!(this.future.poll(cx)?);
 
-        match *this.mode {
-            InsertHeaderMode::Override => {
-                if let Some(value) = this.make.make_header_value(&res) {
-                    res.headers_mut().insert(this.header_name.clone(), value);
-                }
-            }
-            InsertHeaderMode::IfNotPresent => {
-                if !res.headers().contains_key(&*this.header_name) {
-                    if let Some(value) = this.make.make_header_value(&res) {
-                        res.headers_mut().insert(this.header_name.clone(), value);
-                    }
-                }
-            }
-            InsertHeaderMode::Append => {
-                if let Some(value) = this.make.make_header_value(&res) {
-                    res.headers_mut().append(this.header_name.clone(), value);
-                }
-            }
-        }
+        this.mode.apply(this.header_name, &mut res, &mut *this.make);
 
         Poll::Ready(Ok(res))
-    }
-}
-
-/// Trait for producing header values.
-///
-/// Used by [`SetResponseHeader`].
-///
-/// This trait is implemented for closures with the correct type signature. Typically
-/// users will not have to implement this trait for their own types.
-///
-/// It is also implemented directly for [`HeaderValue`]. When a fixed header value
-/// should be added to all responses, it can be  supplied directly to
-/// [`SetResponseHeaderLayer`].
-pub trait MakeHeaderValue<T> {
-    /// Try to create a header value from the request or response.
-    fn make_header_value(&mut self, message: &T) -> Option<HeaderValue>;
-}
-
-impl<F, T> MakeHeaderValue<T> for F
-where
-    F: FnMut(&T) -> Option<HeaderValue>,
-{
-    fn make_header_value(&mut self, message: &T) -> Option<HeaderValue> {
-        self(message)
-    }
-}
-
-impl<T> MakeHeaderValue<T> for HeaderValue {
-    fn make_header_value(&mut self, _message: &T) -> Option<HeaderValue> {
-        Some(self.clone())
-    }
-}
-
-impl<T> MakeHeaderValue<T> for Option<HeaderValue> {
-    fn make_header_value(&mut self, _message: &T) -> Option<HeaderValue> {
-        self.clone()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use http::header;
+    use http::{header, HeaderValue};
     use hyper::Body;
     use std::convert::Infallible;
     use tower::{service_fn, ServiceExt};


### PR DESCRIPTION
Exactly the same as `SetResponseHeader` but modifies the request instead. Useful on clients for example for setting `User-Agent`.

As it shares `MakeHeaderValue` and `InsertHeaderMode` with `SetResponseHeader` I moved these two middlewares into a `set_header` module.

Fixes https://github.com/tower-rs/tower-http/issues/66