### PR TITLE
`Trace` middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ These are the middlewares included in this crate:
 - `SetResponseHeader`: Set a header on the response.
 - `SetSensitiveRequestHeader`: Marks a given request header as [sensitive].
 - `SetSensitiveResponseHeader`: Marks a given response header as [sensitive].
+- `Trace`: High level logging of requests and responses.
 
 Middlewares uses the [`http`] crate as the HTTP interface so they're compatible with any library or framework that also uses [`http`]. For example hyper and actix.
 

--- a/examples/tonic-key-value-store/README.md
+++ b/examples/tonic-key-value-store/README.md
@@ -7,7 +7,7 @@ This examples contains a simple key/value store with a gRPC API and client built
 Running a server:
 
 ```
-cargo run --bin tonic-key-value-store -- -p 3000 server
+RUST_LOG=tower_http=trace cargo run --bin tonic-key-value-store -- -p 3000 server
 ```
 
 Setting values:

--- a/examples/tonic-key-value-store/README.md
+++ b/examples/tonic-key-value-store/README.md
@@ -13,11 +13,11 @@ RUST_LOG=tower_http=trace cargo run --bin tonic-key-value-store -- -p 3000 serve
 Setting values:
 
 ```
-echo "Hello, World" | cargo run --bin tonic-key-value-store -- -p 3000 set -k foo
+echo "Hello, World" | RUST_LOG=tower_http=trace cargo run --bin tonic-key-value-store -- -p 3000 set -k foo
 ```
 
 Getting values:
 
 ```
-cargo run --bin tonic-key-value-store -- -p 3000 get -k foo
+RUST_LOG=tower_http=trace cargo run --bin tonic-key-value-store -- -p 3000 get -k foo
 ```

--- a/examples/tonic-key-value-store/src/main.rs
+++ b/examples/tonic-key-value-store/src/main.rs
@@ -23,6 +23,7 @@ use tower::{BoxError, Service};
 use tower_http::{
     compression::CompressionLayer, decompression::DecompressionLayer,
     sensitive_header::SetSensitiveHeaderLayer, set_header::SetRequestHeaderLayer,
+    trace::TraceLayer,
 };
 
 mod proto {
@@ -136,6 +137,8 @@ async fn serve_forever(listener: TcpListener) -> Result<(), Box<dyn std::error::
         .layer(CompressionLayer::new())
         // Mark the `Authorization` header as sensitive so it doesn't show in logs
         .layer(SetSensitiveHeaderLayer::new(header::AUTHORIZATION))
+        // Log all requests and responses
+        .layer(TraceLayer::new_for_grpc())
         // Build our final `Service`
         .service(service);
 

--- a/examples/warp-key-value-store/README.md
+++ b/examples/warp-key-value-store/README.md
@@ -10,5 +10,6 @@ This examples contains a simple key/value store with an HTTP API built using war
 ## Running the example
 
 ```
-cargo run --bin warp-key-value-store
+RUST_LOG=warp_key_value_store=trace,tower_http=trace \
+    cargo run --bin warp-key-value-store
 ```

--- a/examples/warp-key-value-store/src/main.rs
+++ b/examples/warp-key-value-store/src/main.rs
@@ -145,7 +145,7 @@ pub fn set() -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
         })
 }
 
-// Filter for looking up a key
+// Test filter that always fails
 pub fn error() -> impl Filter<Extract = (&'static str,), Error = Rejection> + Clone {
     warp::get()
         .and(path!("debug" / "error"))

--- a/examples/warp-key-value-store/src/main.rs
+++ b/examples/warp-key-value-store/src/main.rs
@@ -12,12 +12,9 @@ use std::time::Duration;
 use structopt::StructOpt;
 use tower::{make::Shared, ServiceBuilder};
 use tower_http::{
-    add_extension::AddExtensionLayer,
-    compression::CompressionLayer,
-    sensitive_header::SetSensitiveHeaderLayer,
-    set_header::SetResponseHeaderLayer,
-    trace::{DefaultOnEos, DefaultOnFailure, DefaultOnRequest, DefaultOnResponse, TraceLayer},
-    LatencyUnit,
+    add_extension::AddExtensionLayer, compression::CompressionLayer,
+    sensitive_header::SetSensitiveHeaderLayer, set_header::SetResponseHeaderLayer,
+    trace::TraceLayer,
 };
 use warp::{filters, path};
 use warp::{Filter, Rejection, Reply};

--- a/examples/warp-key-value-store/src/main.rs
+++ b/examples/warp-key-value-store/src/main.rs
@@ -66,7 +66,11 @@ async fn serve_forever(listener: TcpListener) -> Result<(), hyper::Error> {
     // Apply middlewares to our service.
     let service = ServiceBuilder::new()
         // Add high level tracing/logging to all requests
-        .layer(TraceLayer::new_for_http())
+        .layer(
+            TraceLayer::new_for_http().on_body_chunk(|chunk: &Bytes, latency: Duration| {
+                tracing::trace!(size_bytes = chunk.len(), latency = ?latency, "sending body chunk")
+            }),
+        )
         // Set a timeout
         .timeout(Duration::from_secs(10))
         // Share the state with each handler via a request extension

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -34,8 +34,9 @@ flate2 = "1.0"
 futures = "0.3"
 hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
-tower = { version = "0.4", features = ["util", "retry", "make"] }
+tower = { version = "0.4.6", features = ["util", "retry", "make"] }
 tracing-subscriber = "0.2"
+once_cell = "1"
 
 [features]
 default = []

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -27,6 +27,7 @@ bytes = { version = "1", optional = true }
 hyper = { version = "0.14", optional = true, default_features = false, features = ["stream"] }
 tokio = { version = "1", optional = true, default_features = false }
 tokio-util = { version = "0.6", optional = true, default_features = false, features = ["io"] }
+tracing = { version = "0.1", default_features = false, optional = true }
 
 [dev-dependencies]
 flate2 = "1.0"
@@ -34,6 +35,7 @@ futures = "0.3"
 hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 tower = { version = "0.4", features = ["util", "retry", "make"] }
+tracing-subscriber = "0.2"
 
 [features]
 default = []
@@ -48,6 +50,7 @@ full = [
     "redirect",
     "sensitive-header",
     "set-header",
+    "trace",
 ]
 
 add-extension = []
@@ -57,6 +60,7 @@ propagate-header = []
 redirect = []
 sensitive-header = []
 set-header = []
+trace = ["tracing"]
 
 compression = ["bytes", "tokio-util", "tokio"]
 compression-br = ["async-compression/brotli", "compression"]

--- a/tower-http/src/classify.rs
+++ b/tower-http/src/classify.rs
@@ -284,7 +284,7 @@ impl<E> ClassifyEos<E> for GrpcEosErrorsAsFailures {
     }
 }
 
-fn classify_grpc_metadata(headers: &HeaderMap) -> Option<Result<(), i32>> {
+pub(crate) fn classify_grpc_metadata(headers: &HeaderMap) -> Option<Result<(), i32>> {
     let status = headers.get("grpc-status")?;
     let status = status.to_str().ok()?;
     let status = status.parse::<i32>().ok()?;

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -243,5 +243,7 @@ pub enum LatencyUnit {
     /// TODO(david): docs
     Millis,
     /// TODO(david): docs
+    Micros,
+    /// TODO(david): docs
     Nanos,
 }

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -183,6 +183,10 @@ pub mod map_response_body;
 #[cfg_attr(docsrs, doc(cfg(feature = "map-request-body")))]
 pub mod map_request_body;
 
+#[cfg(feature = "trace")]
+#[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
+pub mod trace;
+
 pub mod classify;
 pub mod services;
 
@@ -230,4 +234,14 @@ where
             BodyOrIoError::Body(inner) => inner.source(),
         }
     }
+}
+
+/// TODO(david): docs
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug)]
+pub enum LatencyUnit {
+    /// TODO(david): docs
+    Millis,
+    /// TODO(david): docs
+    Nanos,
 }

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -236,14 +236,14 @@ where
     }
 }
 
-/// TODO(david): docs
+/// The latency unit used to report latencies by middlewares.
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug)]
 pub enum LatencyUnit {
-    /// TODO(david): docs
+    /// Use milliseconds.
     Millis,
-    /// TODO(david): docs
+    /// Use microseconds.
     Micros,
-    /// TODO(david): docs
+    /// Use nanoseconds.
     Nanos,
 }

--- a/tower-http/src/trace/body.rs
+++ b/tower-http/src/trace/body.rs
@@ -1,4 +1,4 @@
-use super::{OnEos, OnFailure};
+use super::{OnBodyChunk, OnEos, OnFailure};
 use crate::classify::ClassifyEos;
 use http::HeaderMap;
 use http_body::Body;
@@ -14,21 +14,24 @@ use tracing::Span;
 ///
 /// [`Trace`]: super::Trace
 #[pin_project]
-pub struct ResponseBody<B, C, OnEos, OnFailure> {
+pub struct ResponseBody<B, C, OnBodyChunk, OnEos, OnFailure> {
     #[pin]
     pub(crate) inner: B,
     pub(crate) classify_eos: Option<C>,
     pub(crate) on_eos: Option<(OnEos, Instant)>,
+    pub(crate) on_body_chunk: OnBodyChunk,
     pub(crate) on_failure: Option<OnFailure>,
     pub(crate) start: Instant,
     pub(crate) span: Span,
 }
 
-impl<B, C, OnEosT, OnFailureT> Body for ResponseBody<B, C, OnEosT, OnFailureT>
+impl<B, C, OnBodyChunkT, OnEosT, OnFailureT> Body
+    for ResponseBody<B, C, OnBodyChunkT, OnEosT, OnFailureT>
 where
     B: Body,
     C: ClassifyEos<B::Error>,
     OnEosT: OnEos,
+    OnBodyChunkT: OnBodyChunk<B::Data>,
     OnFailureT: OnFailure<C::FailureClass>,
 {
     type Data = B::Data;
@@ -40,7 +43,6 @@ where
     ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
         let this = self.project();
         let _guard = this.span.enter();
-        let latency = this.start.elapsed();
 
         let result = if let Some(result) = futures_util::ready!(this.inner.poll_data(cx)) {
             result
@@ -48,18 +50,19 @@ where
             return Poll::Ready(None);
         };
 
-        if let Some((classify_eos, on_failure)) =
+        let latency = this.start.elapsed();
+
+        if let Some((classify_eos, mut on_failure)) =
             this.classify_eos.take().zip(this.on_failure.take())
         {
-            match &result {
-                Ok(_chunk) => {
-                    // TODO(david): add call back
-                }
-                Err(err) => {
-                    let failure_class = classify_eos.classify_error(err);
-                    on_failure.on_failure(failure_class, latency);
-                }
+            if let Err(err) = &result {
+                let failure_class = classify_eos.classify_error(err);
+                on_failure.on_failure(failure_class, latency);
             }
+        }
+
+        if let Ok(chunk) = &result {
+            this.on_body_chunk.on_body_chunk(chunk, latency);
         }
 
         Poll::Ready(Some(result))
@@ -75,7 +78,7 @@ where
 
         let latency = this.start.elapsed();
 
-        if let Some((classify_eos, on_failure)) =
+        if let Some((classify_eos, mut on_failure)) =
             this.classify_eos.take().zip(this.on_failure.take())
         {
             match &result {

--- a/tower-http/src/trace/body.rs
+++ b/tower-http/src/trace/body.rs
@@ -1,0 +1,94 @@
+use super::{OnEos, OnFailure};
+use crate::classify::ClassifyEos;
+use http::HeaderMap;
+use http_body::Body;
+use pin_project::pin_project;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+    time::Instant,
+};
+use tracing::Span;
+
+/// Response body for [`Trace`].
+///
+/// [`Trace`]: super::Trace
+#[pin_project]
+pub struct ResponseBody<B, C, OnEos, OnFailure> {
+    #[pin]
+    pub(crate) inner: B,
+    pub(crate) classify_eos: Option<C>,
+    pub(crate) on_eos: Option<(OnEos, Instant)>,
+    pub(crate) on_failure: Option<OnFailure>,
+    pub(crate) start: Instant,
+    pub(crate) span: Span,
+}
+
+impl<B, C, OnEosT, OnFailureT> Body for ResponseBody<B, C, OnEosT, OnFailureT>
+where
+    B: Body,
+    C: ClassifyEos<B::Error>,
+    OnEosT: OnEos,
+    OnFailureT: OnFailure<C::FailureClass>,
+{
+    type Data = B::Data;
+    type Error = B::Error;
+
+    fn poll_data(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        let this = self.project();
+        let _guard = this.span.enter();
+        let latency = this.start.elapsed();
+
+        if let Some(result) = futures_util::ready!(this.inner.poll_data(cx)) {
+            if let Some((classify_eos, on_failure)) =
+                this.classify_eos.take().zip(this.on_failure.take())
+            {
+                match &result {
+                    Ok(_chunk) => {}
+                    Err(err) => {
+                        let failure_class = classify_eos.classify_error(err);
+                        on_failure.on_failure(failure_class, latency);
+                    }
+                }
+            }
+
+            Poll::Ready(Some(result))
+        } else {
+            Poll::Ready(None)
+        }
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
+        let this = self.project();
+        let _guard = this.span.enter();
+        let result = futures_util::ready!(this.inner.poll_trailers(cx));
+
+        let latency = this.start.elapsed();
+
+        if let Some((classify_eos, on_failure)) =
+            this.classify_eos.take().zip(this.on_failure.take())
+        {
+            match &result {
+                Ok(trailers) => {
+                    if let Err(failure_class) = classify_eos.classify_eos(trailers.as_ref()) {
+                        on_failure.on_failure(failure_class, latency);
+                    } else if let Some((on_eos, stream_start)) = this.on_eos.take() {
+                        on_eos.on_eos(trailers.as_ref(), stream_start.elapsed());
+                    }
+                }
+                Err(err) => {
+                    let failure_class = classify_eos.classify_error(err);
+                    on_failure.on_failure(failure_class, latency);
+                }
+            }
+        }
+
+        Poll::Ready(result)
+    }
+}

--- a/tower-http/src/trace/body.rs
+++ b/tower-http/src/trace/body.rs
@@ -88,7 +88,9 @@ where
                 Ok(trailers) => {
                     if let Err(failure_class) = classify_eos.classify_eos(trailers.as_ref()) {
                         on_failure.on_failure(failure_class, latency);
-                    } else if let Some((on_eos, stream_start)) = this.on_eos.take() {
+                    }
+
+                    if let Some((on_eos, stream_start)) = this.on_eos.take() {
                         on_eos.on_eos(trailers.as_ref(), stream_start.elapsed());
                     }
                 }

--- a/tower-http/src/trace/future.rs
+++ b/tower-http/src/trace/future.rs
@@ -1,0 +1,101 @@
+use super::{OnEos, OnFailure, OnResponse, ResponseBody};
+use crate::classify::{ClassifiedResponse, ClassifyResponse};
+use http::Response;
+use http_body::Body;
+use pin_project::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Instant,
+};
+use tracing::Span;
+
+/// Response future for [`Trace`].
+///
+/// [`Trace`]: super::Trace
+#[pin_project]
+pub struct ResponseFuture<F, C, OnResponse, OnEos, OnFailure> {
+    #[pin]
+    pub(crate) inner: F,
+    pub(crate) span: Span,
+    pub(crate) classifier: Option<C>,
+    pub(crate) on_response: Option<OnResponse>,
+    pub(crate) on_eos: Option<OnEos>,
+    pub(crate) on_failure: Option<OnFailure>,
+    pub(crate) start: Instant,
+}
+
+impl<Fut, ResBody, E, C, OnResponseT, OnEosT, OnFailureT> Future
+    for ResponseFuture<Fut, C, OnResponseT, OnEosT, OnFailureT>
+where
+    Fut: Future<Output = Result<Response<ResBody>, E>>,
+    ResBody: Body,
+    C: ClassifyResponse<E>,
+    OnResponseT: OnResponse<ResBody>,
+    OnFailureT: OnFailure<C::FailureClass>,
+    OnEosT: OnEos,
+{
+    type Output = Result<Response<ResponseBody<ResBody, C::ClassifyEos, OnEosT, OnFailureT>>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let _guard = this.span.enter();
+        let result = futures_util::ready!(this.inner.poll(cx));
+        let latency = this.start.elapsed();
+
+        let classifier = this.classifier.take().unwrap();
+        let on_eos = this.on_eos.take();
+        let on_failure = this.on_failure.take().unwrap();
+
+        match result {
+            Ok(res) => {
+                let classification = classifier.classify_response(&res);
+                let start = *this.start;
+
+                match classification {
+                    ClassifiedResponse::Ready(classification) => {
+                        if let Err(failure_class) = classification {
+                            on_failure.on_failure(failure_class, latency);
+                        }
+
+                        this.on_response.take().unwrap().on_response(&res, latency);
+
+                        let span = this.span.clone();
+                        let res = res.map(|body| ResponseBody {
+                            inner: body,
+                            classify_eos: None,
+                            on_eos: None,
+                            on_failure: None,
+                            start,
+                            span,
+                        });
+
+                        Poll::Ready(Ok(res))
+                    }
+                    ClassifiedResponse::RequiresEos(classify_eos) => {
+                        this.on_response.take().unwrap().on_response(&res, latency);
+
+                        let span = this.span.clone();
+                        let res = res.map(|body| ResponseBody {
+                            inner: body,
+                            classify_eos: Some(classify_eos),
+                            on_eos: on_eos.zip(Some(Instant::now())),
+                            on_failure: Some(on_failure),
+                            start,
+                            span,
+                        });
+
+                        Poll::Ready(Ok(res))
+                    }
+                }
+            }
+            Err(err) => {
+                let failure_class = classifier.classify_error(&err);
+                on_failure.on_failure(failure_class, latency);
+
+                Poll::Ready(Err(err))
+            }
+        }
+    }
+}

--- a/tower-http/src/trace/layer.rs
+++ b/tower-http/src/trace/layer.rs
@@ -10,7 +10,7 @@ use tower_layer::Layer;
 
 /// [`Layer`] that adds high level [tracing] to a [`Service`].
 ///
-/// See the [module docs](crate::trace) for an example.
+/// See the [module docs](crate::trace) for more details.
 ///
 /// [`Layer`]: tower_layer::Layer
 /// [tracing]: https://crates.io/crates/tracing
@@ -82,6 +82,11 @@ impl<M, E> TraceLayer<M, E> {
 impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
     TraceLayer<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
 {
+    /// Customize what to do when a request is received.
+    ///
+    /// `NewOnRequest` is expected to implement [`OnRequest`].
+    ///
+    /// [`OnRequest`]: super::OnRequest
     pub fn on_request<NewOnRequest>(
         self,
         new_on_request: NewOnRequest,
@@ -98,6 +103,11 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
         }
     }
 
+    /// Customize what to do when a response has been produced.
+    ///
+    /// `NewOnResponse` is expected to implement [`OnResponse`].
+    ///
+    /// [`OnResponse`]: super::OnResponse
     pub fn on_response<NewOnResponse>(
         self,
         new_on_response: NewOnResponse,
@@ -114,6 +124,11 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
         }
     }
 
+    /// Customize what to do when a body chunk has been sent.
+    ///
+    /// `NewOnBodyChunk` is expected to implement [`OnBodyChunk`].
+    ///
+    /// [`OnBodyChunk`]: super::OnBodyChunk
     pub fn on_body_chunk<NewOnBodyChunk>(
         self,
         new_on_body_chunk: NewOnBodyChunk,
@@ -130,6 +145,11 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
         }
     }
 
+    /// Customize what to do when a streaming response has closed.
+    ///
+    /// `NewOnEos` is expected to implement [`OnEos`].
+    ///
+    /// [`OnEos`]: super::OnEos
     pub fn on_eos<NewOnEos>(
         self,
         new_on_eos: NewOnEos,
@@ -146,6 +166,11 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
         }
     }
 
+    /// Customize what to do when a response has been classified as a failure.
+    ///
+    /// `NewOnFailure` is expected to implement [`OnFailure`].
+    ///
+    /// [`OnFailure`]: super::OnFailure
     pub fn on_failure<NewOnFailure>(
         self,
         new_on_failure: NewOnFailure,
@@ -162,6 +187,12 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
         }
     }
 
+    /// Customize how to make [`Span`]s that all request handling will be wrapped in.
+    ///
+    /// `NewMakeSpan` is expected to implement [`MakeSpan`].
+    ///
+    /// [`MakeSpan`]: super::MakeSpan
+    /// [`Span`]: tracing::Span
     pub fn make_span_with<NewMakeSpan>(
         self,
         new_make_span: NewMakeSpan,

--- a/tower-http/src/trace/layer.rs
+++ b/tower-http/src/trace/layer.rs
@@ -1,0 +1,250 @@
+use super::{
+    DefaultMakeSpan, DefaultOnEos, DefaultOnFailure, DefaultOnRequest, DefaultOnResponse, Trace,
+};
+use crate::classify::{
+    GrpcErrorsAsFailures, MakeClassifier, ServerErrorsAsFailures, SharedClassifier,
+};
+use std::{fmt, marker::PhantomData};
+use tower_layer::Layer;
+
+/// [`Layer`] that adds high level [tracing] to a [`Service`].
+///
+/// See the [module docs](crate::trace) for an example.
+///
+/// [`Layer`]: tower_layer::Layer
+/// [tracing]: https://crates.io/crates/tracing
+/// [`Service`]: tower_service::Service
+pub struct TraceLayer<
+    M,
+    E,
+    MakeSpan = DefaultMakeSpan,
+    OnRequest = DefaultOnRequest,
+    OnResponse = DefaultOnResponse,
+    OnEos = DefaultOnEos,
+    OnFailure = DefaultOnFailure,
+> {
+    pub(crate) make_classifier: M,
+    pub(crate) make_span: MakeSpan,
+    pub(crate) add_headers_to_span: bool,
+    pub(crate) on_request: OnRequest,
+    pub(crate) on_response: OnResponse,
+    pub(crate) on_eos: OnEos,
+    pub(crate) on_failure: OnFailure,
+    pub(crate) _error: PhantomData<fn() -> E>,
+}
+
+impl<M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure> Clone
+    for TraceLayer<M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>
+where
+    M: Clone,
+    MakeSpan: Clone,
+    OnRequest: Clone,
+    OnResponse: Clone,
+    OnEos: Clone,
+    OnFailure: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            on_request: self.on_request.clone(),
+            on_response: self.on_response.clone(),
+            on_failure: self.on_failure.clone(),
+            on_eos: self.on_eos.clone(),
+            make_span: self.make_span.clone(),
+            add_headers_to_span: self.add_headers_to_span,
+            make_classifier: self.make_classifier.clone(),
+            _error: self._error,
+        }
+    }
+}
+
+impl<M, E> TraceLayer<M, E> {
+    /// Create a new [`TraceLayer`] using the given [`MakeClassifier`].
+    pub fn new(make_classifier: M) -> Self
+    where
+        M: MakeClassifier<E>,
+    {
+        Self {
+            make_classifier,
+            make_span: DefaultMakeSpan::new(),
+            on_failure: DefaultOnFailure::default(),
+            on_request: DefaultOnRequest::default(),
+            on_eos: DefaultOnEos::default(),
+            on_response: DefaultOnResponse::default(),
+            add_headers_to_span: false,
+            _error: PhantomData,
+        }
+    }
+}
+
+impl<M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>
+    TraceLayer<M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>
+{
+    pub fn on_request<NewOnRequest>(
+        self,
+        new_on_request: NewOnRequest,
+    ) -> TraceLayer<M, E, MakeSpan, NewOnRequest, OnResponse, OnEos, OnFailure> {
+        TraceLayer {
+            on_request: new_on_request,
+            on_failure: self.on_failure,
+            on_eos: self.on_eos,
+            make_span: self.make_span,
+            on_response: self.on_response,
+            add_headers_to_span: self.add_headers_to_span,
+            make_classifier: self.make_classifier,
+            _error: self._error,
+        }
+    }
+
+    pub fn on_response<NewOnResponse>(
+        self,
+        new_on_response: NewOnResponse,
+    ) -> TraceLayer<M, E, MakeSpan, OnRequest, NewOnResponse, OnEos, OnFailure> {
+        TraceLayer {
+            on_response: new_on_response,
+            on_request: self.on_request,
+            on_eos: self.on_eos,
+            on_failure: self.on_failure,
+            make_span: self.make_span,
+            add_headers_to_span: self.add_headers_to_span,
+            make_classifier: self.make_classifier,
+            _error: self._error,
+        }
+    }
+
+    pub fn on_eos<NewOnEos>(
+        self,
+        new_on_eos: NewOnEos,
+    ) -> TraceLayer<M, E, MakeSpan, OnRequest, OnResponse, NewOnEos, OnFailure> {
+        TraceLayer {
+            on_eos: new_on_eos,
+            on_failure: self.on_failure,
+            on_request: self.on_request,
+            make_span: self.make_span,
+            on_response: self.on_response,
+            add_headers_to_span: self.add_headers_to_span,
+            make_classifier: self.make_classifier,
+            _error: self._error,
+        }
+    }
+
+    pub fn on_failure<NewOnFailure>(
+        self,
+        new_on_failure: NewOnFailure,
+    ) -> TraceLayer<M, E, MakeSpan, OnRequest, OnResponse, OnEos, NewOnFailure> {
+        TraceLayer {
+            on_failure: new_on_failure,
+            on_request: self.on_request,
+            on_eos: self.on_eos,
+            make_span: self.make_span,
+            on_response: self.on_response,
+            add_headers_to_span: self.add_headers_to_span,
+            make_classifier: self.make_classifier,
+            _error: self._error,
+        }
+    }
+
+    pub fn make_span_with<NewMakeSpan>(
+        self,
+        new_make_span: NewMakeSpan,
+    ) -> TraceLayer<M, E, NewMakeSpan, OnRequest, OnResponse, OnEos, OnFailure> {
+        TraceLayer {
+            make_span: new_make_span,
+            on_request: self.on_request,
+            on_failure: self.on_failure,
+            on_eos: self.on_eos,
+            on_response: self.on_response,
+            add_headers_to_span: self.add_headers_to_span,
+            make_classifier: self.make_classifier,
+            _error: self._error,
+        }
+    }
+
+    pub fn add_headers_to_span(mut self, value: bool) -> Self {
+        self.add_headers_to_span = value;
+        self
+    }
+}
+
+impl<E> TraceLayer<SharedClassifier<ServerErrorsAsFailures>, E> {
+    /// Create a new [`TraceLayer`] using [`ServerErrorsAsFailures`] which supports classifying
+    /// regular HTTP responses based on the status code.
+    pub fn new_for_http() -> Self {
+        Self {
+            make_classifier: SharedClassifier::new::<E>(ServerErrorsAsFailures::default()),
+            make_span: DefaultMakeSpan::new(),
+            add_headers_to_span: false,
+            on_response: DefaultOnResponse::default(),
+            on_request: DefaultOnRequest::default(),
+            on_eos: DefaultOnEos::default(),
+            on_failure: DefaultOnFailure::default(),
+            _error: PhantomData,
+        }
+    }
+}
+
+impl<E> TraceLayer<SharedClassifier<GrpcErrorsAsFailures>, E> {
+    /// Create a new [`TraceLayer`] using [`GrpcErrorsAsFailures`] which supports classifying
+    /// gRPC responses and streams based on the `grpc-status` header.
+    pub fn new_for_grpc() -> Self {
+        Self {
+            make_classifier: SharedClassifier::new::<E>(GrpcErrorsAsFailures::default()),
+            make_span: DefaultMakeSpan::new(),
+            add_headers_to_span: false,
+            on_response: DefaultOnResponse::default(),
+            on_request: DefaultOnRequest::default(),
+            on_eos: DefaultOnEos::default(),
+            on_failure: DefaultOnFailure::default(),
+            _error: PhantomData,
+        }
+    }
+}
+
+impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure> Layer<S>
+    for TraceLayer<M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>
+where
+    M: Clone,
+    MakeSpan: Clone,
+    OnRequest: Clone,
+    OnResponse: Clone,
+    OnEos: Clone,
+    OnFailure: Clone,
+{
+    type Service = Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Trace {
+            inner,
+            make_classifier: self.make_classifier.clone(),
+            make_span: self.make_span.clone(),
+            on_request: self.on_request.clone(),
+            on_eos: self.on_eos.clone(),
+            on_response: self.on_response.clone(),
+            on_failure: self.on_failure.clone(),
+            add_headers_to_span: self.add_headers_to_span,
+            _error: PhantomData,
+        }
+    }
+}
+
+impl<M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure> fmt::Debug
+    for TraceLayer<M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>
+where
+    M: fmt::Debug,
+    MakeSpan: fmt::Debug,
+    OnRequest: fmt::Debug,
+    OnResponse: fmt::Debug,
+    OnEos: fmt::Debug,
+    OnFailure: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TraceLayer")
+            .field("make_classifier", &self.make_classifier)
+            .field("make_span", &self.make_span)
+            .field("add_headers_to_span", &self.add_headers_to_span)
+            .field("on_request", &self.on_request)
+            .field("on_response", &self.on_response)
+            .field("on_eos", &self.on_eos)
+            .field("on_failure", &self.on_failure)
+            .finish()
+    }
+}

--- a/tower-http/src/trace/layer.rs
+++ b/tower-http/src/trace/layer.rs
@@ -27,7 +27,6 @@ pub struct TraceLayer<
 > {
     pub(crate) make_classifier: M,
     pub(crate) make_span: MakeSpan,
-    pub(crate) add_headers_to_span: bool,
     pub(crate) on_request: OnRequest,
     pub(crate) on_response: OnResponse,
     pub(crate) on_body_chunk: OnBodyChunk,
@@ -55,7 +54,6 @@ where
             on_eos: self.on_eos.clone(),
             on_body_chunk: self.on_body_chunk.clone(),
             make_span: self.make_span.clone(),
-            add_headers_to_span: self.add_headers_to_span,
             make_classifier: self.make_classifier.clone(),
             _error: self._error,
         }
@@ -76,7 +74,6 @@ impl<M, E> TraceLayer<M, E> {
             on_eos: DefaultOnEos::default(),
             on_body_chunk: DefaultOnBodyChunk::default(),
             on_response: DefaultOnResponse::default(),
-            add_headers_to_span: false,
             _error: PhantomData,
         }
     }
@@ -96,7 +93,6 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_body_chunk: self.on_body_chunk,
             make_span: self.make_span,
             on_response: self.on_response,
-            add_headers_to_span: self.add_headers_to_span,
             make_classifier: self.make_classifier,
             _error: self._error,
         }
@@ -113,7 +109,6 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_body_chunk: self.on_body_chunk,
             on_failure: self.on_failure,
             make_span: self.make_span,
-            add_headers_to_span: self.add_headers_to_span,
             make_classifier: self.make_classifier,
             _error: self._error,
         }
@@ -130,7 +125,6 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_request: self.on_request,
             make_span: self.make_span,
             on_response: self.on_response,
-            add_headers_to_span: self.add_headers_to_span,
             make_classifier: self.make_classifier,
             _error: self._error,
         }
@@ -147,7 +141,6 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_request: self.on_request,
             make_span: self.make_span,
             on_response: self.on_response,
-            add_headers_to_span: self.add_headers_to_span,
             make_classifier: self.make_classifier,
             _error: self._error,
         }
@@ -164,7 +157,6 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_body_chunk: self.on_body_chunk,
             make_span: self.make_span,
             on_response: self.on_response,
-            add_headers_to_span: self.add_headers_to_span,
             make_classifier: self.make_classifier,
             _error: self._error,
         }
@@ -181,15 +173,9 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_body_chunk: self.on_body_chunk,
             on_eos: self.on_eos,
             on_response: self.on_response,
-            add_headers_to_span: self.add_headers_to_span,
             make_classifier: self.make_classifier,
             _error: self._error,
         }
-    }
-
-    pub fn add_headers_to_span(mut self, value: bool) -> Self {
-        self.add_headers_to_span = value;
-        self
     }
 }
 
@@ -200,7 +186,6 @@ impl<E> TraceLayer<SharedClassifier<ServerErrorsAsFailures>, E> {
         Self {
             make_classifier: SharedClassifier::new::<E>(ServerErrorsAsFailures::default()),
             make_span: DefaultMakeSpan::new(),
-            add_headers_to_span: false,
             on_response: DefaultOnResponse::default(),
             on_request: DefaultOnRequest::default(),
             on_body_chunk: DefaultOnBodyChunk::default(),
@@ -218,7 +203,6 @@ impl<E> TraceLayer<SharedClassifier<GrpcErrorsAsFailures>, E> {
         Self {
             make_classifier: SharedClassifier::new::<E>(GrpcErrorsAsFailures::default()),
             make_span: DefaultMakeSpan::new(),
-            add_headers_to_span: false,
             on_response: DefaultOnResponse::default(),
             on_request: DefaultOnRequest::default(),
             on_body_chunk: DefaultOnBodyChunk::default(),
@@ -252,7 +236,6 @@ where
             on_body_chunk: self.on_body_chunk.clone(),
             on_response: self.on_response.clone(),
             on_failure: self.on_failure.clone(),
-            add_headers_to_span: self.add_headers_to_span,
             _error: PhantomData,
         }
     }
@@ -273,7 +256,6 @@ where
         f.debug_struct("TraceLayer")
             .field("make_classifier", &self.make_classifier)
             .field("make_span", &self.make_span)
-            .field("add_headers_to_span", &self.add_headers_to_span)
             .field("on_request", &self.on_request)
             .field("on_response", &self.on_response)
             .field("on_body_chunk", &self.on_body_chunk)

--- a/tower-http/src/trace/make_span.rs
+++ b/tower-http/src/trace/make_span.rs
@@ -1,7 +1,13 @@
 use http::Request;
 use tracing::Span;
 
+/// Trait used to generate [`Span`]s from requests. [`Trace`] wraps all request handling in this
+/// span.
+///
+/// [`Span`]: tracing::Span
+/// [`Trace`]: super::Trace
 pub trait MakeSpan<B> {
+    /// Make a span from a request.
     fn make_span(&mut self, request: &Request<B>) -> Span;
 }
 
@@ -20,18 +26,28 @@ where
     }
 }
 
+/// The default way [`Span`]s will be created for [`Trace`].
+///
+/// [`Span`]: tracing::Span
+/// [`Trace`]: super::Trace
 #[derive(Debug, Clone, Default)]
 pub struct DefaultMakeSpan {
     include_headers: bool,
 }
 
 impl DefaultMakeSpan {
+    /// Create a new `DefaultMakeSpan`.
     pub fn new() -> Self {
         Self {
             include_headers: false,
         }
     }
 
+    /// Include request headers on the [`Span`].
+    ///
+    /// By default headers are not included.
+    ///
+    /// [`Span`]: tracing::Span
     pub fn include_headers(mut self, include_headers: bool) -> Self {
         self.include_headers = include_headers;
         self

--- a/tower-http/src/trace/make_span.rs
+++ b/tower-http/src/trace/make_span.rs
@@ -1,0 +1,34 @@
+use http::Request;
+use tracing::{field::Empty, Span};
+
+pub trait MakeSpan {
+    fn make_span<B>(&mut self, request: &Request<B>) -> Span;
+}
+
+impl MakeSpan for Span {
+    fn make_span<B>(&mut self, _request: &Request<B>) -> Span {
+        self.clone()
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DefaultMakeSpan {
+    _priv: (),
+}
+
+impl DefaultMakeSpan {
+    pub fn new() -> Self {
+        Self { _priv: () }
+    }
+}
+
+impl MakeSpan for DefaultMakeSpan {
+    fn make_span<B>(&mut self, request: &Request<B>) -> Span {
+        tracing::debug_span!(
+            "request",
+            method = %request.method(),
+            path = request.uri().path(),
+            headers = Empty,
+        )
+    }
+}

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -59,6 +59,7 @@ pub use self::{
     future::ResponseFuture,
     layer::TraceLayer,
     make_span::{DefaultMakeSpan, MakeSpan},
+    on_body_chunk::{DefaultOnBodyChunk, OnBodyChunk},
     on_eos::{DefaultOnEos, OnEos},
     on_failure::{DefaultOnFailure, OnFailure},
     on_request::{DefaultOnRequest, OnRequest},
@@ -70,6 +71,7 @@ mod body;
 mod future;
 mod layer;
 mod make_span;
+mod on_body_chunk;
 mod on_eos;
 mod on_failure;
 mod on_request;
@@ -78,3 +80,131 @@ mod service;
 
 const DEFAULT_MESSAGE_LEVEL: Level = Level::DEBUG;
 const DEFAULT_ERROR_LEVEL: Level = Level::ERROR;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use http::{HeaderMap, Request, Response, StatusCode};
+    use hyper::Body;
+    use once_cell::sync::Lazy;
+    use std::{
+        sync::atomic::{AtomicU32, Ordering},
+        time::Duration,
+    };
+    use tower::{BoxError, Service, ServiceBuilder, ServiceExt};
+
+    #[tokio::test]
+    async fn unary_request() {
+        static ON_REQUEST_COUNT: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+        static ON_RESPONSE_COUNT: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+        static ON_BODY_CHUNK_COUNT: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+        static ON_EOS: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+        static ON_FAILURE: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+
+        let trace_layer = TraceLayer::<_, BoxError>::new_for_http()
+            .on_request(|_req: &Request<Body>| {
+                ON_REQUEST_COUNT.fetch_add(1, Ordering::SeqCst);
+            })
+            .on_response(|_res: &Response<Body>, _latency: Duration| {
+                ON_RESPONSE_COUNT.fetch_add(1, Ordering::SeqCst);
+            })
+            .on_body_chunk(|_chunk: &Bytes, _latency: Duration| {
+                ON_BODY_CHUNK_COUNT.fetch_add(1, Ordering::SeqCst);
+            })
+            .on_eos(|_trailers: Option<&HeaderMap>, _latency: Duration| {
+                ON_EOS.fetch_add(1, Ordering::SeqCst);
+            })
+            .on_failure(|_err: StatusCode, _latency: Duration| {
+                ON_FAILURE.fetch_add(1, Ordering::SeqCst);
+            });
+
+        let mut svc = ServiceBuilder::new().layer(trace_layer).service_fn(echo);
+
+        let res = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(Request::new(Body::from("foobar")))
+            .await
+            .unwrap();
+
+        assert_eq!(1, ON_REQUEST_COUNT.load(Ordering::SeqCst), "request");
+        assert_eq!(1, ON_RESPONSE_COUNT.load(Ordering::SeqCst), "request");
+        assert_eq!(0, ON_BODY_CHUNK_COUNT.load(Ordering::SeqCst), "body chunk");
+        assert_eq!(0, ON_EOS.load(Ordering::SeqCst), "eos");
+        assert_eq!(0, ON_FAILURE.load(Ordering::SeqCst), "failure");
+
+        hyper::body::to_bytes(res.into_body()).await.unwrap();
+        assert_eq!(1, ON_BODY_CHUNK_COUNT.load(Ordering::SeqCst), "body chunk");
+        assert_eq!(0, ON_EOS.load(Ordering::SeqCst), "eos");
+        assert_eq!(0, ON_FAILURE.load(Ordering::SeqCst), "failure");
+    }
+
+    #[tokio::test]
+    async fn streaming_response() {
+        static ON_REQUEST_COUNT: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+        static ON_RESPONSE_COUNT: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+        static ON_BODY_CHUNK_COUNT: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+        static ON_EOS: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+        static ON_FAILURE: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+
+        let trace_layer = TraceLayer::<_, BoxError>::new_for_http()
+            .on_request(|_req: &Request<Body>| {
+                ON_REQUEST_COUNT.fetch_add(1, Ordering::SeqCst);
+            })
+            .on_response(|_res: &Response<Body>, _latency: Duration| {
+                ON_RESPONSE_COUNT.fetch_add(1, Ordering::SeqCst);
+            })
+            .on_body_chunk(|_chunk: &Bytes, _latency: Duration| {
+                ON_BODY_CHUNK_COUNT.fetch_add(1, Ordering::SeqCst);
+            })
+            .on_eos(|_trailers: Option<&HeaderMap>, _latency: Duration| {
+                ON_EOS.fetch_add(1, Ordering::SeqCst);
+            })
+            .on_failure(|_err: StatusCode, _latency: Duration| {
+                ON_FAILURE.fetch_add(1, Ordering::SeqCst);
+            });
+
+        let mut svc = ServiceBuilder::new()
+            .layer(trace_layer)
+            .service_fn(streaming_body);
+
+        let res = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(Request::new(Body::empty()))
+            .await
+            .unwrap();
+
+        assert_eq!(1, ON_REQUEST_COUNT.load(Ordering::SeqCst), "request");
+        assert_eq!(1, ON_RESPONSE_COUNT.load(Ordering::SeqCst), "request");
+        assert_eq!(0, ON_BODY_CHUNK_COUNT.load(Ordering::SeqCst), "body chunk");
+        assert_eq!(0, ON_EOS.load(Ordering::SeqCst), "eos");
+        assert_eq!(0, ON_FAILURE.load(Ordering::SeqCst), "failure");
+
+        hyper::body::to_bytes(res.into_body()).await.unwrap();
+        assert_eq!(3, ON_BODY_CHUNK_COUNT.load(Ordering::SeqCst), "body chunk");
+        assert_eq!(0, ON_EOS.load(Ordering::SeqCst), "eos");
+        assert_eq!(0, ON_FAILURE.load(Ordering::SeqCst), "failure");
+    }
+
+    async fn echo(req: Request<Body>) -> Result<Response<Body>, BoxError> {
+        Ok(Response::new(req.into_body()))
+    }
+
+    async fn streaming_body(_req: Request<Body>) -> Result<Response<Body>, BoxError> {
+        use futures::stream::iter;
+
+        let stream = iter(vec![
+            Ok::<_, BoxError>(Bytes::from("one")),
+            Ok::<_, BoxError>(Bytes::from("two")),
+            Ok::<_, BoxError>(Bytes::from("three")),
+        ]);
+
+        let body = Body::wrap_stream(stream);
+
+        Ok(Response::new(body))
+    }
+}

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -1,0 +1,80 @@
+//! Middleware that adds high level [tracing] to a [`Service`].
+//!
+//! # Example
+//!
+//! Adding tracing to your service can be as simple as:
+//!
+//! ```rust
+//! use http::{Request, Response};
+//! use hyper::Body;
+//! use tower::{ServiceBuilder, service_fn, ServiceExt, Service};
+//! use tower_http::trace::TraceLayer;
+//! use std::convert::Infallible;
+//!
+//! async fn handle(request: Request<Body>) -> Result<Response<Body>, Infallible> {
+//!     Ok(Response::new(Body::from("foo")))
+//! }
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Setup tracing
+//! tracing_subscriber::fmt::init();
+//!
+//! let mut service = ServiceBuilder::new()
+//!     .layer(TraceLayer::new_for_http())
+//!     .service(service_fn(handle));
+//!
+//! let request = Request::new(Body::from("foo"));
+//!
+//! let response = service
+//!     .ready()
+//!     .await?
+//!     .call(request)
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! If you run this application with `RUST_LOG=tower_http=trace cargo run` you should see logs like:
+//!
+//! ```text
+//! Mar 05 20:50:28.523 DEBUG request{method=GET path="/foo"}: tower_http::trace::on_request: started processing request
+//! Mar 05 20:50:28.524 DEBUG request{method=GET path="/foo"}: tower_http::trace::on_response: finished processing request latency=1 ms status=200
+//! ```
+//!
+//! TODO(david): Document these things
+//! - gRPC support
+//! - Setting classifiers
+//! - Customizing what to do on request, response, eos, failure
+//!
+//! [tracing]: https://crates.io/crates/tracing
+//! [`Service`]: tower_service::Service
+
+// TODO(david): Document all the things
+#![allow(missing_docs)]
+
+use tracing::Level;
+
+pub use self::{
+    body::ResponseBody,
+    future::ResponseFuture,
+    layer::TraceLayer,
+    make_span::{DefaultMakeSpan, MakeSpan},
+    on_eos::{DefaultOnEos, OnEos},
+    on_failure::{DefaultOnFailure, OnFailure},
+    on_request::{DefaultOnRequest, OnRequest},
+    on_response::{DefaultOnResponse, OnResponse},
+    service::Trace,
+};
+
+mod body;
+mod future;
+mod layer;
+mod make_span;
+mod on_eos;
+mod on_failure;
+mod on_request;
+mod on_response;
+mod service;
+
+const DEFAULT_MESSAGE_LEVEL: Level = Level::DEBUG;
+const DEFAULT_ERROR_LEVEL: Level = Level::ERROR;

--- a/tower-http/src/trace/on_body_chunk.rs
+++ b/tower-http/src/trace/on_body_chunk.rs
@@ -1,6 +1,17 @@
 use std::time::Duration;
 
+/// Trait used to tell [`Trace`] what to do when a body chunk has been sent.
+///
+/// [`Trace`]: super::Trace
 pub trait OnBodyChunk<B> {
+    /// Do the thing.
+    ///
+    /// `latency` is the duration since the response was sent or since the last body chunk as sent.
+    ///
+    /// If you're using [hyper] as your server `B` will most likely be [`Bytes`].
+    ///
+    /// [hyper]: https://hyper.rs
+    /// [`Bytes`]: https://docs.rs/bytes/latest/bytes/struct.Bytes.html
     fn on_body_chunk(&mut self, chunk: &B, latency: Duration);
 }
 
@@ -13,12 +24,23 @@ where
     }
 }
 
+impl<B> OnBodyChunk<B> for () {
+    #[inline]
+    fn on_body_chunk(&mut self, _: &B, _: Duration) {}
+}
+
+/// The default [`OnBodyChunk`] implementation used by [`Trace`].
+///
+/// Simply does nothing.
+///
+/// [`Trace`]: super::Trace
 #[derive(Debug, Default, Clone)]
 pub struct DefaultOnBodyChunk {
     _priv: (),
 }
 
 impl DefaultOnBodyChunk {
+    /// Create a new `DefaultOnBodyChunk`.
     pub fn new() -> Self {
         Self { _priv: () }
     }

--- a/tower-http/src/trace/on_body_chunk.rs
+++ b/tower-http/src/trace/on_body_chunk.rs
@@ -1,0 +1,30 @@
+use std::time::Duration;
+
+pub trait OnBodyChunk<B> {
+    fn on_body_chunk(&mut self, chunk: &B, latency: Duration);
+}
+
+impl<B, F> OnBodyChunk<B> for F
+where
+    F: FnMut(&B, Duration),
+{
+    fn on_body_chunk(&mut self, chunk: &B, latency: Duration) {
+        self(chunk, latency)
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DefaultOnBodyChunk {
+    _priv: (),
+}
+
+impl DefaultOnBodyChunk {
+    pub fn new() -> Self {
+        Self { _priv: () }
+    }
+}
+
+impl<B> OnBodyChunk<B> for DefaultOnBodyChunk {
+    #[inline]
+    fn on_body_chunk(&mut self, _: &B, _: Duration) {}
+}

--- a/tower-http/src/trace/on_eos.rs
+++ b/tower-http/src/trace/on_eos.rs
@@ -1,0 +1,76 @@
+use super::DEFAULT_MESSAGE_LEVEL;
+use crate::LatencyUnit;
+use http::header::HeaderMap;
+use std::time::Duration;
+use tracing::Level;
+
+pub trait OnEos {
+    fn on_eos(self, trailers: Option<&HeaderMap>, stream_duration: Duration);
+}
+
+impl<F> OnEos for F
+where
+    F: FnOnce(Option<&HeaderMap>, Duration),
+{
+    fn on_eos(self, trailers: Option<&HeaderMap>, stream_duration: Duration) {
+        self(trailers, stream_duration)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DefaultOnEos {
+    level: Level,
+    latency_unit: LatencyUnit,
+}
+
+impl Default for DefaultOnEos {
+    fn default() -> Self {
+        Self {
+            level: DEFAULT_MESSAGE_LEVEL,
+            latency_unit: LatencyUnit::Millis,
+        }
+    }
+}
+
+impl DefaultOnEos {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+// Repeating this pattern match for each case is tedious. So we do it with a quick and
+// dirty macro.
+//
+// Tracing requires all these parts to be declared statically. You cannot easily build
+// events dynamically.
+#[allow(unused_macros)]
+macro_rules! log_pattern_match {
+    (
+        $this:expr, $stream_duration:expr, [$($level:ident),*]
+    ) => {
+        match ($this.level, $this.latency_unit) {
+            $(
+                (Level::$level, LatencyUnit::Millis) => {
+                    tracing::event!(
+                        Level::$level,
+                        stream_duration = format_args!("{} ms", $stream_duration.as_millis()),
+                        "end of stream"
+                    );
+                }
+                (Level::$level, LatencyUnit::Nanos) => {
+                    tracing::event!(
+                        Level::$level,
+                        stream_duration = format_args!("{} ns", $stream_duration.as_nanos()),
+                        "end of stream"
+                    );
+                }
+            )*
+        }
+    };
+}
+
+impl OnEos for DefaultOnEos {
+    fn on_eos(self, _trailers: Option<&HeaderMap>, stream_duration: Duration) {
+        log_pattern_match!(self, stream_duration, [ERROR, WARN, INFO, DEBUG, TRACE]);
+    }
+}

--- a/tower-http/src/trace/on_eos.rs
+++ b/tower-http/src/trace/on_eos.rs
@@ -8,6 +8,11 @@ pub trait OnEos {
     fn on_eos(self, trailers: Option<&HeaderMap>, stream_duration: Duration);
 }
 
+impl OnEos for () {
+    #[inline]
+    fn on_eos(self, _: Option<&HeaderMap>, _: Duration) {}
+}
+
 impl<F> OnEos for F
 where
     F: FnOnce(Option<&HeaderMap>, Duration),

--- a/tower-http/src/trace/on_eos.rs
+++ b/tower-http/src/trace/on_eos.rs
@@ -4,7 +4,13 @@ use http::header::HeaderMap;
 use std::time::Duration;
 use tracing::Level;
 
+/// Trait used to tell [`Trace`] what to do when a stream closes.
+///
+/// [`Trace`]: super::Trace
 pub trait OnEos {
+    /// Do the thing.
+    ///
+    /// `stream_duration` is the duration since the response was sent.
     fn on_eos(self, trailers: Option<&HeaderMap>, stream_duration: Duration);
 }
 
@@ -22,6 +28,9 @@ where
     }
 }
 
+/// The default [`OnEos`] implementation used by [`Trace`].
+///
+/// [`Trace`]: super::Trace
 #[derive(Clone, Debug)]
 pub struct DefaultOnEos {
     level: Level,
@@ -38,8 +47,28 @@ impl Default for DefaultOnEos {
 }
 
 impl DefaultOnEos {
+    /// Create a new [`DefaultOnEos`].
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Set the [`Level`] used for [tracing events].
+    ///
+    /// Defaults to [`Level::DEBUG`].
+    ///
+    /// [tracing events]: https://docs.rs/tracing/latest/tracing/#events
+    /// [`Level::DEBUG`]: https://docs.rs/tracing/latest/tracing/struct.Level.html#associatedconstant.DEBUG
+    pub fn level(mut self, level: Level) -> Self {
+        self.level = level;
+        self
+    }
+
+    /// Set the [`LatencyUnit`] latencies will be reported in.
+    ///
+    /// Defaults to [`LatencyUnit::Millis`].
+    pub fn latency_unit(mut self, latency_unit: LatencyUnit) -> Self {
+        self.latency_unit = latency_unit;
+        self
     }
 }
 

--- a/tower-http/src/trace/on_eos.rs
+++ b/tower-http/src/trace/on_eos.rs
@@ -62,6 +62,13 @@ macro_rules! log_pattern_match {
                         "end of stream"
                     );
                 }
+                (Level::$level, LatencyUnit::Micros) => {
+                    tracing::event!(
+                        Level::$level,
+                        stream_duration = format_args!("{} μs", $stream_duration.as_micros()),
+                        "end of stream"
+                    );
+                }
                 (Level::$level, LatencyUnit::Nanos) => {
                     tracing::event!(
                         Level::$level,

--- a/tower-http/src/trace/on_failure.rs
+++ b/tower-http/src/trace/on_failure.rs
@@ -1,0 +1,96 @@
+use crate::LatencyUnit;
+use std::{fmt, time::Duration};
+use tracing::Level;
+
+use super::DEFAULT_ERROR_LEVEL;
+
+pub trait OnFailure<FailureClass> {
+    fn on_failure(self, failure_classification: FailureClass, latency: Duration);
+}
+
+impl<F, FailureClass> OnFailure<FailureClass> for F
+where
+    F: FnOnce(FailureClass, Duration),
+{
+    fn on_failure(self, failure_classification: FailureClass, latency: Duration) {
+        self(failure_classification, latency)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DefaultOnFailure {
+    level: Level,
+    latency_unit: LatencyUnit,
+}
+
+impl Default for DefaultOnFailure {
+    fn default() -> Self {
+        Self {
+            level: DEFAULT_ERROR_LEVEL,
+            latency_unit: LatencyUnit::Millis,
+        }
+    }
+}
+
+impl DefaultOnFailure {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn level(self, level: Level) -> Self {
+        Self { level, ..self }
+    }
+
+    pub fn latency_unit(self, latency_unit: LatencyUnit) -> Self {
+        Self {
+            latency_unit,
+            ..self
+        }
+    }
+}
+
+// Repeating this pattern match for each case is tedious. So we do it with a quick and
+// dirty macro.
+//
+// Tracing requires all these parts to be declared statically. You cannot easily build
+// events dynamically.
+macro_rules! log_pattern_match {
+    (
+        $this:expr, $failure_classification:expr, $latency:expr, [$($level:ident),*]
+    ) => {
+        match ($this.level, $this.latency_unit) {
+            $(
+                (Level::$level, LatencyUnit::Millis) => {
+                    tracing::event!(
+                        Level::$level,
+                        classification = tracing::field::display($failure_classification),
+                        latency = format_args!("{} ms", $latency.as_millis()),
+                        "response failed"
+                    );
+                }
+                (Level::$level, LatencyUnit::Nanos) => {
+                    tracing::event!(
+                        Level::$level,
+                        classification = tracing::field::display($failure_classification),
+                        latency = format_args!("{} ns", $latency.as_nanos()),
+                        "response failed"
+                    );
+                }
+            )*
+        }
+    };
+}
+
+impl<FailureClass> OnFailure<FailureClass> for DefaultOnFailure
+where
+    FailureClass: fmt::Display,
+{
+    fn on_failure(self, failure_classification: FailureClass, latency: Duration) {
+        log_pattern_match!(
+            self,
+            &failure_classification,
+            latency,
+            [ERROR, WARN, INFO, DEBUG, TRACE]
+        );
+    }
+}

--- a/tower-http/src/trace/on_failure.rs
+++ b/tower-http/src/trace/on_failure.rs
@@ -73,6 +73,14 @@ macro_rules! log_pattern_match {
                         "response failed"
                     );
                 }
+                (Level::$level, LatencyUnit::Micros) => {
+                    tracing::event!(
+                        Level::$level,
+                        classification = tracing::field::display($failure_classification),
+                        latency = format_args!("{} μs", $latency.as_micros()),
+                        "response failed"
+                    );
+                }
                 (Level::$level, LatencyUnit::Nanos) => {
                     tracing::event!(
                         Level::$level,

--- a/tower-http/src/trace/on_failure.rs
+++ b/tower-http/src/trace/on_failure.rs
@@ -5,19 +5,19 @@ use tracing::Level;
 use super::DEFAULT_ERROR_LEVEL;
 
 pub trait OnFailure<FailureClass> {
-    fn on_failure(self, failure_classification: FailureClass, latency: Duration);
+    fn on_failure(&mut self, failure_classification: FailureClass, latency: Duration);
 }
 
 impl<FailureClass> OnFailure<FailureClass> for () {
     #[inline]
-    fn on_failure(self, _: FailureClass, _: Duration) {}
+    fn on_failure(&mut self, _: FailureClass, _: Duration) {}
 }
 
 impl<F, FailureClass> OnFailure<FailureClass> for F
 where
-    F: FnOnce(FailureClass, Duration),
+    F: FnMut(FailureClass, Duration),
 {
-    fn on_failure(self, failure_classification: FailureClass, latency: Duration) {
+    fn on_failure(&mut self, failure_classification: FailureClass, latency: Duration) {
         self(failure_classification, latency)
     }
 }
@@ -90,7 +90,7 @@ impl<FailureClass> OnFailure<FailureClass> for DefaultOnFailure
 where
     FailureClass: fmt::Display,
 {
-    fn on_failure(self, failure_classification: FailureClass, latency: Duration) {
+    fn on_failure(&mut self, failure_classification: FailureClass, latency: Duration) {
         log_pattern_match!(
             self,
             &failure_classification,

--- a/tower-http/src/trace/on_failure.rs
+++ b/tower-http/src/trace/on_failure.rs
@@ -1,10 +1,15 @@
+use super::DEFAULT_ERROR_LEVEL;
 use crate::LatencyUnit;
 use std::{fmt, time::Duration};
 use tracing::Level;
 
-use super::DEFAULT_ERROR_LEVEL;
-
+/// Trait used to tell [`Trace`] what to do when a request fails.
+///
+/// [`Trace`]: super::Trace
 pub trait OnFailure<FailureClass> {
+    /// Do the thing.
+    ///
+    /// `latency` is the duration since the request was received.
     fn on_failure(&mut self, failure_classification: FailureClass, latency: Duration);
 }
 
@@ -22,6 +27,9 @@ where
     }
 }
 
+/// The default [`OnFailure`] implementation used by [`Trace`].
+///
+/// [`Trace`]: super::Trace
 #[derive(Clone, Debug)]
 pub struct DefaultOnFailure {
     level: Level,
@@ -38,19 +46,27 @@ impl Default for DefaultOnFailure {
 }
 
 impl DefaultOnFailure {
+    /// Create a new `DefaultOnFailure`.
     pub fn new() -> Self {
         Self::default()
     }
 
-    pub fn level(self, level: Level) -> Self {
-        Self { level, ..self }
+    /// Set the [`Level`] used for [tracing events].
+    ///
+    /// Defaults to [`Level::DEBUG`].
+    ///
+    /// [tracing events]: https://docs.rs/tracing/latest/tracing/#events
+    pub fn level(mut self, level: Level) -> Self {
+        self.level = level;
+        self
     }
 
-    pub fn latency_unit(self, latency_unit: LatencyUnit) -> Self {
-        Self {
-            latency_unit,
-            ..self
-        }
+    /// Set the [`LatencyUnit`] latencies will be reported in.
+    ///
+    /// Defaults to [`LatencyUnit::Millis`].
+    pub fn latency_unit(mut self, latency_unit: LatencyUnit) -> Self {
+        self.latency_unit = latency_unit;
+        self
     }
 }
 

--- a/tower-http/src/trace/on_failure.rs
+++ b/tower-http/src/trace/on_failure.rs
@@ -8,6 +8,11 @@ pub trait OnFailure<FailureClass> {
     fn on_failure(self, failure_classification: FailureClass, latency: Duration);
 }
 
+impl<FailureClass> OnFailure<FailureClass> for () {
+    #[inline]
+    fn on_failure(self, _: FailureClass, _: Duration) {}
+}
+
 impl<F, FailureClass> OnFailure<FailureClass> for F
 where
     F: FnOnce(FailureClass, Duration),

--- a/tower-http/src/trace/on_request.rs
+++ b/tower-http/src/trace/on_request.rs
@@ -2,7 +2,11 @@ use super::DEFAULT_MESSAGE_LEVEL;
 use http::Request;
 use tracing::Level;
 
+/// Trait used to tell [`Trace`] what to do when a request is received.
+///
+/// [`Trace`]: super::Trace
 pub trait OnRequest<B> {
+    /// Do the thing.
     fn on_request(&mut self, request: &Request<B>);
 }
 
@@ -20,6 +24,9 @@ where
     }
 }
 
+/// The default [`OnRequest`] implementation used by [`Trace`].
+///
+/// [`Trace`]: super::Trace
 #[derive(Clone, Debug)]
 pub struct DefaultOnRequest {
     level: Level,
@@ -34,10 +41,17 @@ impl Default for DefaultOnRequest {
 }
 
 impl DefaultOnRequest {
+    /// Create a new `DefaultOnRequest`.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Set the [`Level`] used for [tracing events].
+    ///
+    /// Defaults to [`Level::DEBUG`].
+    ///
+    /// [tracing events]: https://docs.rs/tracing/latest/tracing/#events
+    /// [`Level::DEBUG`]: https://docs.rs/tracing/latest/tracing/struct.Level.html#associatedconstant.DEBUG
     pub fn level(mut self, level: Level) -> Self {
         self.level = level;
         self

--- a/tower-http/src/trace/on_request.rs
+++ b/tower-http/src/trace/on_request.rs
@@ -6,6 +6,11 @@ pub trait OnRequest<B> {
     fn on_request(&mut self, request: &Request<B>);
 }
 
+impl<B> OnRequest<B> for () {
+    #[inline]
+    fn on_request(&mut self, _: &Request<B>) {}
+}
+
 impl<B, F> OnRequest<B> for F
 where
     F: FnMut(&Request<B>),

--- a/tower-http/src/trace/on_request.rs
+++ b/tower-http/src/trace/on_request.rs
@@ -1,0 +1,62 @@
+use super::DEFAULT_MESSAGE_LEVEL;
+use http::Request;
+use tracing::Level;
+
+pub trait OnRequest<B> {
+    fn on_request(&mut self, request: &Request<B>);
+}
+
+impl<B, F> OnRequest<B> for F
+where
+    F: FnMut(&Request<B>),
+{
+    fn on_request(&mut self, request: &Request<B>) {
+        self(request)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DefaultOnRequest {
+    level: Level,
+}
+
+impl Default for DefaultOnRequest {
+    fn default() -> Self {
+        Self {
+            level: DEFAULT_MESSAGE_LEVEL,
+        }
+    }
+}
+
+impl DefaultOnRequest {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn level(mut self, level: Level) -> Self {
+        self.level = level;
+        self
+    }
+}
+
+impl<B> OnRequest<B> for DefaultOnRequest {
+    fn on_request(&mut self, _request: &Request<B>) {
+        match self.level {
+            Level::ERROR => {
+                tracing::event!(Level::ERROR, "started processing request");
+            }
+            Level::WARN => {
+                tracing::event!(Level::WARN, "started processing request");
+            }
+            Level::INFO => {
+                tracing::event!(Level::INFO, "started processing request");
+            }
+            Level::DEBUG => {
+                tracing::event!(Level::DEBUG, "started processing request");
+            }
+            Level::TRACE => {
+                tracing::event!(Level::TRACE, "started processing request");
+            }
+        }
+    }
+}

--- a/tower-http/src/trace/on_response.rs
+++ b/tower-http/src/trace/on_response.rs
@@ -1,0 +1,107 @@
+use super::DEFAULT_MESSAGE_LEVEL;
+use crate::LatencyUnit;
+use http::Response;
+use std::time::Duration;
+use tracing::Level;
+
+pub trait OnResponse<B> {
+    fn on_response(self, response: &Response<B>, latency: Duration);
+}
+
+impl<B, F> OnResponse<B> for F
+where
+    F: FnOnce(&Response<B>, Duration),
+{
+    fn on_response(self, response: &Response<B>, latency: Duration) {
+        self(response, latency)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DefaultOnResponse {
+    level: Level,
+    latency_unit: LatencyUnit,
+}
+
+impl Default for DefaultOnResponse {
+    fn default() -> Self {
+        Self {
+            level: DEFAULT_MESSAGE_LEVEL,
+            latency_unit: LatencyUnit::Millis,
+        }
+    }
+}
+
+impl DefaultOnResponse {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn level(mut self, level: Level) -> Self {
+        self.level = level;
+        self
+    }
+
+    pub fn latency_unit(mut self, latency_unit: LatencyUnit) -> Self {
+        self.latency_unit = latency_unit;
+        self
+    }
+}
+
+// Repeating this pattern match for each case is tedious. So we do it with a quick and
+// dirty macro.
+//
+// Tracing requires all these parts to be declared statically. You cannot easily build
+// events dynamically.
+#[allow(unused_macros)]
+macro_rules! log_pattern_match {
+    (
+        $this:expr, $latency:expr, $status:expr, [$($level:ident),*]
+    ) => {
+        match ($this.level, $this.latency_unit) {
+            $(
+                (Level::$level, LatencyUnit::Millis) => {
+                    tracing::event!(
+                        Level::$level,
+                        latency = format_args!("{} ms", $latency.as_millis()),
+                        status = $status,
+                        "finished processing request"
+                    );
+                }
+                (Level::$level, LatencyUnit::Nanos) => {
+                    tracing::event!(
+                        Level::$level,
+                        latency = format_args!("{} ns", $latency.as_nanos()),
+                        status = $status,
+                        "finished processing request"
+                    );
+                }
+            )*
+        }
+    };
+}
+
+impl<B> OnResponse<B> for DefaultOnResponse {
+    fn on_response(self, response: &Response<B>, latency: Duration) {
+        let status = status(response);
+        log_pattern_match!(self, latency, status, [ERROR, WARN, INFO, DEBUG, TRACE]);
+    }
+}
+
+fn status<B>(res: &Response<B>) -> i32 {
+    let is_grpc = res
+        .headers()
+        .get(http::header::CONTENT_TYPE)
+        .map_or(false, |value| value == "application/grpc");
+
+    if is_grpc {
+        if let Some(Err(status)) = crate::classify::classify_grpc_metadata(res.headers()) {
+            status
+        } else {
+            // 0 is success in gRPC
+            0
+        }
+    } else {
+        res.status().as_u16().into()
+    }
+}

--- a/tower-http/src/trace/on_response.rs
+++ b/tower-http/src/trace/on_response.rs
@@ -4,7 +4,13 @@ use http::Response;
 use std::time::Duration;
 use tracing::Level;
 
+/// Trait used to tell [`Trace`] what to do when a response has been produced.
+///
+/// [`Trace`]: super::Trace
 pub trait OnResponse<B> {
+    /// Do the thing.
+    ///
+    /// `latency` is the duration since the request was received.
     fn on_response(self, response: &Response<B>, latency: Duration);
 }
 
@@ -22,6 +28,9 @@ where
     }
 }
 
+/// The default [`OnResponse`] implementation used by [`Trace`].
+///
+/// [`Trace`]: super::Trace
 #[derive(Clone, Debug)]
 pub struct DefaultOnResponse {
     level: Level,
@@ -40,20 +49,35 @@ impl Default for DefaultOnResponse {
 }
 
 impl DefaultOnResponse {
+    /// Create a new `DefaultOnResponse`.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Set the [`Level`] used for [tracing events].
+    ///
+    /// Defaults to [`Level::DEBUG`].
+    ///
+    /// [tracing events]: https://docs.rs/tracing/latest/tracing/#events
+    /// [`Level::DEBUG`]: https://docs.rs/tracing/latest/tracing/struct.Level.html#associatedconstant.DEBUG
     pub fn level(mut self, level: Level) -> Self {
         self.level = level;
         self
     }
 
+    /// Set the [`LatencyUnit`] latencies will be reported in.
+    ///
+    /// Defaults to [`LatencyUnit::Millis`].
     pub fn latency_unit(mut self, latency_unit: LatencyUnit) -> Self {
         self.latency_unit = latency_unit;
         self
     }
 
+    /// Include response headers on the [`Event`].
+    ///
+    /// By default headers are not included.
+    ///
+    /// [`Event`]: tracing::Event
     pub fn include_headers(mut self, include_headers: bool) -> Self {
         self.include_headers = include_headers;
         self
@@ -89,7 +113,6 @@ macro_rules! log_pattern_match {
                         "finished processing request"
                     );
                 }
-
                 (Level::$level, true, LatencyUnit::Micros) => {
                     tracing::event!(
                         Level::$level,
@@ -99,7 +122,6 @@ macro_rules! log_pattern_match {
                         "finished processing request"
                     );
                 }
-
                 (Level::$level, false, LatencyUnit::Micros) => {
                     tracing::event!(
                         Level::$level,
@@ -108,7 +130,6 @@ macro_rules! log_pattern_match {
                         "finished processing request"
                     );
                 }
-
                 (Level::$level, true, LatencyUnit::Nanos) => {
                     tracing::event!(
                         Level::$level,

--- a/tower-http/src/trace/on_response.rs
+++ b/tower-http/src/trace/on_response.rs
@@ -8,6 +8,11 @@ pub trait OnResponse<B> {
     fn on_response(self, response: &Response<B>, latency: Duration);
 }
 
+impl<B> OnResponse<B> for () {
+    #[inline]
+    fn on_response(self, _: &Response<B>, _: Duration) {}
+}
+
 impl<B, F> OnResponse<B> for F
 where
     F: FnOnce(&Response<B>, Duration),

--- a/tower-http/src/trace/service.rs
+++ b/tower-http/src/trace/service.rs
@@ -36,7 +36,6 @@ pub struct Trace<
     pub(crate) inner: S,
     pub(crate) make_classifier: M,
     pub(crate) make_span: MakeSpan,
-    pub(crate) add_headers_to_span: bool,
     pub(crate) on_request: OnRequest,
     pub(crate) on_response: OnResponse,
     pub(crate) on_body_chunk: OnBodyChunk,
@@ -55,7 +54,6 @@ impl<S, M, E> Trace<S, M, E> {
             inner,
             make_classifier,
             make_span: DefaultMakeSpan::new(),
-            add_headers_to_span: false,
             on_request: DefaultOnRequest::default(),
             on_response: DefaultOnResponse::default(),
             on_body_chunk: DefaultOnBodyChunk::default(),
@@ -92,7 +90,6 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_eos: self.on_eos,
             on_body_chunk: self.on_body_chunk,
             make_span: self.make_span,
-            add_headers_to_span: self.add_headers_to_span,
             on_response: self.on_response,
             make_classifier: self.make_classifier,
             _error: self._error,
@@ -111,7 +108,6 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_body_chunk: self.on_body_chunk,
             on_eos: self.on_eos,
             make_span: self.make_span,
-            add_headers_to_span: self.add_headers_to_span,
             make_classifier: self.make_classifier,
             _error: self._error,
         }
@@ -129,7 +125,6 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_request: self.on_request,
             on_eos: self.on_eos,
             on_response: self.on_response,
-            add_headers_to_span: self.add_headers_to_span,
             make_classifier: self.make_classifier,
             _error: self._error,
         }
@@ -147,7 +142,6 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_failure: self.on_failure,
             on_request: self.on_request,
             on_response: self.on_response,
-            add_headers_to_span: self.add_headers_to_span,
             make_classifier: self.make_classifier,
             _error: self._error,
         }
@@ -165,7 +159,6 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_request: self.on_request,
             on_body_chunk: self.on_body_chunk,
             on_response: self.on_response,
-            add_headers_to_span: self.add_headers_to_span,
             make_classifier: self.make_classifier,
             _error: self._error,
         }
@@ -183,15 +176,9 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_body_chunk: self.on_body_chunk,
             on_response: self.on_response,
             on_eos: self.on_eos,
-            add_headers_to_span: self.add_headers_to_span,
             make_classifier: self.make_classifier,
             _error: self._error,
         }
-    }
-
-    pub fn add_headers_to_span(mut self, value: bool) -> Self {
-        self.add_headers_to_span = value;
-        self
     }
 }
 
@@ -219,7 +206,6 @@ impl<S, E>
             on_response: DefaultOnResponse::default(),
             on_body_chunk: DefaultOnBodyChunk::default(),
             on_eos: DefaultOnEos::default(),
-            add_headers_to_span: false,
             on_failure: DefaultOnFailure::default(),
             _error: PhantomData,
         }
@@ -250,7 +236,6 @@ impl<S, E>
             on_response: DefaultOnResponse::default(),
             on_body_chunk: DefaultOnBodyChunk::default(),
             on_eos: DefaultOnEos::default(),
-            add_headers_to_span: false,
             on_failure: DefaultOnFailure::default(),
             _error: PhantomData,
         }
@@ -298,10 +283,6 @@ where
 
         let span = self.make_span.make_span(&req);
 
-        if self.add_headers_to_span {
-            span.record("headers", &tracing::field::debug(req.headers()));
-        }
-
         let classifier = self.make_classifier.make_classifier(&req);
 
         let future = {
@@ -343,7 +324,6 @@ where
             on_response: self.on_response.clone(),
             on_body_chunk: self.on_body_chunk.clone(),
             on_eos: self.on_eos.clone(),
-            add_headers_to_span: self.add_headers_to_span,
             make_classifier: self.make_classifier.clone(),
             on_request: self.on_request.clone(),
             _error: self._error,
@@ -368,7 +348,6 @@ where
             .field("inner", &self.inner)
             .field("make_classifier", &self.make_classifier)
             .field("make_span", &self.make_span)
-            .field("add_headers_to_span", &self.add_headers_to_span)
             .field("on_request", &self.on_request)
             .field("on_response", &self.on_response)
             .field("on_body_chunk", &self.on_body_chunk)

--- a/tower-http/src/trace/service.rs
+++ b/tower-http/src/trace/service.rs
@@ -79,6 +79,11 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
 {
     define_inner_service_accessors!();
 
+    /// Customize what to do when a request is received.
+    ///
+    /// `NewOnRequest` is expected to implement [`OnRequest`].
+    ///
+    /// [`OnRequest`]: super::OnRequest
     pub fn on_request<NewOnRequest>(
         self,
         new_on_request: NewOnRequest,
@@ -96,6 +101,11 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
         }
     }
 
+    /// Customize what to do when a response has been produced.
+    ///
+    /// `NewOnResponse` is expected to implement [`OnResponse`].
+    ///
+    /// [`OnResponse`]: super::OnResponse
     pub fn on_response<NewOnResponse>(
         self,
         new_on_response: NewOnResponse,
@@ -113,23 +123,11 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
         }
     }
 
-    pub fn on_failure<NewOnFailure>(
-        self,
-        new_on_failure: NewOnFailure,
-    ) -> Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, NewOnFailure> {
-        Trace {
-            on_failure: new_on_failure,
-            inner: self.inner,
-            make_span: self.make_span,
-            on_body_chunk: self.on_body_chunk,
-            on_request: self.on_request,
-            on_eos: self.on_eos,
-            on_response: self.on_response,
-            make_classifier: self.make_classifier,
-            _error: self._error,
-        }
-    }
-
+    /// Customize what to do when a body chunk has been sent.
+    ///
+    /// `NewOnBodyChunk` is expected to implement [`OnBodyChunk`].
+    ///
+    /// [`OnBodyChunk`]: super::OnBodyChunk
     pub fn on_body_chunk<NewOnBodyChunk>(
         self,
         new_on_body_chunk: NewOnBodyChunk,
@@ -147,6 +145,11 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
         }
     }
 
+    /// Customize what to do when a streaming response has closed.
+    ///
+    /// `NewOnEos` is expected to implement [`OnEos`].
+    ///
+    /// [`OnEos`]: super::OnEos
     pub fn on_eos<NewOnEos>(
         self,
         new_on_eos: NewOnEos,
@@ -164,6 +167,34 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
         }
     }
 
+    /// Customize what to do when a response has been classified as a failure.
+    ///
+    /// `NewOnFailure` is expected to implement [`OnFailure`].
+    ///
+    /// [`OnFailure`]: super::OnFailure
+    pub fn on_failure<NewOnFailure>(
+        self,
+        new_on_failure: NewOnFailure,
+    ) -> Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, NewOnFailure> {
+        Trace {
+            on_failure: new_on_failure,
+            inner: self.inner,
+            make_span: self.make_span,
+            on_body_chunk: self.on_body_chunk,
+            on_request: self.on_request,
+            on_eos: self.on_eos,
+            on_response: self.on_response,
+            make_classifier: self.make_classifier,
+            _error: self._error,
+        }
+    }
+
+    /// Customize how to make [`Span`]s that all request handling will be wrapped in.
+    ///
+    /// `NewMakeSpan` is expected to implement [`MakeSpan`].
+    ///
+    /// [`MakeSpan`]: super::MakeSpan
+    /// [`Span`]: tracing::Span
     pub fn make_span_with<NewMakeSpan>(
         self,
         new_make_span: NewMakeSpan,

--- a/tower-http/src/trace/service.rs
+++ b/tower-http/src/trace/service.rs
@@ -1,6 +1,7 @@
 use super::{
-    DefaultMakeSpan, DefaultOnEos, DefaultOnFailure, DefaultOnRequest, DefaultOnResponse, MakeSpan,
-    OnEos, OnFailure, OnRequest, OnResponse, ResponseBody, ResponseFuture, TraceLayer,
+    DefaultMakeSpan, DefaultOnBodyChunk, DefaultOnEos, DefaultOnFailure, DefaultOnRequest,
+    DefaultOnResponse, MakeSpan, OnBodyChunk, OnEos, OnFailure, OnRequest, OnResponse,
+    ResponseBody, ResponseFuture, TraceLayer,
 };
 use crate::classify::{
     GrpcErrorsAsFailures, MakeClassifier, ServerErrorsAsFailures, SharedClassifier,
@@ -28,6 +29,7 @@ pub struct Trace<
     MakeSpan = DefaultMakeSpan,
     OnRequest = DefaultOnRequest,
     OnResponse = DefaultOnResponse,
+    OnBodyChunk = DefaultOnBodyChunk,
     OnEos = DefaultOnEos,
     OnFailure = DefaultOnFailure,
 > {
@@ -37,6 +39,7 @@ pub struct Trace<
     pub(crate) add_headers_to_span: bool,
     pub(crate) on_request: OnRequest,
     pub(crate) on_response: OnResponse,
+    pub(crate) on_body_chunk: OnBodyChunk,
     pub(crate) on_eos: OnEos,
     pub(crate) on_failure: OnFailure,
     pub(crate) _error: PhantomData<fn() -> E>,
@@ -55,6 +58,7 @@ impl<S, M, E> Trace<S, M, E> {
             add_headers_to_span: false,
             on_request: DefaultOnRequest::default(),
             on_response: DefaultOnResponse::default(),
+            on_body_chunk: DefaultOnBodyChunk::default(),
             on_eos: DefaultOnEos::default(),
             on_failure: DefaultOnFailure::default(),
             _error: PhantomData,
@@ -72,20 +76,21 @@ impl<S, M, E> Trace<S, M, E> {
     }
 }
 
-impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>
-    Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>
+impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
+    Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
 {
     define_inner_service_accessors!();
 
     pub fn on_request<NewOnRequest>(
         self,
         new_on_request: NewOnRequest,
-    ) -> Trace<S, M, E, MakeSpan, NewOnRequest, OnResponse, OnEos, OnFailure> {
+    ) -> Trace<S, M, E, MakeSpan, NewOnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> {
         Trace {
             on_request: new_on_request,
             inner: self.inner,
             on_failure: self.on_failure,
             on_eos: self.on_eos,
+            on_body_chunk: self.on_body_chunk,
             make_span: self.make_span,
             add_headers_to_span: self.add_headers_to_span,
             on_response: self.on_response,
@@ -97,12 +102,13 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>
     pub fn on_response<NewOnResponse>(
         self,
         new_on_response: NewOnResponse,
-    ) -> Trace<S, M, E, MakeSpan, OnRequest, NewOnResponse, OnEos, OnFailure> {
+    ) -> Trace<S, M, E, MakeSpan, OnRequest, NewOnResponse, OnBodyChunk, OnEos, OnFailure> {
         Trace {
             on_response: new_on_response,
             inner: self.inner,
             on_request: self.on_request,
             on_failure: self.on_failure,
+            on_body_chunk: self.on_body_chunk,
             on_eos: self.on_eos,
             make_span: self.make_span,
             add_headers_to_span: self.add_headers_to_span,
@@ -114,13 +120,50 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>
     pub fn on_failure<NewOnFailure>(
         self,
         new_on_failure: NewOnFailure,
-    ) -> Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, NewOnFailure> {
+    ) -> Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, NewOnFailure> {
         Trace {
             on_failure: new_on_failure,
             inner: self.inner,
             make_span: self.make_span,
+            on_body_chunk: self.on_body_chunk,
             on_request: self.on_request,
             on_eos: self.on_eos,
+            on_response: self.on_response,
+            add_headers_to_span: self.add_headers_to_span,
+            make_classifier: self.make_classifier,
+            _error: self._error,
+        }
+    }
+
+    pub fn on_body_chunk<NewOnBodyChunk>(
+        self,
+        new_on_body_chunk: NewOnBodyChunk,
+    ) -> Trace<S, M, E, MakeSpan, OnRequest, OnResponse, NewOnBodyChunk, OnEos, OnFailure> {
+        Trace {
+            on_body_chunk: new_on_body_chunk,
+            on_eos: self.on_eos,
+            make_span: self.make_span,
+            inner: self.inner,
+            on_failure: self.on_failure,
+            on_request: self.on_request,
+            on_response: self.on_response,
+            add_headers_to_span: self.add_headers_to_span,
+            make_classifier: self.make_classifier,
+            _error: self._error,
+        }
+    }
+
+    pub fn on_eos<NewOnEos>(
+        self,
+        new_on_eos: NewOnEos,
+    ) -> Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, NewOnEos, OnFailure> {
+        Trace {
+            on_eos: new_on_eos,
+            make_span: self.make_span,
+            inner: self.inner,
+            on_failure: self.on_failure,
+            on_request: self.on_request,
+            on_body_chunk: self.on_body_chunk,
             on_response: self.on_response,
             add_headers_to_span: self.add_headers_to_span,
             make_classifier: self.make_classifier,
@@ -131,12 +174,13 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>
     pub fn make_span_with<NewMakeSpan>(
         self,
         new_make_span: NewMakeSpan,
-    ) -> Trace<S, M, E, NewMakeSpan, OnRequest, OnResponse, OnEos, OnFailure> {
+    ) -> Trace<S, M, E, NewMakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> {
         Trace {
             make_span: new_make_span,
             inner: self.inner,
             on_failure: self.on_failure,
             on_request: self.on_request,
+            on_body_chunk: self.on_body_chunk,
             on_response: self.on_response,
             on_eos: self.on_eos,
             add_headers_to_span: self.add_headers_to_span,
@@ -159,6 +203,7 @@ impl<S, E>
         DefaultMakeSpan,
         DefaultOnRequest,
         DefaultOnResponse,
+        DefaultOnBodyChunk,
         DefaultOnEos,
         DefaultOnFailure,
     >
@@ -172,6 +217,7 @@ impl<S, E>
             make_span: DefaultMakeSpan::new(),
             on_request: DefaultOnRequest::default(),
             on_response: DefaultOnResponse::default(),
+            on_body_chunk: DefaultOnBodyChunk::default(),
             on_eos: DefaultOnEos::default(),
             add_headers_to_span: false,
             on_failure: DefaultOnFailure::default(),
@@ -188,6 +234,7 @@ impl<S, E>
         DefaultMakeSpan,
         DefaultOnRequest,
         DefaultOnResponse,
+        DefaultOnBodyChunk,
         DefaultOnEos,
         DefaultOnFailure,
     >
@@ -201,6 +248,7 @@ impl<S, E>
             make_span: DefaultMakeSpan::new(),
             on_request: DefaultOnRequest::default(),
             on_response: DefaultOnResponse::default(),
+            on_body_chunk: DefaultOnBodyChunk::default(),
             on_eos: DefaultOnEos::default(),
             add_headers_to_span: false,
             on_failure: DefaultOnFailure::default(),
@@ -209,9 +257,19 @@ impl<S, E>
     }
 }
 
-impl<S, ReqBody, ResBody, M, OnRequestT, OnResponseT, OnFailureT, OnEosT, MakeSpanT>
-    Service<Request<ReqBody>>
-    for Trace<S, M, S::Error, MakeSpanT, OnRequestT, OnResponseT, OnEosT, OnFailureT>
+impl<
+        S,
+        ReqBody,
+        ResBody,
+        M,
+        OnRequestT,
+        OnResponseT,
+        OnFailureT,
+        OnBodyChunkT,
+        OnEosT,
+        MakeSpanT,
+    > Service<Request<ReqBody>>
+    for Trace<S, M, S::Error, MakeSpanT, OnRequestT, OnResponseT, OnBodyChunkT, OnEosT, OnFailureT>
 where
     S: Service<Request<ReqBody>, Response = Response<ResBody>>,
     ReqBody: Body,
@@ -221,12 +279,15 @@ where
     MakeSpanT: MakeSpan<ReqBody>,
     OnRequestT: OnRequest<ReqBody>,
     OnResponseT: OnResponse<ResBody> + Clone,
+    OnBodyChunkT: OnBodyChunk<ResBody::Data> + Clone,
     OnEosT: OnEos + Clone,
     OnFailureT: OnFailure<M::FailureClass> + Clone,
 {
-    type Response = Response<ResponseBody<ResBody, M::ClassifyEos, OnEosT, OnFailureT>>;
+    type Response =
+        Response<ResponseBody<ResBody, M::ClassifyEos, OnBodyChunkT, OnEosT, OnFailureT>>;
     type Error = S::Error;
-    type Future = ResponseFuture<S::Future, M::Classifier, OnResponseT, OnEosT, OnFailureT>;
+    type Future =
+        ResponseFuture<S::Future, M::Classifier, OnResponseT, OnBodyChunkT, OnEosT, OnFailureT>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
@@ -254,6 +315,7 @@ where
             span,
             classifier: Some(classifier),
             on_response: Some(self.on_response.clone()),
+            on_body_chunk: Some(self.on_body_chunk.clone()),
             on_eos: Some(self.on_eos.clone()),
             on_failure: Some(self.on_failure.clone()),
             start,
@@ -261,8 +323,8 @@ where
     }
 }
 
-impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure> Clone
-    for Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>
+impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> Clone
+    for Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
 where
     S: Clone,
     M: Clone,
@@ -270,6 +332,7 @@ where
     OnFailure: Clone,
     OnRequest: Clone,
     OnResponse: Clone,
+    OnBodyChunk: Clone,
     OnEos: Clone,
 {
     fn clone(&self) -> Self {
@@ -278,6 +341,7 @@ where
             on_failure: self.on_failure.clone(),
             make_span: self.make_span.clone(),
             on_response: self.on_response.clone(),
+            on_body_chunk: self.on_body_chunk.clone(),
             on_eos: self.on_eos.clone(),
             add_headers_to_span: self.add_headers_to_span,
             make_classifier: self.make_classifier.clone(),
@@ -287,14 +351,15 @@ where
     }
 }
 
-impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure> fmt::Debug
-    for Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>
+impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> fmt::Debug
+    for Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
 where
     S: fmt::Debug,
     M: fmt::Debug,
     MakeSpan: fmt::Debug,
     OnFailure: fmt::Debug,
     OnRequest: fmt::Debug,
+    OnBodyChunk: fmt::Debug,
     OnResponse: fmt::Debug,
     OnEos: fmt::Debug,
 {
@@ -306,6 +371,7 @@ where
             .field("add_headers_to_span", &self.add_headers_to_span)
             .field("on_request", &self.on_request)
             .field("on_response", &self.on_response)
+            .field("on_body_chunk", &self.on_body_chunk)
             .field("on_eos", &self.on_eos)
             .field("on_failure", &self.on_failure)
             .finish()

--- a/tower-http/src/trace/service.rs
+++ b/tower-http/src/trace/service.rs
@@ -1,0 +1,313 @@
+use super::{
+    DefaultMakeSpan, DefaultOnEos, DefaultOnFailure, DefaultOnRequest, DefaultOnResponse, MakeSpan,
+    OnEos, OnFailure, OnRequest, OnResponse, ResponseBody, ResponseFuture, TraceLayer,
+};
+use crate::classify::{
+    GrpcErrorsAsFailures, MakeClassifier, ServerErrorsAsFailures, SharedClassifier,
+};
+use http::{Request, Response};
+use http_body::Body;
+use std::{
+    fmt,
+    marker::PhantomData,
+    task::{Context, Poll},
+    time::Instant,
+};
+use tower_service::Service;
+
+/// Middleware that adds high level [tracing] to a [`Service`].
+///
+/// See the [module docs](crate::trace) for an example.
+///
+/// [tracing]: https://crates.io/crates/tracing
+/// [`Service`]: tower_service::Service
+pub struct Trace<
+    S,
+    M,
+    E,
+    MakeSpan = DefaultMakeSpan,
+    OnRequest = DefaultOnRequest,
+    OnResponse = DefaultOnResponse,
+    OnEos = DefaultOnEos,
+    OnFailure = DefaultOnFailure,
+> {
+    pub(crate) inner: S,
+    pub(crate) make_classifier: M,
+    pub(crate) make_span: MakeSpan,
+    pub(crate) add_headers_to_span: bool,
+    pub(crate) on_request: OnRequest,
+    pub(crate) on_response: OnResponse,
+    pub(crate) on_eos: OnEos,
+    pub(crate) on_failure: OnFailure,
+    pub(crate) _error: PhantomData<fn() -> E>,
+}
+
+impl<S, M, E> Trace<S, M, E> {
+    /// Create a new [`Trace`] using the given [`MakeClassifier`].
+    pub fn new(inner: S, make_classifier: M) -> Self
+    where
+        M: MakeClassifier<E>,
+    {
+        Self {
+            inner,
+            make_classifier,
+            make_span: DefaultMakeSpan::new(),
+            add_headers_to_span: false,
+            on_request: DefaultOnRequest::default(),
+            on_response: DefaultOnResponse::default(),
+            on_eos: DefaultOnEos::default(),
+            on_failure: DefaultOnFailure::default(),
+            _error: PhantomData,
+        }
+    }
+
+    /// Returns a new [`Layer`] that wraps services with a [`TraceLayer`] middleware.
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(make_classifier: M) -> TraceLayer<M, E>
+    where
+        M: MakeClassifier<E>,
+    {
+        TraceLayer::new(make_classifier)
+    }
+}
+
+impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>
+    Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>
+{
+    define_inner_service_accessors!();
+
+    pub fn on_request<NewOnRequest>(
+        self,
+        new_on_request: NewOnRequest,
+    ) -> Trace<S, M, E, MakeSpan, NewOnRequest, OnResponse, OnEos, OnFailure> {
+        Trace {
+            on_request: new_on_request,
+            inner: self.inner,
+            on_failure: self.on_failure,
+            on_eos: self.on_eos,
+            make_span: self.make_span,
+            add_headers_to_span: self.add_headers_to_span,
+            on_response: self.on_response,
+            make_classifier: self.make_classifier,
+            _error: self._error,
+        }
+    }
+
+    pub fn on_response<NewOnResponse>(
+        self,
+        new_on_response: NewOnResponse,
+    ) -> Trace<S, M, E, MakeSpan, OnRequest, NewOnResponse, OnEos, OnFailure> {
+        Trace {
+            on_response: new_on_response,
+            inner: self.inner,
+            on_request: self.on_request,
+            on_failure: self.on_failure,
+            on_eos: self.on_eos,
+            make_span: self.make_span,
+            add_headers_to_span: self.add_headers_to_span,
+            make_classifier: self.make_classifier,
+            _error: self._error,
+        }
+    }
+
+    pub fn on_failure<NewOnFailure>(
+        self,
+        new_on_failure: NewOnFailure,
+    ) -> Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, NewOnFailure> {
+        Trace {
+            on_failure: new_on_failure,
+            inner: self.inner,
+            make_span: self.make_span,
+            on_request: self.on_request,
+            on_eos: self.on_eos,
+            on_response: self.on_response,
+            add_headers_to_span: self.add_headers_to_span,
+            make_classifier: self.make_classifier,
+            _error: self._error,
+        }
+    }
+
+    pub fn make_span_with<NewMakeSpan>(
+        self,
+        new_make_span: NewMakeSpan,
+    ) -> Trace<S, M, E, NewMakeSpan, OnRequest, OnResponse, OnEos, OnFailure> {
+        Trace {
+            make_span: new_make_span,
+            inner: self.inner,
+            on_failure: self.on_failure,
+            on_request: self.on_request,
+            on_response: self.on_response,
+            on_eos: self.on_eos,
+            add_headers_to_span: self.add_headers_to_span,
+            make_classifier: self.make_classifier,
+            _error: self._error,
+        }
+    }
+
+    pub fn add_headers_to_span(mut self, value: bool) -> Self {
+        self.add_headers_to_span = value;
+        self
+    }
+}
+
+impl<S, E>
+    Trace<
+        S,
+        SharedClassifier<ServerErrorsAsFailures>,
+        E,
+        DefaultMakeSpan,
+        DefaultOnRequest,
+        DefaultOnResponse,
+        DefaultOnEos,
+        DefaultOnFailure,
+    >
+{
+    /// Create a new [`Trace`] using [`ServerErrorsAsFailures`] which supports classifying
+    /// regular HTTP responses based on the status code.
+    pub fn new_for_http(inner: S) -> Self {
+        Self {
+            inner,
+            make_classifier: SharedClassifier::new::<E>(ServerErrorsAsFailures::default()),
+            make_span: DefaultMakeSpan::new(),
+            on_request: DefaultOnRequest::default(),
+            on_response: DefaultOnResponse::default(),
+            on_eos: DefaultOnEos::default(),
+            add_headers_to_span: false,
+            on_failure: DefaultOnFailure::default(),
+            _error: PhantomData,
+        }
+    }
+}
+
+impl<S, E>
+    Trace<
+        S,
+        SharedClassifier<GrpcErrorsAsFailures>,
+        E,
+        DefaultMakeSpan,
+        DefaultOnRequest,
+        DefaultOnResponse,
+        DefaultOnEos,
+        DefaultOnFailure,
+    >
+{
+    /// Create a new [`Trace`] using [`GrpcErrorsAsFailures`] which supports classifying
+    /// gRPC responses and streams based on the `grpc-status` header.
+    pub fn new_for_grpc(inner: S) -> Self {
+        Self {
+            inner,
+            make_classifier: SharedClassifier::new::<E>(GrpcErrorsAsFailures::default()),
+            make_span: DefaultMakeSpan::new(),
+            on_request: DefaultOnRequest::default(),
+            on_response: DefaultOnResponse::default(),
+            on_eos: DefaultOnEos::default(),
+            add_headers_to_span: false,
+            on_failure: DefaultOnFailure::default(),
+            _error: PhantomData,
+        }
+    }
+}
+
+impl<S, ReqBody, ResBody, M, OnRequestT, OnResponseT, OnFailureT, OnEosT, MakeSpanT>
+    Service<Request<ReqBody>>
+    for Trace<S, M, S::Error, MakeSpanT, OnRequestT, OnResponseT, OnEosT, OnFailureT>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    ReqBody: Body,
+    ResBody: Body,
+    M: MakeClassifier<S::Error>,
+    M::Classifier: Clone,
+    MakeSpanT: MakeSpan,
+    OnRequestT: OnRequest<ReqBody>,
+    OnResponseT: OnResponse<ResBody> + Clone,
+    OnEosT: OnEos + Clone,
+    OnFailureT: OnFailure<M::FailureClass> + Clone,
+{
+    type Response = Response<ResponseBody<ResBody, M::ClassifyEos, OnEosT, OnFailureT>>;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future, M::Classifier, OnResponseT, OnEosT, OnFailureT>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let start = Instant::now();
+
+        let span = self.make_span.make_span(&req);
+
+        if self.add_headers_to_span {
+            span.record("headers", &tracing::field::debug(req.headers()));
+        }
+
+        let classifier = self.make_classifier.make_classifier(&req);
+
+        let future = {
+            let _guard = span.enter();
+            self.on_request.on_request(&req);
+            self.inner.call(req)
+        };
+
+        ResponseFuture {
+            inner: future,
+            span,
+            classifier: Some(classifier),
+            on_response: Some(self.on_response.clone()),
+            on_eos: Some(self.on_eos.clone()),
+            on_failure: Some(self.on_failure.clone()),
+            start,
+        }
+    }
+}
+
+impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure> Clone
+    for Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>
+where
+    S: Clone,
+    M: Clone,
+    MakeSpan: Clone,
+    OnFailure: Clone,
+    OnRequest: Clone,
+    OnResponse: Clone,
+    OnEos: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            on_failure: self.on_failure.clone(),
+            make_span: self.make_span.clone(),
+            on_response: self.on_response.clone(),
+            on_eos: self.on_eos.clone(),
+            add_headers_to_span: self.add_headers_to_span,
+            make_classifier: self.make_classifier.clone(),
+            on_request: self.on_request.clone(),
+            _error: self._error,
+        }
+    }
+}
+
+impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure> fmt::Debug
+    for Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnEos, OnFailure>
+where
+    S: fmt::Debug,
+    M: fmt::Debug,
+    MakeSpan: fmt::Debug,
+    OnFailure: fmt::Debug,
+    OnRequest: fmt::Debug,
+    OnResponse: fmt::Debug,
+    OnEos: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Trace")
+            .field("inner", &self.inner)
+            .field("make_classifier", &self.make_classifier)
+            .field("make_span", &self.make_span)
+            .field("add_headers_to_span", &self.add_headers_to_span)
+            .field("on_request", &self.on_request)
+            .field("on_response", &self.on_response)
+            .field("on_eos", &self.on_eos)
+            .field("on_failure", &self.on_failure)
+            .finish()
+    }
+}

--- a/tower-http/src/trace/service.rs
+++ b/tower-http/src/trace/service.rs
@@ -218,7 +218,7 @@ where
     ResBody: Body,
     M: MakeClassifier<S::Error>,
     M::Classifier: Clone,
-    MakeSpanT: MakeSpan,
+    MakeSpanT: MakeSpan<ReqBody>,
     OnRequestT: OnRequest<ReqBody>,
     OnResponseT: OnResponse<ResBody> + Clone,
     OnEosT: OnEos + Clone,


### PR DESCRIPTION
This adds a quite comprehensive `Trace` middleware. We have used it for some time at Embark for both servers and clients and its been working well.

I've spent put a lot of effort into making it easy to get started with while also providing deep customization.

I'm sorry for the size of this PR but most of it is plumbing like builder methods. The actual service/future/body implementation isn't that big.

Basic usage:

```rust
let service = ServiceBuilder::new()
    .layer(TraceLayer::new_for_http())
    .service_fn(handle);
```

Output with default tracing subscriber:

```
Mar 05 20:50:28.523 DEBUG request{method=GET path="/foo"}: tower_http::trace::on_request: started processing request
Mar 05 20:50:28.524 DEBUG request{method=GET path="/foo"}: tower_http::trace::on_response: finished processing request latency=1 ms status=200
```

Using a gRPC response classifier:

```rust
let service = ServiceBuilder::new()
    .layer(TraceLayer::new_for_grpc())
    .service_fn(handle);
```

Custom classifiers are of course also supported.

Every part of the output can be customized:

```rust
let service = ServiceBuilder::new()
    .layer(
        TraceLayer::new_for_http()
            .make_span_with(|request: &Request<Body>| {
                tracing::debug_span!("http-request")
            })
            .on_request(|request: &Request<Body>| {
                tracing::debug!("started {} {}", request.method(), request.uri().path())
            })
            .on_response(|response: &Response<Body>, latency: Duration| {
                tracing::debug!("response generated in {:?}", latency)
            })
            .on_body_chunk(|chunk: &Bytes, latency: Duration| {
                tracing::debug!("sending {} bytes", chunk.len())
            })
            .on_eos(|trailers: Option<&HeaderMap>, stream_duration: Duration| {
                tracing::debug!("stream closed after {:?}", stream_duration)
            })
            .on_failure(|error: StatusCode, latency: Duration| {
                tracing::debug!("something went wrong")
            })
    )
    .service_fn(handle);
```

You can probably imagine this leads to `Trace` having quite a few generic types 😕

If you only want to customize a few things the default behaviours have builder methods:

```rust
let service = ServiceBuilder::new()
    .layer(
        TraceLayer::new_for_http()
            .make_span_with(
                DefaultMakeSpan::new().include_headers(true)
            )
            .on_response(
                DefaultOnResponse::new()
                    .level(Level::INFO)
                    .latency_unit(LatencyUnit::Micros)
            )
            // ...
    )
    .service_fn(handle);
```

Fixes https://github.com/tower-rs/tower-http/issues/65