### PR TITLE
Disable compression for gRPC and add tonic streaming example

### DIFF
--- a/examples/tonic-key-value-store/Cargo.toml
+++ b/examples/tonic-key-value-store/Cargo.toml
@@ -12,6 +12,8 @@ hyper = { version = "0.14.4", features = ["full"] }
 prost = "0.7"
 structopt = "0.3.21"
 tokio = { version = "1.2.0", features = ["full"] }
+futures = "0.3"
+tokio-stream = { version = "0.1", features = ["sync"] }
 tonic = "0.4"
 tower = { version = "0.4.5", features = ["full"] }
 tower-http = { path = "../../tower-http", features = ["full"] }

--- a/examples/tonic-key-value-store/README.md
+++ b/examples/tonic-key-value-store/README.md
@@ -7,7 +7,8 @@ This examples contains a simple key/value store with a gRPC API and client built
 Running a server:
 
 ```
-cargo run --bin tonic-key-value-store -- -p 3000 server
+RUST_LOG=tonic_key_value_store=trace,tower_http=trace \
+    cargo run --bin tonic-key-value-store -- -p 3000 server
 ```
 
 Setting values:
@@ -20,4 +21,10 @@ Getting values:
 
 ```
 cargo run --bin tonic-key-value-store -- -p 3000 get -k foo
+```
+
+Create a stream of new keys:
+
+```
+cargo run --bin tonic-key-value-store -- -p 3000 subscribe
 ```

--- a/examples/tonic-key-value-store/build.rs
+++ b/examples/tonic-key-value-store/build.rs
@@ -1,3 +1,6 @@
 fn main() {
-    tonic_build::compile_protos("proto/key_value_store.proto").unwrap();
+    tonic_build::configure()
+        .format(false)
+        .compile(&["key_value_store.proto"], &["proto"])
+        .unwrap();
 }

--- a/examples/tonic-key-value-store/proto/key_value_store.proto
+++ b/examples/tonic-key-value-store/proto/key_value_store.proto
@@ -5,6 +5,7 @@ package key_value_store;
 service KeyValueStore {
     rpc Get (GetRequest) returns (GetReply);
     rpc Set (SetRequest) returns (SetReply);
+    rpc Subscribe (SubscribeRequest) returns (stream SubscribeReply);
 }
 
 message GetRequest {
@@ -21,3 +22,9 @@ message SetRequest {
 }
 
 message SetReply {}
+
+message SubscribeRequest {}
+
+message SubscribeReply {
+   string key = 1;
+}

--- a/examples/tonic-key-value-store/src/main.rs
+++ b/examples/tonic-key-value-store/src/main.rs
@@ -19,7 +19,7 @@ use std::{
 };
 use structopt::StructOpt;
 use tokio::io::AsyncReadExt;
-use tokio::sync::broadcast::{channel, Sender};
+use tokio::sync::broadcast::{self, Sender};
 use tokio_stream::{wrappers::BroadcastStream, Stream};
 use tonic::{async_trait, body::BoxBody, transport::Channel, Code, Request, Response, Status};
 use tower::{make::Shared, ServiceBuilder};
@@ -153,7 +153,7 @@ async fn serve_forever(listener: TcpListener) -> Result<(), Box<dyn std::error::
     // Build our database for holding the key/value pairs
     let db = Arc::new(RwLock::new(HashMap::new()));
 
-    let (tx, _rx) = channel(1024);
+    let (tx, _rx) = broadcast::channel(1024);
 
     // Build our tonic `Service`
     let service = key_value_store_server::KeyValueStoreServer::new(ServerImpl { db, tx });

--- a/examples/tonic-key-value-store/src/main.rs
+++ b/examples/tonic-key-value-store/src/main.rs
@@ -241,7 +241,7 @@ impl key_value_store_server::KeyValueStore for ServerImpl {
                 item.ok()
             })
             .map(Ok);
-        let stream: Self::SubscribeStream = Box::pin(stream);
+        let stream = Box::pin(stream) as Self::SubscribeStream;
         let res = Response::new(stream);
 
         Ok(res)

--- a/tower-http/src/compression/future.rs
+++ b/tower-http/src/compression/future.rs
@@ -37,7 +37,7 @@ where
         let (mut parts, body) = res.into_parts();
 
         let body = match (
-            dbg!(supports_transparent_compression(&parts.headers)),
+            supports_transparent_compression(&parts.headers),
             self.encoding,
         ) {
             // if compression is _not_ support or the client doesn't accept it

--- a/tower-http/src/compression/future.rs
+++ b/tower-http/src/compression/future.rs
@@ -3,7 +3,7 @@
 use super::{body::BodyInner, CompressionBody, Encoding};
 use crate::compression_utils::{BoxError, WrapBody};
 use futures_util::ready;
-use http::{header, HeaderValue, Response};
+use http::{header, HeaderMap, HeaderValue, Response};
 use http_body::Body;
 use pin_project::pin_project;
 use std::{
@@ -36,19 +36,24 @@ where
 
         let (mut parts, body) = res.into_parts();
 
-        let body = match self.encoding {
-            #[cfg(feature = "compression-gzip")]
-            Encoding::Gzip => CompressionBody(BodyInner::Gzip(WrapBody::new(body))),
-            #[cfg(feature = "compression-deflate")]
-            Encoding::Deflate => CompressionBody(BodyInner::Deflate(WrapBody::new(body))),
-            #[cfg(feature = "compression-br")]
-            Encoding::Brotli => CompressionBody(BodyInner::Brotli(WrapBody::new(body))),
-            Encoding::Identity => {
+        let body = match (
+            dbg!(supports_transparent_compression(&parts.headers)),
+            self.encoding,
+        ) {
+            // if compression is _not_ support or the client doesn't accept it
+            (false, _) | (_, Encoding::Identity) => {
                 return Poll::Ready(Ok(Response::from_parts(
                     parts,
                     CompressionBody(BodyInner::Identity(body)),
                 )))
             }
+
+            #[cfg(feature = "compression-gzip")]
+            (_, Encoding::Gzip) => CompressionBody(BodyInner::Gzip(WrapBody::new(body))),
+            #[cfg(feature = "compression-deflate")]
+            (_, Encoding::Deflate) => CompressionBody(BodyInner::Deflate(WrapBody::new(body))),
+            #[cfg(feature = "compression-br")]
+            (_, Encoding::Brotli) => CompressionBody(BodyInner::Brotli(WrapBody::new(body))),
         };
 
         parts.headers.remove(header::CONTENT_LENGTH);
@@ -60,4 +65,28 @@ where
         let res = Response::from_parts(parts, body);
         Poll::Ready(Ok(res))
     }
+}
+
+#[allow(clippy::clippy::needless_bool)]
+fn supports_transparent_compression(response_headers: &HeaderMap) -> bool {
+    let content_type = if let Some(content_type) = content_type(response_headers) {
+        content_type
+    } else {
+        return true;
+    };
+
+    if content_type == "application/grpc" {
+        // grpc doesn't support transparent compression and instead has its compression own
+        // algorithm that implementations can use
+        // https://grpc.github.io/grpc/core/md_doc_compression.html
+        false
+    } else {
+        // for now just say that all non-grpc requests support compression
+        true
+    }
+}
+
+fn content_type(headers: &HeaderMap) -> Option<&str> {
+    let content_type = headers.get(http::header::CONTENT_TYPE)?;
+    content_type.to_str().ok()
 }

--- a/tower-http/src/compression_utils.rs
+++ b/tower-http/src/compression_utils.rs
@@ -317,7 +317,7 @@ pub(crate) fn supports_transparent_compression(headers: &HeaderMap) -> bool {
         return true;
     };
 
-    if content_type == "application/grpc" {
+    if content_type.starts_with("application/grpc") {
         // grpc doesn't support transparent compression and instead has its compression own
         // algorithm that implementations can use
         // https://grpc.github.io/grpc/core/md_doc_compression.html

--- a/tower-http/src/compression_utils.rs
+++ b/tower-http/src/compression_utils.rs
@@ -3,7 +3,7 @@
 use bytes::{Bytes, BytesMut};
 use futures_core::Stream;
 use futures_util::ready;
-use http::HeaderValue;
+use http::{HeaderMap, HeaderValue};
 use http_body::Body;
 use pin_project::pin_project;
 use std::{
@@ -308,3 +308,27 @@ where
 }
 
 pub(crate) const SENTINEL_ERROR_CODE: i32 = -837459418;
+
+#[allow(clippy::clippy::needless_bool)]
+pub(crate) fn supports_transparent_compression(headers: &HeaderMap) -> bool {
+    let content_type = if let Some(content_type) = content_type(headers) {
+        content_type
+    } else {
+        return true;
+    };
+
+    if content_type == "application/grpc" {
+        // grpc doesn't support transparent compression and instead has its compression own
+        // algorithm that implementations can use
+        // https://grpc.github.io/grpc/core/md_doc_compression.html
+        false
+    } else {
+        // for now just say that all non-grpc requests support compression
+        true
+    }
+}
+
+fn content_type(headers: &HeaderMap) -> Option<&str> {
+    let content_type = headers.get(http::header::CONTENT_TYPE)?;
+    content_type.to_str().ok()
+}

--- a/tower-http/src/decompression/service.rs
+++ b/tower-http/src/decompression/service.rs
@@ -1,5 +1,5 @@
 use super::{DecompressionBody, DecompressionLayer, ResponseFuture};
-use crate::compression_utils::{AcceptEncoding, BoxError};
+use crate::compression_utils::{supports_transparent_compression, AcceptEncoding, BoxError};
 use http::{
     header::{self, ACCEPT_ENCODING, RANGE},
     Request, Response,
@@ -102,7 +102,7 @@ where
     }
 
     fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
-        if !req.headers().contains_key(RANGE) {
+        if supports_transparent_compression(req.headers()) && !req.headers().contains_key(RANGE) {
             if let header::Entry::Vacant(entry) = req.headers_mut().entry(ACCEPT_ENCODING) {
                 if let Some(accept) = self.accept.to_header_value() {
                     entry.insert(accept);


### PR DESCRIPTION
This adds a server streaming example to the tonic example. Adding that made me aware of https://github.com/tower-rs/tower-http/issues/81.

After much debugging I most admit I don't fully understand why compression breaks gRPC streams. My best idea is that async-compression changes the body chunks in ways that are incompatible with gRPC. This is also hinted at in the [gRPC core document on compression](https://grpc.github.io/grpc/core/md_doc_compression.html) where it says:

> The compression supported by gRPC acts at the individual message level

If you don't compress the whole body stream but instead compress (and decompress) each individual chunk yielded by `poll_data` then everything works.

The solution I have implemented is to simply detect gRPC responses and don't compress them, even if the client claims to accept compression. As compression part of the gRPC protocol that is probably a better place to implement it.

Fixes https://github.com/tower-rs/tower-http/issues/81