### PR TITLE
Use better failure class for HTTP and gRPC classifiers

### DIFF
--- a/examples/tonic-key-value-store/Cargo.toml
+++ b/examples/tonic-key-value-store/Cargo.toml
@@ -8,14 +8,15 @@ license = "MIT"
 
 [dependencies]
 bytes = "1"
+futures = "0.3"
 hyper = { version = "0.14.4", features = ["full"] }
 prost = "0.7"
 structopt = "0.3.21"
+thiserror = "1"
 tokio = { version = "1.2.0", features = ["full"] }
-futures = "0.3"
 tokio-stream = { version = "0.1", features = ["sync"] }
 tonic = "0.4"
-tower = { version = "0.4.5", features = ["full"] }
+tower = { version = "0.4.7", features = ["full"] }
 tower-http = { path = "../../tower-http", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/tower-http/src/classify.rs
+++ b/tower-http/src/classify.rs
@@ -223,7 +223,7 @@ where
 pub enum StatusCodeOrError {
     /// A failure was classified as a status code.
     StatusCode(StatusCode),
-    /// An was encountered.
+    /// An error was encountered.
     ///
     /// As [`ClassifyResponse::classify_error`] receives a reference to a generic type,
     /// [`ServerErrorsAsFailures`] requires its type to implement [`fmt::Display`] and uses that
@@ -324,7 +324,7 @@ where
 pub enum GrpcCodeOrError {
     /// A failure was classified as a gRPC code.
     Code(i32),
-    /// An was encountered.
+    /// An error was encountered.
     ///
     /// As [`ClassifyResponse::classify_error`] receives a reference to a generic type,
     /// [`GrpcEosErrorsAsFailures`] requires its type to implement [`fmt::Display`] and uses that

--- a/tower-http/src/classify.rs
+++ b/tower-http/src/classify.rs
@@ -353,7 +353,7 @@ where
     F: FnOnce(&E) -> T,
 {
     type FailureClass = GrpcCodeOrError<T>;
-    type ClassifyEos = GrpcEosErrorsAsFailures<E, F>;
+    type ClassifyEos = GrpcEosErrorsAsFailures<F>;
 
     fn classify_response<B>(
         self,
@@ -364,7 +364,6 @@ where
         } else {
             ClassifiedResponse::RequiresEos(GrpcEosErrorsAsFailures {
                 map_error: self.map_error,
-                _error: PhantomData,
             })
         }
     }
@@ -376,33 +375,30 @@ where
 }
 
 /// The [`ClassifyEos`] for [`GrpcErrorsAsFailures`].
-pub struct GrpcEosErrorsAsFailures<E, F = fn(&E) -> String> {
+pub struct GrpcEosErrorsAsFailures<F> {
     map_error: F,
-    _error: PhantomData<fn() -> E>,
 }
 
-impl<E, F> fmt::Debug for GrpcEosErrorsAsFailures<E, F> {
+impl<F> fmt::Debug for GrpcEosErrorsAsFailures<F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GrpcEosErrorsAsFailures")
             .field("map_error", &format_args!("{}", std::any::type_name::<F>()))
-            .field("_error", &self._error)
             .finish()
     }
 }
 
-impl<E, F> Clone for GrpcEosErrorsAsFailures<E, F>
+impl<F> Clone for GrpcEosErrorsAsFailures<F>
 where
     F: Clone,
 {
     fn clone(&self) -> Self {
         Self {
             map_error: self.map_error.clone(),
-            _error: PhantomData,
         }
     }
 }
 
-impl<E, F, T> ClassifyEos<E> for GrpcEosErrorsAsFailures<E, F>
+impl<E, F, T> ClassifyEos<E> for GrpcEosErrorsAsFailures<F>
 where
     F: FnOnce(&E) -> T,
 {

--- a/tower-http/src/trace/layer.rs
+++ b/tower-http/src/trace/layer.rs
@@ -210,12 +210,15 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
     }
 }
 
-impl<E> TraceLayer<SharedClassifier<ServerErrorsAsFailures>, E> {
+impl<E> TraceLayer<SharedClassifier<ServerErrorsAsFailures<fn(&E) -> String>>, E> {
     /// Create a new [`TraceLayer`] using [`ServerErrorsAsFailures`] which supports classifying
     /// regular HTTP responses based on the status code.
-    pub fn new_for_http() -> Self {
+    pub fn new_for_http() -> Self
+    where
+        E: fmt::Display,
+    {
         Self {
-            make_classifier: SharedClassifier::new::<E>(ServerErrorsAsFailures::default()),
+            make_classifier: ServerErrorsAsFailures::make_classifier(),
             make_span: DefaultMakeSpan::new(),
             on_response: DefaultOnResponse::default(),
             on_request: DefaultOnRequest::default(),
@@ -227,12 +230,15 @@ impl<E> TraceLayer<SharedClassifier<ServerErrorsAsFailures>, E> {
     }
 }
 
-impl<E> TraceLayer<SharedClassifier<GrpcErrorsAsFailures>, E> {
+impl<E> TraceLayer<SharedClassifier<GrpcErrorsAsFailures<fn(&E) -> String>>, E>
+where
+    E: fmt::Display,
+{
     /// Create a new [`TraceLayer`] using [`GrpcErrorsAsFailures`] which supports classifying
     /// gRPC responses and streams based on the `grpc-status` header.
     pub fn new_for_grpc() -> Self {
         Self {
-            make_classifier: SharedClassifier::new::<E>(GrpcErrorsAsFailures::default()),
+            make_classifier: GrpcErrorsAsFailures::make_classifier(),
             make_span: DefaultMakeSpan::new(),
             on_response: DefaultOnResponse::default(),
             on_request: DefaultOnRequest::default(),

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -316,8 +316,9 @@ const DEFAULT_ERROR_LEVEL: Level = Level::ERROR;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::classify::StatusCodeOrError;
     use bytes::Bytes;
-    use http::{HeaderMap, Request, Response, StatusCode};
+    use http::{HeaderMap, Request, Response};
     use hyper::Body;
     use once_cell::sync::Lazy;
     use std::{
@@ -347,7 +348,7 @@ mod tests {
             .on_eos(|_trailers: Option<&HeaderMap>, _latency: Duration| {
                 ON_EOS.fetch_add(1, Ordering::SeqCst);
             })
-            .on_failure(|_err: StatusCode, _latency: Duration| {
+            .on_failure(|_err: StatusCodeOrError<String>, _latency: Duration| {
                 ON_FAILURE.fetch_add(1, Ordering::SeqCst);
             });
 
@@ -394,7 +395,7 @@ mod tests {
             .on_eos(|_trailers: Option<&HeaderMap>, _latency: Duration| {
                 ON_EOS.fetch_add(1, Ordering::SeqCst);
             })
-            .on_failure(|_err: StatusCode, _latency: Duration| {
+            .on_failure(|_err: StatusCodeOrError<String>, _latency: Duration| {
                 ON_FAILURE.fetch_add(1, Ordering::SeqCst);
             });
 

--- a/tower-http/src/trace/on_response.rs
+++ b/tower-http/src/trace/on_response.rs
@@ -154,30 +154,32 @@ macro_rules! log_pattern_match {
 
 impl<B> OnResponse<B> for DefaultOnResponse {
     fn on_response(self, response: &Response<B>, latency: Duration) {
-        log_pattern_match!(
-            self,
-            response,
-            latency,
-            self.include_headers,
-            [ERROR, WARN, INFO, DEBUG, TRACE]
-        );
+        todo!()
+
+        // log_pattern_match!(
+        //     self,
+        //     response,
+        //     latency,
+        //     self.include_headers,
+        //     [ERROR, WARN, INFO, DEBUG, TRACE]
+        // );
     }
 }
 
-fn status<B>(res: &Response<B>) -> i32 {
-    let is_grpc = res
-        .headers()
-        .get(http::header::CONTENT_TYPE)
-        .map_or(false, |value| value == "application/grpc");
+// fn status<B>(res: &Response<B>) -> i32 {
+//     let is_grpc = res
+//         .headers()
+//         .get(http::header::CONTENT_TYPE)
+//         .map_or(false, |value| value == "application/grpc");
 
-    if is_grpc {
-        if let Some(Err(status)) = crate::classify::classify_grpc_metadata(res.headers()) {
-            status
-        } else {
-            // 0 is success in gRPC
-            0
-        }
-    } else {
-        res.status().as_u16().into()
-    }
-}
+//     if is_grpc {
+//         if let Some(Err(status)) = crate::classify::classify_grpc_metadata(res.headers()) {
+//             status
+//         } else {
+//             // 0 is success in gRPC
+//             0
+//         }
+//     } else {
+//         res.status().as_u16().into()
+//     }
+// }

--- a/tower-http/src/trace/on_response.rs
+++ b/tower-http/src/trace/on_response.rs
@@ -154,32 +154,30 @@ macro_rules! log_pattern_match {
 
 impl<B> OnResponse<B> for DefaultOnResponse {
     fn on_response(self, response: &Response<B>, latency: Duration) {
-        todo!()
-
-        // log_pattern_match!(
-        //     self,
-        //     response,
-        //     latency,
-        //     self.include_headers,
-        //     [ERROR, WARN, INFO, DEBUG, TRACE]
-        // );
+        log_pattern_match!(
+            self,
+            response,
+            latency,
+            self.include_headers,
+            [ERROR, WARN, INFO, DEBUG, TRACE]
+        );
     }
 }
 
-// fn status<B>(res: &Response<B>) -> i32 {
-//     let is_grpc = res
-//         .headers()
-//         .get(http::header::CONTENT_TYPE)
-//         .map_or(false, |value| value == "application/grpc");
+fn status<B>(res: &Response<B>) -> i32 {
+    let is_grpc = res
+        .headers()
+        .get(http::header::CONTENT_TYPE)
+        .map_or(false, |value| value == "application/grpc");
 
-//     if is_grpc {
-//         if let Some(Err(status)) = crate::classify::classify_grpc_metadata(res.headers()) {
-//             status
-//         } else {
-//             // 0 is success in gRPC
-//             0
-//         }
-//     } else {
-//         res.status().as_u16().into()
-//     }
-// }
+    if is_grpc {
+        if let Some(Err(status)) = crate::classify::classify_grpc_metadata(res.headers()) {
+            status
+        } else {
+            // 0 is success in gRPC
+            0
+        }
+    } else {
+        res.status().as_u16().into()
+    }
+}

--- a/tower-http/src/trace/service.rs
+++ b/tower-http/src/trace/service.rs
@@ -216,7 +216,7 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
 impl<S, E>
     Trace<
         S,
-        SharedClassifier<ServerErrorsAsFailures>,
+        SharedClassifier<ServerErrorsAsFailures<fn(&E) -> String>>,
         E,
         DefaultMakeSpan,
         DefaultOnRequest,
@@ -228,10 +228,13 @@ impl<S, E>
 {
     /// Create a new [`Trace`] using [`ServerErrorsAsFailures`] which supports classifying
     /// regular HTTP responses based on the status code.
-    pub fn new_for_http(inner: S) -> Self {
+    pub fn new_for_http(inner: S) -> Self
+    where
+        E: fmt::Display,
+    {
         Self {
             inner,
-            make_classifier: SharedClassifier::new::<E>(ServerErrorsAsFailures::default()),
+            make_classifier: ServerErrorsAsFailures::make_classifier(),
             make_span: DefaultMakeSpan::new(),
             on_request: DefaultOnRequest::default(),
             on_response: DefaultOnResponse::default(),
@@ -246,7 +249,7 @@ impl<S, E>
 impl<S, E>
     Trace<
         S,
-        SharedClassifier<GrpcErrorsAsFailures>,
+        SharedClassifier<GrpcErrorsAsFailures<fn(&E) -> String>>,
         E,
         DefaultMakeSpan,
         DefaultOnRequest,
@@ -258,10 +261,13 @@ impl<S, E>
 {
     /// Create a new [`Trace`] using [`GrpcErrorsAsFailures`] which supports classifying
     /// gRPC responses and streams based on the `grpc-status` header.
-    pub fn new_for_grpc(inner: S) -> Self {
+    pub fn new_for_grpc(inner: S) -> Self
+    where
+        E: fmt::Display,
+    {
         Self {
             inner,
-            make_classifier: SharedClassifier::new::<E>(GrpcErrorsAsFailures::default()),
+            make_classifier: GrpcErrorsAsFailures::make_classifier(),
             make_span: DefaultMakeSpan::new(),
             on_request: DefaultOnRequest::default(),
             on_response: DefaultOnResponse::default(),


### PR DESCRIPTION
Previously `<ServerErrorsAsFailures as ClassifyResponse<E>>::classify_error` would return `StatusCode::INTERNAL_SERVER_ERROR`.

That is because `classify_error` receives an opaque `&E` so it couldn't do much else without adding more requirements or returning some kind of "an error happened, but I know nothing about it" value.

However creating a `StatusCode::INTERNAL_SERVER_ERROR` out of the blue is very ad-hoc especially since a response was never produced so there is no status code to speak of.

When I implemented the trace middleware in #65 I gave this some more thought. I'm currently thinking requiring `E: fmt::Display` for `ServerErrorsAsFailures` and `GrpcErrorsAsFailures` and then returning something that contains the error's string representation. Its not ideal because we loose the error chain but I'm thinking users who can to customize things further can make their own classifier. We could perhaps require `E: std::error::Error` instead but I'm not sure that wouldn't break some setups. In tower we mainly use `Into<BoxError>` instead of `std::error::Error`.

Note that this only changes the built-in classifiers. It classification traits themselves are not changed.