### PR TITLE
Add `InFlightRequests` - The first metrics middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ These are the middlewares included in this crate:
 - `Compression`: Compression response bodies.
 - `Decompression`: Decompress response bodies.
 - `FollowRedirect`: Follow redirection responses.
+- `InFlightRequests`: Measure the number of requests a service is currently processing.
 - `MapRequestBody`: Apply a transformation to the request body.
 - `MapResponseBody`: Apply a transformation to the response body.
 - `PropagateHeader`: Propagate a header from the request to the response.

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -54,6 +54,7 @@ full = [
     "fs",
     "map-request-body",
     "map-response-body",
+    "metrics",
     "propagate-header",
     "redirect",
     "sensitive-header",
@@ -66,6 +67,7 @@ follow-redirect = ["iri-string", "tower/util"]
 fs = ["tokio/fs", "tokio-util/io", "mime_guess", "mime"]
 map-request-body = []
 map-response-body = []
+metrics = ["tokio/time"]
 propagate-header = []
 redirect = []
 sensitive-header = []

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -18,7 +18,6 @@
 //! use tower_http::{
 //!     add_extension::AddExtensionLayer,
 //!     compression::CompressionLayer,
-//!     metrics::InFlightRequestsLayer,
 //!     propagate_header::PropagateHeaderLayer,
 //!     sensitive_header::{SetSensitiveResponseHeaderLayer, SetSensitiveRequestHeaderLayer},
 //!     set_header::SetResponseHeaderLayer,
@@ -54,16 +53,6 @@
 //!         pool: DatabaseConnectionPool::new(),
 //!     };
 //!
-//!     // Create a `Layer` for counting in-flight requests and its associated counter.
-//!     let (in_flight_requests_layer, counter) = InFlightRequestsLayer::pair();
-//!
-//!     // Spawn a task that will receive the number of in-flight requests every 10 seconds.
-//!     tokio::spawn(
-//!         counter.run_emitter(Duration::from_secs(10), |count: usize| async move {
-//!             update_in_flight_requests_metric(count).await;
-//!         }),
-//!     );
-//!
 //!     // Use `tower`'s `ServiceBuilder` API to build a stack of `tower` middleware
 //!     // wrapping our request handler.
 //!     let service = ServiceBuilder::new()
@@ -75,8 +64,6 @@
 //!         // Mark the `Authorization` header as sensitive on responses
 //!         // This must be applied after `TraceLayer`
 //!         .layer(SetSensitiveResponseHeaderLayer::new(AUTHORIZATION))
-//!         // Keep track of the number of in-flight requests
-//!         .layer(in_flight_requests_layer)
 //!         // Share an `Arc<State>` with all requests
 //!         .layer(AddExtensionLayer::new(Arc::new(state)))
 //!         // Compress responses

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -260,8 +260,8 @@ pub mod trace;
 pub mod follow_redirect;
 
 pub mod classify;
-pub mod services;
 pub mod metrics;
+pub mod services;
 
 /// Error type containing either a body error or an IO error.
 ///

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -259,8 +259,11 @@ pub mod trace;
 #[cfg_attr(docsrs, doc(cfg(feature = "follow-redirect")))]
 pub mod follow_redirect;
 
-pub mod classify;
+#[cfg(feature = "metrics")]
+#[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
 pub mod metrics;
+
+pub mod classify;
 pub mod services;
 
 /// Error type containing either a body error or an IO error.

--- a/tower-http/src/metrics/in_flight_requests.rs
+++ b/tower-http/src/metrics/in_flight_requests.rs
@@ -1,0 +1,283 @@
+//! Measure the number of in-flight requests.
+//!
+//! In-flight requests is the number of requests a service is currently processing. The processing
+//! of a request starts when it is received by the service (`tower::Service::call` is called) and
+//! is considered complete when the entire response body as been generated
+//! (`http_body::Body::poll_{data,trailers}` completes) or when an error occurs along the way.
+//!
+//! # Example
+//!
+//! ```
+//! use tower::{Service, ServiceExt, ServiceBuilder};
+//! use tower_http::metrics::InFlightRequestsLayer;
+//! use http::{Request, Response};
+//! use hyper::Body;
+//! use std::{time::Duration, convert::Infallible};
+//!
+//! async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
+//!     // ...
+//!     # Ok(Response::new(Body::empty()))
+//! }
+//!
+//! async fn update_in_flight_requests_metric(count: usize) {
+//!     // ...
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Create a `Layer` with an associated counter.
+//! let (in_flight_requests_layer, counter) = InFlightRequestsLayer::pair();
+//!
+//! // Spawn a task that will receive the number of in-flight requests every 10 seconds.
+//! tokio::spawn(
+//!     counter.run_emitter(Duration::from_secs(10), |count| async move {
+//!         update_in_flight_requests_metric(count).await;
+//!     }),
+//! );
+//!
+//! let mut service = ServiceBuilder::new()
+//!     // Keep track of the number of in-flight requests. This will increment and decrement
+//!     // `counter` automatically.
+//!     .layer(in_flight_requests_layer)
+//!     .service_fn(handle);
+//!
+//! // Call the service.
+//! let response = service
+//!     .ready()
+//!     .await?
+//!     .call(Request::new(Body::empty()))
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+
+use futures_util::ready;
+use http::Response;
+use http_body::Body;
+use pin_project::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
+    time::Duration,
+};
+use tower_layer::Layer;
+use tower_service::Service;
+
+/// Layer for applying [`InFlightRequests`] which counts the number of in-flight requests.
+///
+/// See the [module docs](crate::metrics::in_flight_requests) for more details.
+#[derive(Clone, Debug)]
+pub struct InFlightRequestsLayer {
+    counter: InFlightRequestsCounter,
+}
+
+impl InFlightRequestsLayer {
+    /// Create a new `InFlightRequestsLayer` and its associated counter.
+    pub fn pair() -> (Self, InFlightRequestsCounter) {
+        let counter = InFlightRequestsCounter::new();
+        let layer = Self::new(counter.clone());
+        (layer, counter)
+    }
+
+    /// Create a new `InFlightRequestsLayer` that will update the given counter.
+    pub fn new(counter: InFlightRequestsCounter) -> Self {
+        Self { counter }
+    }
+}
+
+impl<S> Layer<S> for InFlightRequestsLayer {
+    type Service = InFlightRequests<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        InFlightRequests {
+            inner,
+            counter: self.counter.clone(),
+        }
+    }
+}
+
+/// Middleware that counts the number of in-flight requests.
+///
+/// See the [module docs](crate::metrics::in_flight_requests) for more details.
+#[derive(Clone, Debug)]
+pub struct InFlightRequests<S> {
+    inner: S,
+    counter: InFlightRequestsCounter,
+}
+
+impl<S> InFlightRequests<S> {
+    /// Create a new `InFlightRequests` and its associated counter.
+    pub fn pair(inner: S) -> (Self, InFlightRequestsCounter) {
+        let counter = InFlightRequestsCounter::new();
+        let service = Self::new(inner, counter.clone());
+        (service, counter)
+    }
+
+    /// Create a new `InFlightRequests` that will update the given counter.
+    pub fn new(inner: S, counter: InFlightRequestsCounter) -> Self {
+        Self { inner, counter }
+    }
+
+    define_inner_service_accessors!();
+}
+
+/// An atomic counter that keeps track of the number of in-flight requests.
+///
+/// This will normally combined with [`InFlightRequestsLayer`] or [`InFlightRequests`] which will
+/// update the counter as requests arrive.
+#[derive(Debug, Clone, Default)]
+pub struct InFlightRequestsCounter {
+    count: Arc<AtomicUsize>,
+}
+
+impl InFlightRequestsCounter {
+    /// Create a new `InFlightRequestsCounter`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Get the current number of in-flight requests.
+    pub fn get(&self) -> usize {
+        self.count.load(Ordering::Relaxed)
+    }
+
+    fn increment(&self) -> IncrementGuard {
+        self.count.fetch_add(1, Ordering::Relaxed);
+        IncrementGuard {
+            count: self.count.clone(),
+        }
+    }
+
+    /// Run a future every `interval` which receives the current number of in-flight requests.
+    ///
+    /// This can be used to send the current count to your metrics system.
+    ///
+    /// This function will loop forever so normally it is called with [`tokio::spawn`]:
+    ///
+    /// ```rust,no_run
+    /// use tower_http::metrics::in_flight_requests::InFlightRequestsCounter;
+    /// use std::time::Duration;
+    ///
+    /// let counter = InFlightRequestsCounter::new();
+    ///
+    /// tokio::spawn(
+    ///     counter.run_emitter(Duration::from_secs(10), |count: usize| async move {
+    ///         // Send `count` to metrics system.
+    ///     }),
+    /// );
+    /// ```
+    pub async fn run_emitter<F, Fut>(mut self, interval: Duration, mut emit: F)
+    where
+        F: FnMut(usize) -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send,
+    {
+        let mut interval = tokio::time::interval(interval);
+
+        loop {
+            // if all producers have gone away we don't need to emit anymore
+            match Arc::try_unwrap(self.count) {
+                Ok(_) => return,
+                Err(shared_count) => {
+                    self = Self {
+                        count: shared_count,
+                    }
+                }
+            }
+
+            interval.tick().await;
+            emit(self.get()).await;
+        }
+    }
+}
+
+struct IncrementGuard {
+    count: Arc<AtomicUsize>,
+}
+
+impl Drop for IncrementGuard {
+    fn drop(&mut self) {
+        self.count.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+impl<S, R, ResBody> Service<R> for InFlightRequests<S>
+where
+    S: Service<R, Response = Response<ResBody>>,
+{
+    type Response = Response<ResponseBody<ResBody>>;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        let guard = self.counter.increment();
+        ResponseFuture {
+            inner: self.inner.call(req),
+            guard: Some(guard),
+        }
+    }
+}
+
+/// Response future for [`InFlightRequests`].
+#[pin_project]
+pub struct ResponseFuture<F> {
+    #[pin]
+    inner: F,
+    guard: Option<IncrementGuard>,
+}
+
+impl<F, B, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<Response<B>, E>>,
+{
+    type Output = Result<Response<ResponseBody<B>>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let response = ready!(this.inner.poll(cx))?;
+        let guard = this.guard.take().unwrap();
+        let response = response.map(move |body| ResponseBody { inner: body, guard });
+
+        Poll::Ready(Ok(response))
+    }
+}
+
+/// Response body for [`InFlightRequests`].
+#[pin_project]
+pub struct ResponseBody<B> {
+    #[pin]
+    inner: B,
+    guard: IncrementGuard,
+}
+
+impl<B> Body for ResponseBody<B>
+where
+    B: Body,
+{
+    type Data = B::Data;
+    type Error = B::Error;
+
+    #[inline]
+    fn poll_data(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        self.project().inner.poll_data(cx)
+    }
+
+    #[inline]
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
+        self.project().inner.poll_trailers(cx)
+    }
+}

--- a/tower-http/src/metrics/in_flight_requests.rs
+++ b/tower-http/src/metrics/in_flight_requests.rs
@@ -279,6 +279,16 @@ where
     ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
         self.project().inner.poll_trailers(cx)
     }
+
+    #[inline]
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
 }
 
 #[cfg(test)]

--- a/tower-http/src/metrics/mod.rs
+++ b/tower-http/src/metrics/mod.rs
@@ -1,0 +1,16 @@
+//! Middlewares for adding metrics to services.
+//!
+//! Supported metrics:
+//!
+//! - [In-flight requests][]: Measure the number of requests a service is currently processing.
+//!
+//! [In-flight requests]: in_flight_requests
+
+pub mod in_flight_requests;
+
+// requests per scond
+// error rate
+// throughput, bytes per second/minute
+
+#[doc(inline)]
+pub use self::in_flight_requests::{InFlightRequests, InFlightRequestsLayer};

--- a/tower-http/src/metrics/mod.rs
+++ b/tower-http/src/metrics/mod.rs
@@ -8,9 +8,5 @@
 
 pub mod in_flight_requests;
 
-// requests per scond
-// error rate
-// throughput, bytes per second/minute
-
 #[doc(inline)]
 pub use self::in_flight_requests::{InFlightRequests, InFlightRequestsLayer};


### PR DESCRIPTION
Part of https://github.com/tower-rs/tower-http/issues/57

I think the two killer features of tower-http is going to be easy setup of tracing/logging and metrics. Those are non-trivial pieces of functionality that pretty much everyone needs. Now that the [tracing middleware is in](https://github.com/tower-rs/tower-http/pull/77) I would like to start thinking about metrics.

My initial goal is to cover these metrics:

- Traffic, requests per second/minute
- Number of in flight requests
- Error rate
- Throughput, bytes per second/minute

Each of those will be a separate middleware, starting with in-flight requests as I think its the simplest.

The module structure I'm thinking is:

- `tower_http::metrics` all middlewares related to metrics are here
- The `metrics` module exposes the most important pieces, so `tower_http::metrics::{InFlightRequests, InFlightRequestsLayer}` and so on when we have more middlewares
- Response futures, bodies and other lower level types are in `tower_http::metrics::in_flight_requests`.

This is similar to how `std::collections` do it.

Example usage of `InFlightRequests`:

```rust
use tower::{Service, ServiceExt, ServiceBuilder};
use tower_http::metrics::InFlightRequestsLayer;
use http::{Request, Response};
use hyper::Body;
use std::{time::Duration, convert::Infallible};

async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
    // ...
}

async fn update_in_flight_requests_metric(count: usize) {
    // ...
}

// Create a `Layer` with an associated counter.
let (in_flight_requests_layer, counter) = InFlightRequestsLayer::pair();

// Spawn a task that will receive the number of in-flight requests every 10 seconds.
tokio::spawn(
    counter.run_emitter(Duration::from_secs(10), |count| async move {
        update_in_flight_requests_metric(count).await;
    }),
);

let mut service = ServiceBuilder::new()
    // Keep track of the number of in-flight requests. This will increment and decrement
    // `counter` automatically.
    .layer(in_flight_requests_layer)
    .service_fn(handle);

// Call the service.
let response = service
    .ready()
    .await?
    .call(Request::new(Body::empty()))
    .await?;
```

I'm also considering making a `tower-http-metrics` crate that provides integration between `tower-http` and the excellent [`metrics`](https://crates.io/crates/metrics) which we use at Embark.