### PR TITLE
Override `http_body::Body` methods for `TraceBody`

### DIFF
--- a/examples/warp-key-value-store/src/main.rs
+++ b/examples/warp-key-value-store/src/main.rs
@@ -161,11 +161,11 @@ fn content_length_from_response<B>(response: &Response<B>) -> Option<HeaderValue
 where
     B: HttpBody,
 {
-    if let Some(size) = response.body().size_hint().exact() {
-        Some(HeaderValue::from_str(&size.to_string()).unwrap())
-    } else {
-        None
-    }
+    response
+        .body()
+        .size_hint()
+        .exact()
+        .map(|size| HeaderValue::from_str(&size.to_string()).unwrap())
 }
 
 #[cfg(test)]

--- a/tower-http/src/trace/body.rs
+++ b/tower-http/src/trace/body.rs
@@ -103,4 +103,12 @@ where
 
         Poll::Ready(result)
     }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
 }


### PR DESCRIPTION
Forgot to override these. Is safe since `TraceBody` doesn't change the body chunks.