### PR TITLE
Properly classify errors for built-in classifiers

### DIFF
--- a/tower-http/src/trace/body.rs
+++ b/tower-http/src/trace/body.rs
@@ -5,6 +5,7 @@ use http::HeaderMap;
 use http_body::Body;
 use pin_project::pin_project;
 use std::{
+    fmt,
     pin::Pin,
     task::{Context, Poll},
     time::Instant,
@@ -30,7 +31,8 @@ impl<B, C, OnBodyChunkT, OnEosT, OnFailureT> Body
     for ResponseBody<B, C, OnBodyChunkT, OnEosT, OnFailureT>
 where
     B: Body,
-    C: ClassifyEos<B::Error>,
+    B::Error: fmt::Display + 'static,
+    C: ClassifyEos,
     OnEosT: OnEos,
     OnBodyChunkT: OnBodyChunk<B::Data>,
     OnFailureT: OnFailure<C::FailureClass>,

--- a/tower-http/src/trace/future.rs
+++ b/tower-http/src/trace/future.rs
@@ -32,7 +32,9 @@ impl<Fut, ResBody, E, C, OnResponseT, OnBodyChunkT, OnEosT, OnFailureT> Future
 where
     Fut: Future<Output = Result<Response<ResBody>, E>>,
     ResBody: Body,
-    C: ClassifyResponse<E>,
+    ResBody::Error: std::fmt::Display + 'static,
+    E: std::fmt::Display + 'static,
+    C: ClassifyResponse,
     OnResponseT: OnResponse<ResBody>,
     OnFailureT: OnFailure<C::FailureClass>,
     OnBodyChunkT: OnBodyChunk<ResBody::Data>,

--- a/tower-http/src/trace/layer.rs
+++ b/tower-http/src/trace/layer.rs
@@ -5,7 +5,6 @@ use super::{
 use crate::classify::{
     GrpcErrorsAsFailures, MakeClassifier, ServerErrorsAsFailures, SharedClassifier,
 };
-use std::{fmt, marker::PhantomData};
 use tower_layer::Layer;
 
 /// [`Layer`] that adds high level [tracing] to a [`Service`].
@@ -15,9 +14,9 @@ use tower_layer::Layer;
 /// [`Layer`]: tower_layer::Layer
 /// [tracing]: https://crates.io/crates/tracing
 /// [`Service`]: tower_service::Service
+#[derive(Debug, Copy, Clone)]
 pub struct TraceLayer<
     M,
-    E,
     MakeSpan = DefaultMakeSpan,
     OnRequest = DefaultOnRequest,
     OnResponse = DefaultOnResponse,
@@ -32,39 +31,13 @@ pub struct TraceLayer<
     pub(crate) on_body_chunk: OnBodyChunk,
     pub(crate) on_eos: OnEos,
     pub(crate) on_failure: OnFailure,
-    pub(crate) _error: PhantomData<fn() -> E>,
 }
 
-impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> Clone
-    for TraceLayer<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
-where
-    M: Clone,
-    MakeSpan: Clone,
-    OnRequest: Clone,
-    OnResponse: Clone,
-    OnEos: Clone,
-    OnBodyChunk: Clone,
-    OnFailure: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            on_request: self.on_request.clone(),
-            on_response: self.on_response.clone(),
-            on_failure: self.on_failure.clone(),
-            on_eos: self.on_eos.clone(),
-            on_body_chunk: self.on_body_chunk.clone(),
-            make_span: self.make_span.clone(),
-            make_classifier: self.make_classifier.clone(),
-            _error: self._error,
-        }
-    }
-}
-
-impl<M, E> TraceLayer<M, E> {
+impl<M> TraceLayer<M> {
     /// Create a new [`TraceLayer`] using the given [`MakeClassifier`].
     pub fn new(make_classifier: M) -> Self
     where
-        M: MakeClassifier<E>,
+        M: MakeClassifier,
     {
         Self {
             make_classifier,
@@ -74,13 +47,12 @@ impl<M, E> TraceLayer<M, E> {
             on_eos: DefaultOnEos::default(),
             on_body_chunk: DefaultOnBodyChunk::default(),
             on_response: DefaultOnResponse::default(),
-            _error: PhantomData,
         }
     }
 }
 
-impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
-    TraceLayer<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
+impl<M, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
+    TraceLayer<M, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
 {
     /// Customize what to do when a request is received.
     ///
@@ -90,7 +62,7 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
     pub fn on_request<NewOnRequest>(
         self,
         new_on_request: NewOnRequest,
-    ) -> TraceLayer<M, E, MakeSpan, NewOnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> {
+    ) -> TraceLayer<M, MakeSpan, NewOnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> {
         TraceLayer {
             on_request: new_on_request,
             on_failure: self.on_failure,
@@ -99,7 +71,6 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             make_span: self.make_span,
             on_response: self.on_response,
             make_classifier: self.make_classifier,
-            _error: self._error,
         }
     }
 
@@ -111,7 +82,7 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
     pub fn on_response<NewOnResponse>(
         self,
         new_on_response: NewOnResponse,
-    ) -> TraceLayer<M, E, MakeSpan, OnRequest, NewOnResponse, OnBodyChunk, OnEos, OnFailure> {
+    ) -> TraceLayer<M, MakeSpan, OnRequest, NewOnResponse, OnBodyChunk, OnEos, OnFailure> {
         TraceLayer {
             on_response: new_on_response,
             on_request: self.on_request,
@@ -120,7 +91,6 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_failure: self.on_failure,
             make_span: self.make_span,
             make_classifier: self.make_classifier,
-            _error: self._error,
         }
     }
 
@@ -132,7 +102,7 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
     pub fn on_body_chunk<NewOnBodyChunk>(
         self,
         new_on_body_chunk: NewOnBodyChunk,
-    ) -> TraceLayer<M, E, MakeSpan, OnRequest, OnResponse, NewOnBodyChunk, OnEos, OnFailure> {
+    ) -> TraceLayer<M, MakeSpan, OnRequest, OnResponse, NewOnBodyChunk, OnEos, OnFailure> {
         TraceLayer {
             on_body_chunk: new_on_body_chunk,
             on_eos: self.on_eos,
@@ -141,7 +111,6 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             make_span: self.make_span,
             on_response: self.on_response,
             make_classifier: self.make_classifier,
-            _error: self._error,
         }
     }
 
@@ -153,7 +122,7 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
     pub fn on_eos<NewOnEos>(
         self,
         new_on_eos: NewOnEos,
-    ) -> TraceLayer<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, NewOnEos, OnFailure> {
+    ) -> TraceLayer<M, MakeSpan, OnRequest, OnResponse, OnBodyChunk, NewOnEos, OnFailure> {
         TraceLayer {
             on_eos: new_on_eos,
             on_body_chunk: self.on_body_chunk,
@@ -162,7 +131,6 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             make_span: self.make_span,
             on_response: self.on_response,
             make_classifier: self.make_classifier,
-            _error: self._error,
         }
     }
 
@@ -174,7 +142,7 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
     pub fn on_failure<NewOnFailure>(
         self,
         new_on_failure: NewOnFailure,
-    ) -> TraceLayer<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, NewOnFailure> {
+    ) -> TraceLayer<M, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, NewOnFailure> {
         TraceLayer {
             on_failure: new_on_failure,
             on_request: self.on_request,
@@ -183,7 +151,6 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             make_span: self.make_span,
             on_response: self.on_response,
             make_classifier: self.make_classifier,
-            _error: self._error,
         }
     }
 
@@ -196,7 +163,7 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
     pub fn make_span_with<NewMakeSpan>(
         self,
         new_make_span: NewMakeSpan,
-    ) -> TraceLayer<M, E, NewMakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> {
+    ) -> TraceLayer<M, NewMakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> {
         TraceLayer {
             make_span: new_make_span,
             on_request: self.on_request,
@@ -205,47 +172,44 @@ impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_eos: self.on_eos,
             on_response: self.on_response,
             make_classifier: self.make_classifier,
-            _error: self._error,
         }
     }
 }
 
-impl<E> TraceLayer<SharedClassifier<ServerErrorsAsFailures>, E> {
+impl TraceLayer<SharedClassifier<ServerErrorsAsFailures>> {
     /// Create a new [`TraceLayer`] using [`ServerErrorsAsFailures`] which supports classifying
     /// regular HTTP responses based on the status code.
     pub fn new_for_http() -> Self {
         Self {
-            make_classifier: SharedClassifier::new::<E>(ServerErrorsAsFailures::default()),
+            make_classifier: SharedClassifier::new(ServerErrorsAsFailures::default()),
             make_span: DefaultMakeSpan::new(),
             on_response: DefaultOnResponse::default(),
             on_request: DefaultOnRequest::default(),
             on_body_chunk: DefaultOnBodyChunk::default(),
             on_eos: DefaultOnEos::default(),
             on_failure: DefaultOnFailure::default(),
-            _error: PhantomData,
         }
     }
 }
 
-impl<E> TraceLayer<SharedClassifier<GrpcErrorsAsFailures>, E> {
+impl TraceLayer<SharedClassifier<GrpcErrorsAsFailures>> {
     /// Create a new [`TraceLayer`] using [`GrpcErrorsAsFailures`] which supports classifying
     /// gRPC responses and streams based on the `grpc-status` header.
     pub fn new_for_grpc() -> Self {
         Self {
-            make_classifier: SharedClassifier::new::<E>(GrpcErrorsAsFailures::default()),
+            make_classifier: SharedClassifier::new(GrpcErrorsAsFailures::default()),
             make_span: DefaultMakeSpan::new(),
             on_response: DefaultOnResponse::default(),
             on_request: DefaultOnRequest::default(),
             on_body_chunk: DefaultOnBodyChunk::default(),
             on_eos: DefaultOnEos::default(),
             on_failure: DefaultOnFailure::default(),
-            _error: PhantomData,
         }
     }
 }
 
-impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> Layer<S>
-    for TraceLayer<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
+impl<S, M, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> Layer<S>
+    for TraceLayer<M, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
 where
     M: Clone,
     MakeSpan: Clone,
@@ -255,7 +219,7 @@ where
     OnBodyChunk: Clone,
     OnFailure: Clone,
 {
-    type Service = Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>;
+    type Service = Trace<S, M, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>;
 
     fn layer(&self, inner: S) -> Self::Service {
         Trace {
@@ -267,31 +231,6 @@ where
             on_body_chunk: self.on_body_chunk.clone(),
             on_response: self.on_response.clone(),
             on_failure: self.on_failure.clone(),
-            _error: PhantomData,
         }
-    }
-}
-
-impl<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> fmt::Debug
-    for TraceLayer<M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
-where
-    M: fmt::Debug,
-    MakeSpan: fmt::Debug,
-    OnRequest: fmt::Debug,
-    OnResponse: fmt::Debug,
-    OnEos: fmt::Debug,
-    OnBodyChunk: fmt::Debug,
-    OnFailure: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TraceLayer")
-            .field("make_classifier", &self.make_classifier)
-            .field("make_span", &self.make_span)
-            .field("on_request", &self.on_request)
-            .field("on_response", &self.on_response)
-            .field("on_body_chunk", &self.on_body_chunk)
-            .field("on_eos", &self.on_eos)
-            .field("on_failure", &self.on_failure)
-            .finish()
     }
 }

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -407,9 +407,11 @@ mod tests {
                     ON_EOS.fetch_add(1, Ordering::SeqCst);
                 },
             )
-            .on_failure(|_class: ServerErrorsFailureClass, _latency: Duration, _span: &Span| {
-                ON_FAILURE.fetch_add(1, Ordering::SeqCst);
-            });
+            .on_failure(
+                |_class: ServerErrorsFailureClass, _latency: Duration, _span: &Span| {
+                    ON_FAILURE.fetch_add(1, Ordering::SeqCst);
+                },
+            );
 
         let mut svc = ServiceBuilder::new().layer(trace_layer).service_fn(echo);
 
@@ -456,9 +458,11 @@ mod tests {
                     ON_EOS.fetch_add(1, Ordering::SeqCst);
                 },
             )
-            .on_failure(|_class: ServerErrorsFailureClass, _latency: Duration, _span: &Span| {
-                ON_FAILURE.fetch_add(1, Ordering::SeqCst);
-            });
+            .on_failure(
+                |_class: ServerErrorsFailureClass, _latency: Duration, _span: &Span| {
+                    ON_FAILURE.fetch_add(1, Ordering::SeqCst);
+                },
+            );
 
         let mut svc = ServiceBuilder::new()
             .layer(trace_layer)

--- a/tower-http/src/trace/service.rs
+++ b/tower-http/src/trace/service.rs
@@ -10,7 +10,6 @@ use http::{Request, Response};
 use http_body::Body;
 use std::{
     fmt,
-    marker::PhantomData,
     task::{Context, Poll},
     time::Instant,
 };
@@ -22,10 +21,10 @@ use tower_service::Service;
 ///
 /// [tracing]: https://crates.io/crates/tracing
 /// [`Service`]: tower_service::Service
+#[derive(Debug, Clone, Copy)]
 pub struct Trace<
     S,
     M,
-    E,
     MakeSpan = DefaultMakeSpan,
     OnRequest = DefaultOnRequest,
     OnResponse = DefaultOnResponse,
@@ -41,14 +40,13 @@ pub struct Trace<
     pub(crate) on_body_chunk: OnBodyChunk,
     pub(crate) on_eos: OnEos,
     pub(crate) on_failure: OnFailure,
-    pub(crate) _error: PhantomData<fn() -> E>,
 }
 
-impl<S, M, E> Trace<S, M, E> {
+impl<S, M> Trace<S, M> {
     /// Create a new [`Trace`] using the given [`MakeClassifier`].
     pub fn new(inner: S, make_classifier: M) -> Self
     where
-        M: MakeClassifier<E>,
+        M: MakeClassifier,
     {
         Self {
             inner,
@@ -59,23 +57,22 @@ impl<S, M, E> Trace<S, M, E> {
             on_body_chunk: DefaultOnBodyChunk::default(),
             on_eos: DefaultOnEos::default(),
             on_failure: DefaultOnFailure::default(),
-            _error: PhantomData,
         }
     }
 
     /// Returns a new [`Layer`] that wraps services with a [`TraceLayer`] middleware.
     ///
     /// [`Layer`]: tower_layer::Layer
-    pub fn layer(make_classifier: M) -> TraceLayer<M, E>
+    pub fn layer(make_classifier: M) -> TraceLayer<M>
     where
-        M: MakeClassifier<E>,
+        M: MakeClassifier,
     {
         TraceLayer::new(make_classifier)
     }
 }
 
-impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
-    Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
+impl<S, M, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
+    Trace<S, M, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
 {
     define_inner_service_accessors!();
 
@@ -87,7 +84,7 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
     pub fn on_request<NewOnRequest>(
         self,
         new_on_request: NewOnRequest,
-    ) -> Trace<S, M, E, MakeSpan, NewOnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> {
+    ) -> Trace<S, M, MakeSpan, NewOnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> {
         Trace {
             on_request: new_on_request,
             inner: self.inner,
@@ -97,7 +94,6 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             make_span: self.make_span,
             on_response: self.on_response,
             make_classifier: self.make_classifier,
-            _error: self._error,
         }
     }
 
@@ -109,7 +105,7 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
     pub fn on_response<NewOnResponse>(
         self,
         new_on_response: NewOnResponse,
-    ) -> Trace<S, M, E, MakeSpan, OnRequest, NewOnResponse, OnBodyChunk, OnEos, OnFailure> {
+    ) -> Trace<S, M, MakeSpan, OnRequest, NewOnResponse, OnBodyChunk, OnEos, OnFailure> {
         Trace {
             on_response: new_on_response,
             inner: self.inner,
@@ -119,7 +115,6 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_eos: self.on_eos,
             make_span: self.make_span,
             make_classifier: self.make_classifier,
-            _error: self._error,
         }
     }
 
@@ -131,7 +126,7 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
     pub fn on_body_chunk<NewOnBodyChunk>(
         self,
         new_on_body_chunk: NewOnBodyChunk,
-    ) -> Trace<S, M, E, MakeSpan, OnRequest, OnResponse, NewOnBodyChunk, OnEos, OnFailure> {
+    ) -> Trace<S, M, MakeSpan, OnRequest, OnResponse, NewOnBodyChunk, OnEos, OnFailure> {
         Trace {
             on_body_chunk: new_on_body_chunk,
             on_eos: self.on_eos,
@@ -141,7 +136,6 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_request: self.on_request,
             on_response: self.on_response,
             make_classifier: self.make_classifier,
-            _error: self._error,
         }
     }
 
@@ -153,7 +147,7 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
     pub fn on_eos<NewOnEos>(
         self,
         new_on_eos: NewOnEos,
-    ) -> Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, NewOnEos, OnFailure> {
+    ) -> Trace<S, M, MakeSpan, OnRequest, OnResponse, OnBodyChunk, NewOnEos, OnFailure> {
         Trace {
             on_eos: new_on_eos,
             make_span: self.make_span,
@@ -163,7 +157,6 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_body_chunk: self.on_body_chunk,
             on_response: self.on_response,
             make_classifier: self.make_classifier,
-            _error: self._error,
         }
     }
 
@@ -175,7 +168,7 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
     pub fn on_failure<NewOnFailure>(
         self,
         new_on_failure: NewOnFailure,
-    ) -> Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, NewOnFailure> {
+    ) -> Trace<S, M, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, NewOnFailure> {
         Trace {
             on_failure: new_on_failure,
             inner: self.inner,
@@ -185,7 +178,6 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_eos: self.on_eos,
             on_response: self.on_response,
             make_classifier: self.make_classifier,
-            _error: self._error,
         }
     }
 
@@ -198,7 +190,7 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
     pub fn make_span_with<NewMakeSpan>(
         self,
         new_make_span: NewMakeSpan,
-    ) -> Trace<S, M, E, NewMakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> {
+    ) -> Trace<S, M, NewMakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> {
         Trace {
             make_span: new_make_span,
             inner: self.inner,
@@ -208,16 +200,14 @@ impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
             on_response: self.on_response,
             on_eos: self.on_eos,
             make_classifier: self.make_classifier,
-            _error: self._error,
         }
     }
 }
 
-impl<S, E>
+impl<S>
     Trace<
         S,
         SharedClassifier<ServerErrorsAsFailures>,
-        E,
         DefaultMakeSpan,
         DefaultOnRequest,
         DefaultOnResponse,
@@ -231,23 +221,21 @@ impl<S, E>
     pub fn new_for_http(inner: S) -> Self {
         Self {
             inner,
-            make_classifier: SharedClassifier::new::<E>(ServerErrorsAsFailures::default()),
+            make_classifier: SharedClassifier::new(ServerErrorsAsFailures::default()),
             make_span: DefaultMakeSpan::new(),
             on_request: DefaultOnRequest::default(),
             on_response: DefaultOnResponse::default(),
             on_body_chunk: DefaultOnBodyChunk::default(),
             on_eos: DefaultOnEos::default(),
             on_failure: DefaultOnFailure::default(),
-            _error: PhantomData,
         }
     }
 }
 
-impl<S, E>
+impl<S>
     Trace<
         S,
         SharedClassifier<GrpcErrorsAsFailures>,
-        E,
         DefaultMakeSpan,
         DefaultOnRequest,
         DefaultOnResponse,
@@ -261,14 +249,13 @@ impl<S, E>
     pub fn new_for_grpc(inner: S) -> Self {
         Self {
             inner,
-            make_classifier: SharedClassifier::new::<E>(GrpcErrorsAsFailures::default()),
+            make_classifier: SharedClassifier::new(GrpcErrorsAsFailures::default()),
             make_span: DefaultMakeSpan::new(),
             on_request: DefaultOnRequest::default(),
             on_response: DefaultOnResponse::default(),
             on_body_chunk: DefaultOnBodyChunk::default(),
             on_eos: DefaultOnEos::default(),
             on_failure: DefaultOnFailure::default(),
-            _error: PhantomData,
         }
     }
 }
@@ -285,12 +272,14 @@ impl<
         OnEosT,
         MakeSpanT,
     > Service<Request<ReqBody>>
-    for Trace<S, M, S::Error, MakeSpanT, OnRequestT, OnResponseT, OnBodyChunkT, OnEosT, OnFailureT>
+    for Trace<S, M, MakeSpanT, OnRequestT, OnResponseT, OnBodyChunkT, OnEosT, OnFailureT>
 where
     S: Service<Request<ReqBody>, Response = Response<ResBody>>,
     ReqBody: Body,
     ResBody: Body,
-    M: MakeClassifier<S::Error>,
+    ResBody::Error: fmt::Display + 'static,
+    S::Error: fmt::Display + 'static,
+    M: MakeClassifier,
     M::Classifier: Clone,
     MakeSpanT: MakeSpan<ReqBody>,
     OnRequestT: OnRequest<ReqBody>,
@@ -332,58 +321,5 @@ where
             on_failure: Some(self.on_failure.clone()),
             start,
         }
-    }
-}
-
-impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> Clone
-    for Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
-where
-    S: Clone,
-    M: Clone,
-    MakeSpan: Clone,
-    OnFailure: Clone,
-    OnRequest: Clone,
-    OnResponse: Clone,
-    OnBodyChunk: Clone,
-    OnEos: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-            on_failure: self.on_failure.clone(),
-            make_span: self.make_span.clone(),
-            on_response: self.on_response.clone(),
-            on_body_chunk: self.on_body_chunk.clone(),
-            on_eos: self.on_eos.clone(),
-            make_classifier: self.make_classifier.clone(),
-            on_request: self.on_request.clone(),
-            _error: self._error,
-        }
-    }
-}
-
-impl<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure> fmt::Debug
-    for Trace<S, M, E, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
-where
-    S: fmt::Debug,
-    M: fmt::Debug,
-    MakeSpan: fmt::Debug,
-    OnFailure: fmt::Debug,
-    OnRequest: fmt::Debug,
-    OnBodyChunk: fmt::Debug,
-    OnResponse: fmt::Debug,
-    OnEos: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Trace")
-            .field("inner", &self.inner)
-            .field("make_classifier", &self.make_classifier)
-            .field("make_span", &self.make_span)
-            .field("on_request", &self.on_request)
-            .field("on_response", &self.on_response)
-            .field("on_body_chunk", &self.on_body_chunk)
-            .field("on_eos", &self.on_eos)
-            .field("on_failure", &self.on_failure)
-            .finish()
     }
 }


### PR DESCRIPTION
This supersedes #84 which didn't work and was way too complicated.

The problem that this addresses is that previously `<ServerErrorsAsFailures as ClassifyResponse>::classify_error` would return `StatusCode::INTERNAL_SERVER_ERROR`. Instead the error is now formatted using `fmt::Display` so as little info is lost as possible.

As this is a breaking change its something we have to merge before shipping 0.1.

## Why did it return `StatusCode::INTERNAL_SERVER_ERROR` in the first place?

On `master` the `ClassifyResponse` trait is defined as:

```rust
pub trait ClassifyResponse<E> {
    type FailureClass;
    type ClassifyEos: ClassifyEos<E, FailureClass = Self::FailureClass>;

    fn classify_response<B>(
        self,
        res: &Response<B>,
    ) -> ClassifiedResponse<Self::FailureClass, Self::ClassifyEos>;

    fn classify_error(self, error: &E) -> Self::FailureClass;
}
```

Since `E` was a generic type, `ServerErrorsAsFailures` couldn't do anything with the `error: &E` it got in `classify_error`. It has to either add more trait bounds to `E` or return some kind of sentinel value.

Adding bounds doesn't work because Tonic doesn't use the same error type across its `Service` and `Body` implementations. So `E` would be bound to `Service::Error` is and then type error when it got to `Body::Error`. There were no issues with the warp example which I assume is because [it uses `Infallible` as the error type](https://github.com/seanmonstar/warp/blob/b6d1fc0719604ef1010aec00544408e6af1289a5/src/filter/service.rs#L93) which got coerced to `hyper::Error` in the `Body`, I suppose 🤷 

Having `E` bound on the trait also meant that anything that contained a `ClassifyResponse` would have to be generic over `E` as well. That lead to a lot boilerplate in the tracing middleware.

So therefore `ServerErrorsAsFailures` wouldn't put any bounds on `E` and instead return a sentinel value.

## The fix

This changes the `ClassifyResponse` to instead bind `E` on the `classify_error` method with a `fmt::Display + 'static` bound. So the definition is now:

```rust
pub trait ClassifyResponse {
    type FailureClass;
    type ClassifyEos: ClassifyEos<FailureClass = Self::FailureClass>;

    fn classify_response<B>(
        self,
        res: &Response<B>,
    ) -> ClassifiedResponse<Self::FailureClass, Self::ClassifyEos>;

    fn classify_error<E>(self, error: &E) -> Self::FailureClass
    where
        E: fmt::Display + 'static;
}
```

We cannot use `E: std::fmt::Error` since `Box<dyn Error>` doesn't implement `Error` so `fmt::Display` is the second best option. `Box<dyn Error>` does implement `fmt::Display`. It does mean we loose the ability to format the full error chain but I don't see a way to resolve that.

`'static` is added such that `E` implicitly will implement `Any` to allow for downcasting. That can be done with `(error as &dyn Any).downcast_ref::<SomeOtherError>()`.

The failure class of `ServerErrorsAsFailures` now becomes either a status code or an `fmt::Display` formatted error:

```rust
/// Result of doing a classification.
#[derive(Debug)]
pub enum ClassifiedResponse<FailureClass, ClassifyEos> {
    /// The response was able to be classified immediately.
    Ready(Result<(), FailureClass>),
    /// We have to wait until the end of a streaming response to classify it.
    RequiresEos(ClassifyEos),
}
```

`GrpcErrorsAsFailures` was changed in a very similar way.

## Additional wins

Since `ClassifyResponse` is no longer generic over the error type `Trace` could remove that from its list of generic type params. That meant we could derive `Clone` and `Debug` impls which is much cleaner.