### PR TITLE
Pass the current span to all `Trace` callbacks

### DIFF
--- a/examples/warp-key-value-store/src/main.rs
+++ b/examples/warp-key-value-store/src/main.rs
@@ -71,7 +71,7 @@ async fn serve_forever(listener: TcpListener) -> Result<(), hyper::Error> {
         // Add high level tracing/logging to all requests
         .layer(
             TraceLayer::new_for_http()
-                .on_body_chunk(|chunk: &Bytes, latency: Duration| {
+                .on_body_chunk(|chunk: &Bytes, latency: Duration, _current_span: &tracing::Span| {
                     tracing::trace!(size_bytes = chunk.len(), latency = ?latency, "sending body chunk")
                 })
                 .make_span_with(DefaultMakeSpan::new().include_headers(true))

--- a/examples/warp-key-value-store/src/main.rs
+++ b/examples/warp-key-value-store/src/main.rs
@@ -71,7 +71,7 @@ async fn serve_forever(listener: TcpListener) -> Result<(), hyper::Error> {
         // Add high level tracing/logging to all requests
         .layer(
             TraceLayer::new_for_http()
-                .on_body_chunk(|chunk: &Bytes, latency: Duration, _span: &tracing::Span| {
+                .on_body_chunk(|chunk: &Bytes, latency: Duration, _: &tracing::Span| {
                     tracing::trace!(size_bytes = chunk.len(), latency = ?latency, "sending body chunk")
                 })
                 .make_span_with(DefaultMakeSpan::new().include_headers(true))

--- a/examples/warp-key-value-store/src/main.rs
+++ b/examples/warp-key-value-store/src/main.rs
@@ -161,11 +161,11 @@ fn content_length_from_response<B>(response: &Response<B>) -> Option<HeaderValue
 where
     B: HttpBody,
 {
-    if let Some(size) = response.body().size_hint().exact() {
-        Some(HeaderValue::from_str(&size.to_string()).unwrap())
-    } else {
-        None
-    }
+    response
+        .body()
+        .size_hint()
+        .exact()
+        .map(|size| HeaderValue::from_str(&size.to_string()).unwrap())
 }
 
 #[cfg(test)]

--- a/examples/warp-key-value-store/src/main.rs
+++ b/examples/warp-key-value-store/src/main.rs
@@ -71,7 +71,7 @@ async fn serve_forever(listener: TcpListener) -> Result<(), hyper::Error> {
         // Add high level tracing/logging to all requests
         .layer(
             TraceLayer::new_for_http()
-                .on_body_chunk(|chunk: &Bytes, latency: Duration, _current_span: &tracing::Span| {
+                .on_body_chunk(|chunk: &Bytes, latency: Duration, _span: &tracing::Span| {
                     tracing::trace!(size_bytes = chunk.len(), latency = ?latency, "sending body chunk")
                 })
                 .make_span_with(DefaultMakeSpan::new().include_headers(true))

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -157,6 +157,7 @@
 //! [`Service`]: https://docs.rs/tower/latest/tower/trait.Service.html
 //! [chat]: https://discord.gg/tokio
 //! [issue]: https://github.com/tower-rs/tower-http/issues/new
+//! [`Trace`]: crate::trace::Trace
 
 #![doc(html_root_url = "https://docs.rs/tower-http/0.1.0")]
 #![warn(

--- a/tower-http/src/trace/body.rs
+++ b/tower-http/src/trace/body.rs
@@ -56,14 +56,14 @@ where
 
         match &result {
             Ok(chunk) => {
-                this.on_body_chunk.on_body_chunk(chunk, latency);
+                this.on_body_chunk.on_body_chunk(chunk, latency, this.span);
             }
             Err(err) => {
                 if let Some((classify_eos, mut on_failure)) =
                     this.classify_eos.take().zip(this.on_failure.take())
                 {
                     let failure_class = classify_eos.classify_error(err);
-                    on_failure.on_failure(failure_class, latency);
+                    on_failure.on_failure(failure_class, latency, this.span);
                 }
             }
         }
@@ -87,16 +87,16 @@ where
             match &result {
                 Ok(trailers) => {
                     if let Err(failure_class) = classify_eos.classify_eos(trailers.as_ref()) {
-                        on_failure.on_failure(failure_class, latency);
+                        on_failure.on_failure(failure_class, latency, this.span);
                     }
 
                     if let Some((on_eos, stream_start)) = this.on_eos.take() {
-                        on_eos.on_eos(trailers.as_ref(), stream_start.elapsed());
+                        on_eos.on_eos(trailers.as_ref(), stream_start.elapsed(), this.span);
                     }
                 }
                 Err(err) => {
                     let failure_class = classify_eos.classify_error(err);
-                    on_failure.on_failure(failure_class, latency);
+                    on_failure.on_failure(failure_class, latency, this.span);
                 }
             }
         }

--- a/tower-http/src/trace/future.rs
+++ b/tower-http/src/trace/future.rs
@@ -59,16 +59,16 @@ where
                 let classification = classifier.classify_response(&res);
                 let start = *this.start;
 
+                this.on_response
+                    .take()
+                    .unwrap()
+                    .on_response(&res, latency, this.span);
+
                 match classification {
                     ClassifiedResponse::Ready(classification) => {
                         if let Err(failure_class) = classification {
                             on_failure.on_failure(failure_class, latency, this.span);
                         }
-
-                        this.on_response
-                            .take()
-                            .unwrap()
-                            .on_response(&res, latency, this.span);
 
                         let span = this.span.clone();
                         let res = res.map(|body| ResponseBody {
@@ -84,11 +84,6 @@ where
                         Poll::Ready(Ok(res))
                     }
                     ClassifiedResponse::RequiresEos(classify_eos) => {
-                        this.on_response
-                            .take()
-                            .unwrap()
-                            .on_response(&res, latency, this.span);
-
                         let span = this.span.clone();
                         let res = res.map(|body| ResponseBody {
                             inner: body,

--- a/tower-http/src/trace/future.rs
+++ b/tower-http/src/trace/future.rs
@@ -62,10 +62,13 @@ where
                 match classification {
                     ClassifiedResponse::Ready(classification) => {
                         if let Err(failure_class) = classification {
-                            on_failure.on_failure(failure_class, latency);
+                            on_failure.on_failure(failure_class, latency, this.span);
                         }
 
-                        this.on_response.take().unwrap().on_response(&res, latency);
+                        this.on_response
+                            .take()
+                            .unwrap()
+                            .on_response(&res, latency, this.span);
 
                         let span = this.span.clone();
                         let res = res.map(|body| ResponseBody {
@@ -81,7 +84,10 @@ where
                         Poll::Ready(Ok(res))
                     }
                     ClassifiedResponse::RequiresEos(classify_eos) => {
-                        this.on_response.take().unwrap().on_response(&res, latency);
+                        this.on_response
+                            .take()
+                            .unwrap()
+                            .on_response(&res, latency, this.span);
 
                         let span = this.span.clone();
                         let res = res.map(|body| ResponseBody {
@@ -100,7 +106,7 @@ where
             }
             Err(err) => {
                 let failure_class = classifier.classify_error(&err);
-                on_failure.on_failure(failure_class, latency);
+                on_failure.on_failure(failure_class, latency, this.span);
 
                 Poll::Ready(Err(err))
             }

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -178,7 +178,7 @@
 //!             .on_response(())
 //!             .on_body_chunk(())
 //!             .on_eos(())
-//!             .on_failure(|error: StatusCode, latency: Duration, span: &Span| {
+//!             .on_failure(|error: StatusCode, latency: Duration, _: &Span| {
 //!                 tracing::debug!("something went wrong")
 //!             })
 //!     )

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -121,19 +121,19 @@
 //!             .make_span_with(|request: &Request<Body>| {
 //!                 tracing::debug_span!("http-request")
 //!             })
-//!             .on_request(|request: &Request<Body>, span: &Span| {
+//!             .on_request(|request: &Request<Body>, _span: &Span| {
 //!                 tracing::debug!("started {} {}", request.method(), request.uri().path())
 //!             })
-//!             .on_response(|response: &Response<Body>, latency: Duration, span: &Span| {
+//!             .on_response(|response: &Response<Body>, latency: Duration, _span: &Span| {
 //!                 tracing::debug!("response generated in {:?}", latency)
 //!             })
-//!             .on_body_chunk(|chunk: &Bytes, latency: Duration, span: &Span| {
+//!             .on_body_chunk(|chunk: &Bytes, latency: Duration, _span: &Span| {
 //!                 tracing::debug!("sending {} bytes", chunk.len())
 //!             })
-//!             .on_eos(|trailers: Option<&HeaderMap>, stream_duration: Duration, span: &Span| {
+//!             .on_eos(|trailers: Option<&HeaderMap>, stream_duration: Duration, _span: &Span| {
 //!                 tracing::debug!("stream closed after {:?}", stream_duration)
 //!             })
-//!             .on_failure(|error: StatusCode, latency: Duration, span: &Span| {
+//!             .on_failure(|error: StatusCode, latency: Duration, _span: &Span| {
 //!                 tracing::debug!("something went wrong")
 //!             })
 //!     )
@@ -178,7 +178,7 @@
 //!             .on_response(())
 //!             .on_body_chunk(())
 //!             .on_eos(())
-//!             .on_failure(|error: StatusCode, latency: Duration, _: &Span| {
+//!             .on_failure(|error: StatusCode, latency: Duration, _span: &Span| {
 //!                 tracing::debug!("something went wrong")
 //!             })
 //!     )

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -121,19 +121,19 @@
 //!             .make_span_with(|request: &Request<Body>| {
 //!                 tracing::debug_span!("http-request")
 //!             })
-//!             .on_request(|request: &Request<Body>, current_span: &Span| {
+//!             .on_request(|request: &Request<Body>, span: &Span| {
 //!                 tracing::debug!("started {} {}", request.method(), request.uri().path())
 //!             })
-//!             .on_response(|response: &Response<Body>, latency: Duration, current_span: &Span| {
+//!             .on_response(|response: &Response<Body>, latency: Duration, span: &Span| {
 //!                 tracing::debug!("response generated in {:?}", latency)
 //!             })
-//!             .on_body_chunk(|chunk: &Bytes, latency: Duration, current_span: &Span| {
+//!             .on_body_chunk(|chunk: &Bytes, latency: Duration, span: &Span| {
 //!                 tracing::debug!("sending {} bytes", chunk.len())
 //!             })
-//!             .on_eos(|trailers: Option<&HeaderMap>, stream_duration: Duration, current_span: &Span| {
+//!             .on_eos(|trailers: Option<&HeaderMap>, stream_duration: Duration, span: &Span| {
 //!                 tracing::debug!("stream closed after {:?}", stream_duration)
 //!             })
-//!             .on_failure(|error: StatusCode, latency: Duration, current_span: &Span| {
+//!             .on_failure(|error: StatusCode, latency: Duration, span: &Span| {
 //!                 tracing::debug!("something went wrong")
 //!             })
 //!     )
@@ -178,7 +178,7 @@
 //!             .on_response(())
 //!             .on_body_chunk(())
 //!             .on_eos(())
-//!             .on_failure(|error: StatusCode, latency: Duration, current_span: &Span| {
+//!             .on_failure(|error: StatusCode, latency: Duration, span: &Span| {
 //!                 tracing::debug!("something went wrong")
 //!             })
 //!     )

--- a/tower-http/src/trace/on_body_chunk.rs
+++ b/tower-http/src/trace/on_body_chunk.rs
@@ -1,4 +1,5 @@
 use std::time::Duration;
+use tracing::Span;
 
 /// Trait used to tell [`Trace`] what to do when a body chunk has been sent.
 ///
@@ -8,25 +9,28 @@ pub trait OnBodyChunk<B> {
     ///
     /// `latency` is the duration since the response was sent or since the last body chunk as sent.
     ///
+    /// `current_span` can be used to record field values that weren't know when the span was
+    /// created.
+    ///
     /// If you're using [hyper] as your server `B` will most likely be [`Bytes`].
     ///
     /// [hyper]: https://hyper.rs
     /// [`Bytes`]: https://docs.rs/bytes/latest/bytes/struct.Bytes.html
-    fn on_body_chunk(&mut self, chunk: &B, latency: Duration);
+    fn on_body_chunk(&mut self, chunk: &B, latency: Duration, current_span: &Span);
 }
 
 impl<B, F> OnBodyChunk<B> for F
 where
-    F: FnMut(&B, Duration),
+    F: FnMut(&B, Duration, &Span),
 {
-    fn on_body_chunk(&mut self, chunk: &B, latency: Duration) {
-        self(chunk, latency)
+    fn on_body_chunk(&mut self, chunk: &B, latency: Duration, current_span: &Span) {
+        self(chunk, latency, current_span)
     }
 }
 
 impl<B> OnBodyChunk<B> for () {
     #[inline]
-    fn on_body_chunk(&mut self, _: &B, _: Duration) {}
+    fn on_body_chunk(&mut self, _: &B, _: Duration, _: &Span) {}
 }
 
 /// The default [`OnBodyChunk`] implementation used by [`Trace`].
@@ -48,5 +52,5 @@ impl DefaultOnBodyChunk {
 
 impl<B> OnBodyChunk<B> for DefaultOnBodyChunk {
     #[inline]
-    fn on_body_chunk(&mut self, _: &B, _: Duration) {}
+    fn on_body_chunk(&mut self, _: &B, _: Duration, _: &Span) {}
 }

--- a/tower-http/src/trace/on_body_chunk.rs
+++ b/tower-http/src/trace/on_body_chunk.rs
@@ -9,7 +9,7 @@ pub trait OnBodyChunk<B> {
     ///
     /// `latency` is the duration since the response was sent or since the last body chunk as sent.
     ///
-    /// `current_span` can be used to record field values that weren't know when the span was
+    /// `current_span` can be used to record field values that weren't known when the span was
     /// created.
     ///
     /// If you're using [hyper] as your server `B` will most likely be [`Bytes`].

--- a/tower-http/src/trace/on_body_chunk.rs
+++ b/tower-http/src/trace/on_body_chunk.rs
@@ -9,8 +9,13 @@ pub trait OnBodyChunk<B> {
     ///
     /// `latency` is the duration since the response was sent or since the last body chunk as sent.
     ///
-    /// `span` can be used to record field values that weren't known when the span was
+    /// `span` is the `tracing` [`Span`] corresponding to this request, produced
+    /// the closure passed to [`TraceLayer::make_span_with`]. It can be used to
+    /// [record field values][record] that weren't known when the span was
     /// created.
+    ///
+    /// [`Span`]: https://docs.rs/tracing/latest/tracing/span/index.html
+    /// [record]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.record
     ///
     /// If you're using [hyper] as your server `B` will most likely be [`Bytes`].
     ///

--- a/tower-http/src/trace/on_body_chunk.rs
+++ b/tower-http/src/trace/on_body_chunk.rs
@@ -9,10 +9,9 @@ pub trait OnBodyChunk<B> {
     ///
     /// `latency` is the duration since the response was sent or since the last body chunk as sent.
     ///
-    /// `span` is the `tracing` [`Span`] corresponding to this request, produced
-    /// the closure passed to [`TraceLayer::make_span_with`]. It can be used to
-    /// [record field values][record] that weren't known when the span was
-    /// created.
+    /// `span` is the `tracing` [`Span`], corresponding to this request, produced by the closure
+    /// passed to [`TraceLayer::make_span_with`]. It can be used to [record field values][record]
+    /// that weren't known when the span was created.
     ///
     /// [`Span`]: https://docs.rs/tracing/latest/tracing/span/index.html
     /// [record]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.record
@@ -21,6 +20,7 @@ pub trait OnBodyChunk<B> {
     ///
     /// [hyper]: https://hyper.rs
     /// [`Bytes`]: https://docs.rs/bytes/latest/bytes/struct.Bytes.html
+    /// [`TraceLayer::make_span_with`]: crate::trace::TraceLayer::make_span_with
     fn on_body_chunk(&mut self, chunk: &B, latency: Duration, span: &Span);
 }
 

--- a/tower-http/src/trace/on_body_chunk.rs
+++ b/tower-http/src/trace/on_body_chunk.rs
@@ -9,22 +9,22 @@ pub trait OnBodyChunk<B> {
     ///
     /// `latency` is the duration since the response was sent or since the last body chunk as sent.
     ///
-    /// `current_span` can be used to record field values that weren't known when the span was
+    /// `span` can be used to record field values that weren't known when the span was
     /// created.
     ///
     /// If you're using [hyper] as your server `B` will most likely be [`Bytes`].
     ///
     /// [hyper]: https://hyper.rs
     /// [`Bytes`]: https://docs.rs/bytes/latest/bytes/struct.Bytes.html
-    fn on_body_chunk(&mut self, chunk: &B, latency: Duration, current_span: &Span);
+    fn on_body_chunk(&mut self, chunk: &B, latency: Duration, span: &Span);
 }
 
 impl<B, F> OnBodyChunk<B> for F
 where
     F: FnMut(&B, Duration, &Span),
 {
-    fn on_body_chunk(&mut self, chunk: &B, latency: Duration, current_span: &Span) {
-        self(chunk, latency, current_span)
+    fn on_body_chunk(&mut self, chunk: &B, latency: Duration, span: &Span) {
+        self(chunk, latency, span)
     }
 }
 

--- a/tower-http/src/trace/on_eos.rs
+++ b/tower-http/src/trace/on_eos.rs
@@ -12,13 +12,13 @@ pub trait OnEos {
     ///
     /// `stream_duration` is the duration since the response was sent.
     ///
-    /// `span` is the `tracing` [`Span`] corresponding to this request, produced
-    /// the closure passed to [`TraceLayer::make_span_with`]. It can be used to
-    /// [record field values][record] that weren't known when the span was
-    /// created.
+    /// `span` is the `tracing` [`Span`], corresponding to this request, produced by the closure
+    /// passed to [`TraceLayer::make_span_with`]. It can be used to [record field values][record]
+    /// that weren't known when the span was created.
     ///
     /// [`Span`]: https://docs.rs/tracing/latest/tracing/span/index.html
     /// [record]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.record
+    /// [`TraceLayer::make_span_with`]: crate::trace::TraceLayer::make_span_with
     fn on_eos(self, trailers: Option<&HeaderMap>, stream_duration: Duration, span: &Span);
 }
 

--- a/tower-http/src/trace/on_eos.rs
+++ b/tower-http/src/trace/on_eos.rs
@@ -12,9 +12,9 @@ pub trait OnEos {
     ///
     /// `stream_duration` is the duration since the response was sent.
     ///
-    /// `current_span` can be used to record field values that weren't know when the span was
+    /// `span` can be used to record field values that weren't know when the span was
     /// created.
-    fn on_eos(self, trailers: Option<&HeaderMap>, stream_duration: Duration, current_span: &Span);
+    fn on_eos(self, trailers: Option<&HeaderMap>, stream_duration: Duration, span: &Span);
 }
 
 impl OnEos for () {
@@ -26,8 +26,8 @@ impl<F> OnEos for F
 where
     F: FnOnce(Option<&HeaderMap>, Duration, &Span),
 {
-    fn on_eos(self, trailers: Option<&HeaderMap>, stream_duration: Duration, current_span: &Span) {
-        self(trailers, stream_duration, current_span)
+    fn on_eos(self, trailers: Option<&HeaderMap>, stream_duration: Duration, span: &Span) {
+        self(trailers, stream_duration, span)
     }
 }
 

--- a/tower-http/src/trace/on_eos.rs
+++ b/tower-http/src/trace/on_eos.rs
@@ -12,8 +12,13 @@ pub trait OnEos {
     ///
     /// `stream_duration` is the duration since the response was sent.
     ///
-    /// `span` can be used to record field values that weren't know when the span was
+    /// `span` is the `tracing` [`Span`] corresponding to this request, produced
+    /// the closure passed to [`TraceLayer::make_span_with`]. It can be used to
+    /// [record field values][record] that weren't known when the span was
     /// created.
+    ///
+    /// [`Span`]: https://docs.rs/tracing/latest/tracing/span/index.html
+    /// [record]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.record
     fn on_eos(self, trailers: Option<&HeaderMap>, stream_duration: Duration, span: &Span);
 }
 

--- a/tower-http/src/trace/on_failure.rs
+++ b/tower-http/src/trace/on_failure.rs
@@ -11,13 +11,13 @@ pub trait OnFailure<FailureClass> {
     ///
     /// `latency` is the duration since the request was received.
     ///
-    /// `span` is the `tracing` [`Span`] corresponding to this request, produced
-    /// the closure passed to [`TraceLayer::make_span_with`]. It can be used to
-    /// [record field values][record] that weren't known when the span was
-    /// created.
+    /// `span` is the `tracing` [`Span`], corresponding to this request, produced by the closure
+    /// passed to [`TraceLayer::make_span_with`]. It can be used to [record field values][record]
+    /// that weren't known when the span was created.
     ///
     /// [`Span`]: https://docs.rs/tracing/latest/tracing/span/index.html
     /// [record]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.record
+    /// [`TraceLayer::make_span_with`]: crate::trace::TraceLayer::make_span_with
     fn on_failure(&mut self, failure_classification: FailureClass, latency: Duration, span: &Span);
 }
 

--- a/tower-http/src/trace/on_failure.rs
+++ b/tower-http/src/trace/on_failure.rs
@@ -122,12 +122,7 @@ impl<FailureClass> OnFailure<FailureClass> for DefaultOnFailure
 where
     FailureClass: fmt::Display,
 {
-    fn on_failure(
-        &mut self,
-        failure_classification: FailureClass,
-        latency: Duration,
-        _: &Span,
-    ) {
+    fn on_failure(&mut self, failure_classification: FailureClass, latency: Duration, _: &Span) {
         log_pattern_match!(
             self,
             &failure_classification,

--- a/tower-http/src/trace/on_failure.rs
+++ b/tower-http/src/trace/on_failure.rs
@@ -11,8 +11,13 @@ pub trait OnFailure<FailureClass> {
     ///
     /// `latency` is the duration since the request was received.
     ///
-    /// `span` can be used to record field values that weren't know when the span was
+    /// `span` is the `tracing` [`Span`] corresponding to this request, produced
+    /// the closure passed to [`TraceLayer::make_span_with`]. It can be used to
+    /// [record field values][record] that weren't known when the span was
     /// created.
+    ///
+    /// [`Span`]: https://docs.rs/tracing/latest/tracing/span/index.html
+    /// [record]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.record
     fn on_failure(&mut self, failure_classification: FailureClass, latency: Duration, span: &Span);
 }
 
@@ -121,7 +126,7 @@ where
         &mut self,
         failure_classification: FailureClass,
         latency: Duration,
-        _span: &Span,
+        _: &Span,
     ) {
         log_pattern_match!(
             self,

--- a/tower-http/src/trace/on_failure.rs
+++ b/tower-http/src/trace/on_failure.rs
@@ -11,14 +11,9 @@ pub trait OnFailure<FailureClass> {
     ///
     /// `latency` is the duration since the request was received.
     ///
-    /// `current_span` can be used to record field values that weren't know when the span was
+    /// `span` can be used to record field values that weren't know when the span was
     /// created.
-    fn on_failure(
-        &mut self,
-        failure_classification: FailureClass,
-        latency: Duration,
-        current_span: &Span,
-    );
+    fn on_failure(&mut self, failure_classification: FailureClass, latency: Duration, span: &Span);
 }
 
 impl<FailureClass> OnFailure<FailureClass> for () {
@@ -30,13 +25,8 @@ impl<F, FailureClass> OnFailure<FailureClass> for F
 where
     F: FnMut(FailureClass, Duration, &Span),
 {
-    fn on_failure(
-        &mut self,
-        failure_classification: FailureClass,
-        latency: Duration,
-        current_span: &Span,
-    ) {
-        self(failure_classification, latency, current_span)
+    fn on_failure(&mut self, failure_classification: FailureClass, latency: Duration, span: &Span) {
+        self(failure_classification, latency, span)
     }
 }
 

--- a/tower-http/src/trace/on_request.rs
+++ b/tower-http/src/trace/on_request.rs
@@ -9,13 +9,13 @@ use tracing::Span;
 pub trait OnRequest<B> {
     /// Do the thing.
     ///
-    /// `span` is the `tracing` [`Span`] corresponding to this request, produced
-    /// the closure passed to [`TraceLayer::make_span_with`]. It can be used to
-    /// [record field values][record] that weren't known when the span was
-    /// created.
+    /// `span` is the `tracing` [`Span`], corresponding to this request, produced by the closure
+    /// passed to [`TraceLayer::make_span_with`]. It can be used to [record field values][record]
+    /// that weren't known when the span was created.
     ///
     /// [`Span`]: https://docs.rs/tracing/latest/tracing/span/index.html
     /// [record]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.record
+    /// [`TraceLayer::make_span_with`]: crate::trace::TraceLayer::make_span_with
     fn on_request(&mut self, request: &Request<B>, span: &Span);
 }
 

--- a/tower-http/src/trace/on_request.rs
+++ b/tower-http/src/trace/on_request.rs
@@ -9,22 +9,22 @@ use tracing::Span;
 pub trait OnRequest<B> {
     /// Do the thing.
     ///
-    /// `current_span` can be used to record field values that weren't known when the span was
+    /// `span` can be used to record field values that weren't known when the span was
     /// created.
-    fn on_request(&mut self, request: &Request<B>, current_span: &Span);
+    fn on_request(&mut self, request: &Request<B>, span: &Span);
 }
 
 impl<B> OnRequest<B> for () {
     #[inline]
-    fn on_request(&mut self, _: &Request<B>, _current_span: &Span) {}
+    fn on_request(&mut self, _: &Request<B>, _span: &Span) {}
 }
 
 impl<B, F> OnRequest<B> for F
 where
     F: FnMut(&Request<B>, &Span),
 {
-    fn on_request(&mut self, request: &Request<B>, current_span: &Span) {
-        self(request, current_span)
+    fn on_request(&mut self, request: &Request<B>, span: &Span) {
+        self(request, span)
     }
 }
 

--- a/tower-http/src/trace/on_request.rs
+++ b/tower-http/src/trace/on_request.rs
@@ -9,14 +9,19 @@ use tracing::Span;
 pub trait OnRequest<B> {
     /// Do the thing.
     ///
-    /// `span` can be used to record field values that weren't known when the span was
+    /// `span` is the `tracing` [`Span`] corresponding to this request, produced
+    /// the closure passed to [`TraceLayer::make_span_with`]. It can be used to
+    /// [record field values][record] that weren't known when the span was
     /// created.
+    ///
+    /// [`Span`]: https://docs.rs/tracing/latest/tracing/span/index.html
+    /// [record]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.record
     fn on_request(&mut self, request: &Request<B>, span: &Span);
 }
 
 impl<B> OnRequest<B> for () {
     #[inline]
-    fn on_request(&mut self, _: &Request<B>, _span: &Span) {}
+    fn on_request(&mut self, _: &Request<B>, _: &Span) {}
 }
 
 impl<B, F> OnRequest<B> for F
@@ -63,7 +68,7 @@ impl DefaultOnRequest {
 }
 
 impl<B> OnRequest<B> for DefaultOnRequest {
-    fn on_request(&mut self, _request: &Request<B>, _span: &Span) {
+    fn on_request(&mut self, _: &Request<B>, _: &Span) {
         match self.level {
             Level::ERROR => {
                 tracing::event!(Level::ERROR, "started processing request");

--- a/tower-http/src/trace/on_request.rs
+++ b/tower-http/src/trace/on_request.rs
@@ -9,7 +9,7 @@ use tracing::Span;
 pub trait OnRequest<B> {
     /// Do the thing.
     ///
-    /// `current_span` can be used to record field values that weren't know when the span was
+    /// `current_span` can be used to record field values that weren't known when the span was
     /// created.
     fn on_request(&mut self, request: &Request<B>, current_span: &Span);
 }

--- a/tower-http/src/trace/on_response.rs
+++ b/tower-http/src/trace/on_response.rs
@@ -13,9 +13,9 @@ pub trait OnResponse<B> {
     ///
     /// `latency` is the duration since the request was received.
     ///
-    /// `current_span` can be used to record field values that weren't known when the span was
+    /// `span` can be used to record field values that weren't known when the span was
     /// created.
-    fn on_response(self, response: &Response<B>, latency: Duration, current_span: &Span);
+    fn on_response(self, response: &Response<B>, latency: Duration, span: &Span);
 }
 
 impl<B> OnResponse<B> for () {
@@ -27,8 +27,8 @@ impl<B, F> OnResponse<B> for F
 where
     F: FnOnce(&Response<B>, Duration, &Span),
 {
-    fn on_response(self, response: &Response<B>, latency: Duration, current_span: &Span) {
-        self(response, latency, current_span)
+    fn on_response(self, response: &Response<B>, latency: Duration, span: &Span) {
+        self(response, latency, span)
     }
 }
 
@@ -204,7 +204,7 @@ macro_rules! log_pattern_match {
 }
 
 impl<B> OnResponse<B> for DefaultOnResponse {
-    fn on_response(self, response: &Response<B>, latency: Duration, _current_span: &Span) {
+    fn on_response(self, response: &Response<B>, latency: Duration, _span: &Span) {
         log_pattern_match!(
             self,
             response,

--- a/tower-http/src/trace/on_response.rs
+++ b/tower-http/src/trace/on_response.rs
@@ -13,7 +13,7 @@ pub trait OnResponse<B> {
     ///
     /// `latency` is the duration since the request was received.
     ///
-    /// `current_span` can be used to record field values that weren't know when the span was
+    /// `current_span` can be used to record field values that weren't known when the span was
     /// created.
     fn on_response(self, response: &Response<B>, latency: Duration, current_span: &Span);
 }

--- a/tower-http/src/trace/on_response.rs
+++ b/tower-http/src/trace/on_response.rs
@@ -13,13 +13,13 @@ pub trait OnResponse<B> {
     ///
     /// `latency` is the duration since the request was received.
     ///
-    /// `span` is the `tracing` [`Span`] corresponding to this request, produced
-    /// the closure passed to [`TraceLayer::make_span_with`]. It can be used to
-    /// [record field values][record] that weren't known when the span was
-    /// created.
+    /// `span` is the `tracing` [`Span`], corresponding to this request, produced by the closure
+    /// passed to [`TraceLayer::make_span_with`]. It can be used to [record field values][record]
+    /// that weren't known when the span was created.
     ///
     /// [`Span`]: https://docs.rs/tracing/latest/tracing/span/index.html
     /// [record]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.record
+    /// [`TraceLayer::make_span_with`]: crate::trace::TraceLayer::make_span_with
     fn on_response(self, response: &Response<B>, latency: Duration, span: &Span);
 }
 

--- a/tower-http/src/trace/on_response.rs
+++ b/tower-http/src/trace/on_response.rs
@@ -13,8 +13,13 @@ pub trait OnResponse<B> {
     ///
     /// `latency` is the duration since the request was received.
     ///
-    /// `span` can be used to record field values that weren't known when the span was
+    /// `span` is the `tracing` [`Span`] corresponding to this request, produced
+    /// the closure passed to [`TraceLayer::make_span_with`]. It can be used to
+    /// [record field values][record] that weren't known when the span was
     /// created.
+    ///
+    /// [`Span`]: https://docs.rs/tracing/latest/tracing/span/index.html
+    /// [record]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.record
     fn on_response(self, response: &Response<B>, latency: Duration, span: &Span);
 }
 
@@ -204,7 +209,7 @@ macro_rules! log_pattern_match {
 }
 
 impl<B> OnResponse<B> for DefaultOnResponse {
-    fn on_response(self, response: &Response<B>, latency: Duration, _span: &Span) {
+    fn on_response(self, response: &Response<B>, latency: Duration, _: &Span) {
         log_pattern_match!(
             self,
             response,

--- a/tower-http/src/trace/service.rs
+++ b/tower-http/src/trace/service.rs
@@ -318,7 +318,7 @@ where
 
         let future = {
             let _guard = span.enter();
-            self.on_request.on_request(&req);
+            self.on_request.on_request(&req, &span);
             self.inner.call(req)
         };
 


### PR DESCRIPTION
Allows users to record field values that can't be known when the span is created.

Fixes https://github.com/tower-rs/tower-http/issues/92