### PR TITLE
Add `{ClassifyResponse, ClassifyEos}::map_failure_class`

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-None.
+- Add `ClassifyResponse::map_failure_class` and `ClassifyEos::map_failure_class`
+  for transforming the failure classification using a function.
 
 ## Breaking changes
 

--- a/tower-http/src/classify/map_failure_class.rs
+++ b/tower-http/src/classify/map_failure_class.rs
@@ -1,0 +1,79 @@
+use super::{ClassifiedResponse, ClassifyEos, ClassifyResponse};
+use http::{HeaderMap, Response};
+use std::fmt;
+
+/// Response classifier that transforms the failure class of some other classify.
+///
+/// Created with [`ClassifyResponse::map_failure_class`] or
+/// [`ClassifyEos::map_failure_class`].
+#[derive(Clone, Copy)]
+pub struct MapFailureClass<C, F> {
+    inner: C,
+    f: F,
+}
+
+impl<C, F> MapFailureClass<C, F> {
+    pub(super) fn new(classify: C, f: F) -> Self {
+        Self { inner: classify, f }
+    }
+}
+
+impl<C, F> fmt::Debug for MapFailureClass<C, F>
+where
+    C: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MapFailureClass")
+            .field("inner", &self.inner)
+            .field("f", &format_args!("{}", std::any::type_name::<F>()))
+            .finish()
+    }
+}
+
+impl<C, F, NewClass> ClassifyResponse for MapFailureClass<C, F>
+where
+    C: ClassifyResponse,
+    F: FnOnce(C::FailureClass) -> NewClass,
+{
+    type FailureClass = NewClass;
+    type ClassifyEos = MapFailureClass<C::ClassifyEos, F>;
+
+    fn classify_response<B>(
+        self,
+        res: &Response<B>,
+    ) -> ClassifiedResponse<Self::FailureClass, Self::ClassifyEos> {
+        match self.inner.classify_response(res) {
+            ClassifiedResponse::Ready(result) => ClassifiedResponse::Ready(result.map_err(self.f)),
+            ClassifiedResponse::RequiresEos(classify_eos) => {
+                let mapped_classify_eos = MapFailureClass::new(classify_eos, self.f);
+                ClassifiedResponse::RequiresEos(mapped_classify_eos)
+            }
+        }
+    }
+
+    fn classify_error<E>(self, error: &E) -> Self::FailureClass
+    where
+        E: std::fmt::Display + 'static,
+    {
+        (self.f)(self.inner.classify_error(error))
+    }
+}
+
+impl<C, F, NewClass> ClassifyEos for MapFailureClass<C, F>
+where
+    C: ClassifyEos,
+    F: FnOnce(C::FailureClass) -> NewClass,
+{
+    type FailureClass = NewClass;
+
+    fn classify_eos(self, trailers: Option<&HeaderMap>) -> Result<(), Self::FailureClass> {
+        self.inner.classify_eos(trailers).map_err(self.f)
+    }
+
+    fn classify_error<E>(self, error: &E) -> Self::FailureClass
+    where
+        E: std::fmt::Display + 'static,
+    {
+        (self.f)(self.inner.classify_error(error))
+    }
+}

--- a/tower-http/src/classify/map_failure_class.rs
+++ b/tower-http/src/classify/map_failure_class.rs
@@ -2,7 +2,8 @@ use super::{ClassifiedResponse, ClassifyEos, ClassifyResponse};
 use http::{HeaderMap, Response};
 use std::fmt;
 
-/// Response classifier that transforms the failure class of some other classify.
+/// Response classifier that transforms the failure class of some other
+/// classifier.
 ///
 /// Created with [`ClassifyResponse::map_failure_class`] or
 /// [`ClassifyEos::map_failure_class`].

--- a/tower-http/src/classify/mod.rs
+++ b/tower-http/src/classify/mod.rs
@@ -3,6 +3,10 @@
 use http::{HeaderMap, Request, Response, StatusCode};
 use std::{convert::Infallible, fmt, marker::PhantomData, num::NonZeroI32};
 
+mod map_failure_class;
+
+pub use self::map_failure_class::MapFailureClass;
+
 /// Trait for producing response classifiers from a request.
 ///
 /// This is useful when a classifier depends on data from the request. For example, this could
@@ -122,6 +126,60 @@ pub trait ClassifyResponse {
     fn classify_error<E>(self, error: &E) -> Self::FailureClass
     where
         E: fmt::Display + 'static;
+
+    /// Transform the failure classification using a function.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tower_http::classify::{
+    ///     ServerErrorsAsFailures, ServerErrorsFailureClass,
+    ///     ClassifyResponse, ClassifiedResponse
+    /// };
+    /// use http::{Response, StatusCode};
+    /// use http_body::Empty;
+    /// use bytes::Bytes;
+    ///
+    /// fn transform_failure_class(class: ServerErrorsFailureClass) -> NewFailureClass {
+    ///     match class {
+    ///         // Convert status codes into u16
+    ///         ServerErrorsFailureClass::StatusCode(status) => {
+    ///             NewFailureClass::Status(status.as_u16())
+    ///         }
+    ///         // Don't change errors.
+    ///         ServerErrorsFailureClass::Error(error) => {
+    ///             NewFailureClass::Error(error)
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// enum NewFailureClass {
+    ///     Status(u16),
+    ///     Error(String),
+    /// }
+    ///
+    /// // Create a classifier who's failure class will be transformed by `transform_failure_class`
+    /// let classifier = ServerErrorsAsFailures::new().map_failure_class(transform_failure_class);
+    ///
+    /// let response = Response::builder()
+    ///     .status(StatusCode::INTERNAL_SERVER_ERROR)
+    ///     .body(Empty::<Bytes>::new())
+    ///     .unwrap();
+    ///
+    /// let classification = classifier.classify_response(&response);
+    ///
+    /// assert!(matches!(
+    ///     classification,
+    ///     ClassifiedResponse::Ready(Err(NewFailureClass::Status(500)))
+    /// ));
+    /// ```
+    fn map_failure_class<F, NewClass>(self, f: F) -> MapFailureClass<Self, F>
+    where
+        Self: Sized,
+        F: FnOnce(Self::FailureClass) -> NewClass,
+    {
+        MapFailureClass::new(self, f)
+    }
 }
 
 /// Trait for classifying end of streams (EOS) as either success or failure.
@@ -139,6 +197,17 @@ pub trait ClassifyEos {
     fn classify_error<E>(self, error: &E) -> Self::FailureClass
     where
         E: fmt::Display + 'static;
+
+    /// Transform the failure classification using a function.
+    ///
+    /// See [`ClassifyResponse::map_failure_class`] for more details.
+    fn map_failure_class<F, NewClass>(self, f: F) -> MapFailureClass<Self, F>
+    where
+        Self: Sized,
+        F: FnOnce(Self::FailureClass) -> NewClass,
+    {
+        MapFailureClass::new(self, f)
+    }
 }
 
 /// Result of doing a classification.


### PR DESCRIPTION
I have found this combinator to be useful. It allows mapping the failure class of a classifier using a function.