### PR TITLE
Fix documentation for `DefaultOnFailure::level`

### DIFF
--- a/tower-http/src/trace/on_failure.rs
+++ b/tower-http/src/trace/on_failure.rs
@@ -61,7 +61,7 @@ impl DefaultOnFailure {
 
     /// Set the [`Level`] used for [tracing events].
     ///
-    /// Defaults to [`Level::DEBUG`].
+    /// Defaults to [`Level::ERROR`].
     ///
     /// [tracing events]: https://docs.rs/tracing/latest/tracing/#events
     pub fn level(mut self, level: Level) -> Self {


### PR DESCRIPTION
## Motivation

https://github.com/tower-rs/tower-http/blob/27db4f2b3a4fb936986189f7311ff14cf7ff5f63/tower-http/src/trace/on_failure.rs#L47-L54
