### PR TITLE
Change compression body error type to `BoxError`

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -11,7 +11,12 @@ None.
 
 ## Breaking changes
 
-None.
+- Change the response body error type of `Compression` and `Decompression` to
+  `Box<dyn std::error::Error + Send + Sync>`. This makes them usable if the body
+  they're wrapping uses `Box<dyn std::error::Error + Send + Sync>` as its error
+  type which they previously weren't.
+- Remove `BodyOrIoError`. Its been replaced with `Box<dyn std::error::Error +
+  Send + Sync>`.
 
 # 0.1.0 (May 27, 2021)
 

--- a/tower-http/src/compression/future.rs
+++ b/tower-http/src/compression/future.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 
 use super::{body::BodyInner, CompressionBody, Encoding};
-use crate::compression_utils::{supports_transparent_compression, BoxError, WrapBody};
+use crate::compression_utils::{supports_transparent_compression, WrapBody};
 use futures_util::ready;
 use http::{header, HeaderMap, HeaderValue, Response};
 use http_body::Body;

--- a/tower-http/src/compression/service.rs
+++ b/tower-http/src/compression/service.rs
@@ -1,5 +1,5 @@
 use super::{CompressionBody, CompressionLayer, Encoding, ResponseFuture};
-use crate::compression_utils::{AcceptEncoding, BoxError};
+use crate::{compression_utils::AcceptEncoding, BoxError};
 use http::{Request, Response};
 use http_body::Body;
 use std::task::{Context, Poll};

--- a/tower-http/src/decompression/body.rs
+++ b/tower-http/src/decompression/body.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 
 use crate::compression_utils::{AsyncReadBody, BodyIntoStream, DecorateAsyncRead, WrapBody};
-use crate::BodyOrIoError;
+use crate::BoxError;
 #[cfg(feature = "decompression-br")]
 use async_compression::tokio::bufread::BrotliDecoder;
 #[cfg(feature = "decompression-gzip")]
@@ -132,9 +132,10 @@ where
 impl<B> Body for DecompressionBody<B>
 where
     B: Body,
+    B::Error: Into<BoxError>,
 {
     type Data = Bytes;
-    type Error = BodyOrIoError<B::Error>;
+    type Error = BoxError;
 
     fn poll_data(
         self: Pin<&mut Self>,
@@ -152,7 +153,7 @@ where
                     let bytes = buf.copy_to_bytes(buf.remaining());
                     Poll::Ready(Some(Ok(bytes)))
                 }
-                Some(Err(err)) => Poll::Ready(Some(Err(BodyOrIoError::Body(err)))),
+                Some(Err(err)) => Poll::Ready(Some(Err(err.into()))),
                 None => Poll::Ready(None),
             },
         }
@@ -169,7 +170,7 @@ where
             BodyInnerProj::Deflate(inner) => inner.poll_trailers(cx),
             #[cfg(feature = "decompression-br")]
             BodyInnerProj::Brotli(inner) => inner.poll_trailers(cx),
-            BodyInnerProj::Identity(body) => body.poll_trailers(cx).map_err(BodyOrIoError::Body),
+            BodyInnerProj::Identity(body) => body.poll_trailers(cx).map_err(Into::into),
         }
     }
 }

--- a/tower-http/src/decompression/future.rs
+++ b/tower-http/src/decompression/future.rs
@@ -1,7 +1,10 @@
 #![allow(unused_imports)]
 
 use super::{body::BodyInner, DecompressionBody};
-use crate::compression_utils::{AcceptEncoding, BoxError, WrapBody};
+use crate::{
+    compression_utils::{AcceptEncoding, WrapBody},
+    BoxError,
+};
 use futures_util::ready;
 use http::{header, Response};
 use http_body::Body;

--- a/tower-http/src/decompression/mod.rs
+++ b/tower-http/src/decompression/mod.rs
@@ -12,7 +12,7 @@
 //! use tower_http::{compression::Compression, decompression::DecompressionLayer};
 //! #
 //! # #[tokio::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # async fn main() -> Result<(), tower::BoxError> {
 //! # async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
 //! #     let body = Body::from("Hello, World!");
 //! #     Ok(Response::new(body))

--- a/tower-http/src/decompression/service.rs
+++ b/tower-http/src/decompression/service.rs
@@ -1,5 +1,8 @@
 use super::{DecompressionBody, DecompressionLayer, ResponseFuture};
-use crate::compression_utils::{supports_transparent_compression, AcceptEncoding, BoxError};
+use crate::{
+    compression_utils::{supports_transparent_compression, AcceptEncoding},
+    BoxError,
+};
 use http::{
     header::{self, ACCEPT_ENCODING, RANGE},
     Request, Response,

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -271,52 +271,6 @@ pub mod metrics;
 pub mod classify;
 pub mod services;
 
-/// Error type containing either a body error or an IO error.
-///
-/// This type is used to combine errors produced by response bodies with compression or
-/// decompression applied. The body itself can produce errors of type `E` whereas compression or
-/// decompression can produce [`io::Error`]s.
-///
-/// [`io::Error`]: std::io::Error
-#[cfg(any(feature = "compression", feature = "decompression"))]
-#[cfg_attr(
-    docsrs,
-    doc(cfg(any(feature = "compression", feature = "decompression")))
-)]
-#[derive(Debug)]
-pub enum BodyOrIoError<E> {
-    /// Errors produced by the body.
-    Body(E),
-    /// IO errors produced by compression or decompression.
-    Io(std::io::Error),
-}
-
-#[cfg(any(feature = "compression", feature = "decompression"))]
-impl<E> std::fmt::Display for BodyOrIoError<E>
-where
-    E: std::fmt::Display,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            BodyOrIoError::Io(inner) => inner.fmt(f),
-            BodyOrIoError::Body(inner) => inner.fmt(f),
-        }
-    }
-}
-
-#[cfg(any(feature = "compression", feature = "decompression"))]
-impl<E> std::error::Error for BodyOrIoError<E>
-where
-    E: std::error::Error,
-{
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            BodyOrIoError::Io(inner) => inner.source(),
-            BodyOrIoError::Body(inner) => inner.source(),
-        }
-    }
-}
-
 /// The latency unit used to report latencies by middleware.
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug)]
@@ -328,3 +282,5 @@ pub enum LatencyUnit {
     /// Use nanoseconds.
     Nanos,
 }
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;


### PR DESCRIPTION
The compression related middleware would previously use `BodyOrIoError`
as the body error type. That only implemented `std::error::Error` if the
inner error did as well. Since `Box<dyn std::error::Error + Send + Sync>`
does not implement `std::error::Error` `Compression` and
`Decompression` wouldn't be usable with hyper if the body they wrapped
had that error type.

This changes the middleware to use `BoxError` as the error type which
resolves the issue. Its also consistent with other middleware.

Note: This is a breaking change so should be released in 0.2 when we decide to do that.