### PR TITLE
Release 0.1.1

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- Add `AddAuthorizationLayer` for setting the `Authorization` header on
-  requests.
+None.
+
+## Breaking changes
+
+None.
+
+# 0.1.1 (July 2, 2021)
+
 - Add example of using `SharedClassifier`.
 - Add `StatusInRangeAsFailures` which is a response classifier that considers
   responses with status code in a certain range as failures. Useful for HTTP
@@ -19,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `ClassifyResponse::map_failure_class` and `ClassifyEos::map_failure_class`
   for transforming the failure classification using a function.
 - Clarify exactly when each `Trace` callback is called.
+- Add `AddAuthorizationLayer` for setting the `Authorization` header on
+  requests.
 
 ## Breaking changes
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "tower-http"
 description = "Tower middleware and utilities for HTTP clients and servers"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 edition = "2018"
 license = "MIT"
 readme = "../README.md"
 repository = "https://github.com/tower-rs/tower-http"
 homepage = "https://github.com/tower-rs/tower-http"
-documentation = "https://docs.rs/tower-http/0.1.0/tower_http/"
+documentation = "https://docs.rs/tower-http/0.1.1/tower_http/"
 categories = ["asynchronous", "network-programming", "web-programming"]
 keywords = ["io", "async", "futures", "service", "http"]
 

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -145,13 +145,13 @@
 //! your `Cargo.toml`:
 //!
 //! ```toml
-//! tower-http = { version = "0.1.0", features = ["trace"] }
+//! tower-http = { version = "0.1", features = ["trace"] }
 //! ```
 //!
 //! You can use `"full"` to enable everything:
 //!
 //! ```toml
-//! tower-http = { version = "0.1.0", features = ["full"] }
+//! tower-http = { version = "0.1", features = ["full"] }
 //! ```
 //!
 //! # Getting Help
@@ -175,7 +175,7 @@
 //! [`Trace`]: crate::trace::Trace
 //! [examples]: https://github.com/tower-rs/tower-http/tree/master/examples
 
-#![doc(html_root_url = "https://docs.rs/tower-http/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tower-http/0.1.1")]
 #![warn(
     clippy::all,
     clippy::dbg_macro,


### PR DESCRIPTION
# 0.1.1 (July 2, 2021)

- Add example of using `SharedClassifier`.
- Add `StatusInRangeAsFailures` which is a response classifier that considers
  responses with status code in a certain range as failures. Useful for HTTP
  clients where both server errors (5xx) and client errors (4xx) are considered
  failures.
- Implement `Debug` for `NeverClassifyEos`.
- Update iri-string to 0.4.
- Add `ClassifyResponse::map_failure_class` and `ClassifyEos::map_failure_class`
  for transforming the failure classification using a function.
- Clarify exactly when each `Trace` callback is called.
- Add `AddAuthorizationLayer` for setting the `Authorization` header on
  requests.

## Breaking changes

None.