### PR TITLE
Add `Cors` for setting CORS headers

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix the bug that `ServeDir` can not handle percent encoded uri path correctly.
 - Enhancement: avoid using permanent redirection when redirect directory path without a trailing slash to the one has
 - Fix a [bug](https://github.com/tower-rs/tower-http/issues/121) which happens when `append_index_html_on_directories` is set to `false` in `ServeDir`.
+- Add `Cors` for setting [CORS] headers.
 
 ## Breaking changes
 
-- Add `Cors` for setting [CORS] headers.
+None.
 
 # 0.1.1 (July 2, 2021)
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Breaking changes
 
-None.
+- Add `Cors` for setting [CORS] headers.
 
 # 0.1.1 (July 2, 2021)
 
@@ -37,3 +37,5 @@ None.
 # 0.1.0 (May 27, 2021)
 
 - Initial release.
+
+[CORS]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -52,6 +52,7 @@ full = [
     "auth",
     "compression",
     "compression-full",
+    "cors",
     "decompression-full",
     "follow-redirect",
     "fs",
@@ -67,6 +68,7 @@ full = [
 
 add-extension = []
 auth = ["base64"]
+cors = []
 follow-redirect = ["iri-string", "tower/util"]
 fs = ["tokio/fs", "tokio-util/io", "mime_guess", "mime", "percent-encoding"]
 map-request-body = []

--- a/tower-http/src/cors.rs
+++ b/tower-http/src/cors.rs
@@ -1,0 +1,627 @@
+//! Middleware which adds headers for [CORS][mdn].
+//!
+//! # Example
+//!
+//! ```
+//! use http::{Request, Response, Method, header};
+//! use hyper::Body;
+//! use tower::{ServiceBuilder, ServiceExt, Service};
+//! use tower_http::cors::{CorsLayer, Any};
+//! use std::convert::Infallible;
+//!
+//! async fn handle(request: Request<Body>) -> Result<Response<Body>, Infallible> {
+//!     Ok(Response::new(Body::empty()))
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let cors = CorsLayer::new()
+//!     .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS])
+//!     .allow_origin(Any)
+//!     .allow_credentials(false);
+//!
+//! let mut service = ServiceBuilder::new()
+//!     .layer(cors)
+//!     .service_fn(handle);
+//!
+//! let request = Request::builder()
+//!     .header(header::ORIGIN, "https://example.com")
+//!     .body(Body::empty())
+//!     .unwrap();
+//!
+//! let response = service
+//!     .ready()
+//!     .await?
+//!     .call(request)
+//!     .await?;
+//!
+//! assert_eq!(
+//!     response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN).unwrap(),
+//!     "*",
+//! );
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+
+use futures_core::ready;
+use http::{
+    header::{self, HeaderName, HeaderValue},
+    Method, Request, Response, StatusCode,
+};
+use pin_project::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
+use tower_layer::Layer;
+use tower_service::Service;
+
+/// Layer that applies [`Cors`] which adds headers for [CORS][mdn].
+///
+/// See the [module docs](crate::cors) for an example.
+///
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+#[derive(Debug, Clone)]
+pub struct CorsLayer {
+    allow_credentials: Option<HeaderValue>,
+    allow_headers: HeaderValue,
+    allow_methods: HeaderValue,
+    allow_origin: AnyOr<Origin>,
+    expose_headers: Option<HeaderValue>,
+    max_age: HeaderValue,
+}
+
+const DEFAULT_MAX_AGE: &str = "86400"; // 24 hours
+const DEFAULT_METHODS: &str = "GET, POST, OPTIONS";
+const WILDCARD: &str = "*";
+
+impl CorsLayer {
+    /// Create a new `CorsLayer`.
+    pub fn new() -> Self {
+        Self {
+            allow_credentials: None,
+            allow_headers: WILDCARD.parse().unwrap(),
+            allow_methods: DEFAULT_METHODS.parse().unwrap(),
+            allow_origin: AnyOr(AnyOrInner::Any),
+            expose_headers: None,
+            max_age: DEFAULT_MAX_AGE.parse().unwrap(),
+        }
+    }
+
+    /// Set the value of the [`Access-Control-Allow-Credentials`][mdn] header.
+    ///
+    /// ```
+    /// use tower_http::cors::CorsLayer;
+    ///
+    /// let layer = CorsLayer::new().allow_credentials(true);
+    /// ```
+    ///
+    /// By default the header will not be set.
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials
+    pub fn allow_credentials(mut self, allow_credentials: bool) -> Self {
+        self.allow_credentials = Some(allow_credentials.to_string().parse().unwrap());
+        self
+    }
+
+    /// Set the value of the [`Access-Control-Allow-Headers`][mdn] header.
+    ///
+    /// ```
+    /// use tower_http::cors::CorsLayer;
+    /// use http::header::HeaderValue;
+    ///
+    /// let layer = CorsLayer::new().allow_headers(vec![
+    ///     "*".parse().unwrap(),
+    /// ]);
+    /// ```
+    ///
+    /// By default the header will be set to `*`.
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
+    pub fn allow_headers<I>(mut self, headers: I) -> Self
+    where
+        I: IntoIterator<Item = HeaderValue>,
+    {
+        self.allow_headers = separated_by_commas(
+            headers
+                .into_iter()
+                .map(|value| value.to_str().unwrap().to_string()),
+        );
+        self
+    }
+
+    /// Set the value of the [`Access-Control-Max-Age`][mdn] header.
+    ///
+    /// ```
+    /// use tower_http::cors::CorsLayer;
+    /// use std::time::Duration;
+    ///
+    /// let layer = CorsLayer::new().max_age(Duration::from_secs(60) * 10);
+    /// ```
+    ///
+    /// By default the header will be set to 24 hours.
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
+    pub fn max_age(mut self, max_age: Duration) -> Self {
+        self.max_age = max_age.as_secs().into();
+        self
+    }
+
+    /// Set the value of the [`Access-Control-Allow-Methods`][mdn] header.
+    ///
+    /// ```
+    /// use tower_http::cors::CorsLayer;
+    /// use http::Method;
+    ///
+    /// let layer = CorsLayer::new().allow_methods(vec![Method::GET, Method::POST]);
+    /// ```
+    ///
+    /// All methods can be allowed with
+    ///
+    /// ```
+    /// use tower_http::cors::{CorsLayer, Any};
+    ///
+    /// let layer = CorsLayer::new().allow_methods(Any);
+    /// ```
+    ///
+    /// By default the header will be set to `GET, POST, OPTIONS`.
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
+    pub fn allow_methods<T>(mut self, methods: T) -> Self
+    where
+        T: Into<AnyOr<Vec<Method>>>,
+    {
+        self.allow_methods = match methods.into().0 {
+            AnyOrInner::Any => "*".parse().unwrap(),
+            AnyOrInner::Value(methods) => separated_by_commas(methods),
+        };
+        self
+    }
+
+    /// Set the value of the [`Access-Control-Allow-Origin`][mdn] header.
+    ///
+    /// ```
+    /// use tower_http::cors::{CorsLayer, Origin};
+    ///
+    /// let layer = CorsLayer::new().allow_origin(Origin::exact(
+    ///     "http://example.com".parse().unwrap(),
+    /// ));
+    /// ```
+    ///
+    /// All origins can be allowed with
+    ///
+    /// ```
+    /// use tower_http::cors::{CorsLayer, Any};
+    ///
+    /// let layer = CorsLayer::new().allow_origin(Any);
+    /// ```
+    ///
+    /// By default the header will be set to `*`.
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+    pub fn allow_origin<T>(mut self, origin: T) -> Self
+    where
+        T: Into<AnyOr<Origin>>,
+    {
+        self.allow_origin = origin.into();
+        self
+    }
+
+    /// Set the value of the [`Access-Control-Expose-Headers`][mdn] header.
+    ///
+    /// ```
+    /// use tower_http::cors::CorsLayer;
+    /// use http::header::CONTENT_ENCODING;
+    ///
+    /// let layer = CorsLayer::new().expose_headers(vec![CONTENT_ENCODING]);
+    /// ```
+    ///
+    /// All headers can be allowed with
+    ///
+    /// ```
+    /// use tower_http::cors::{CorsLayer, Any};
+    ///
+    /// let layer = CorsLayer::new().expose_headers(Any);
+    /// ```
+    ///
+    /// By default the header will not be set.
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
+    pub fn expose_headers<I>(mut self, headers: I) -> Self
+    where
+        I: Into<AnyOr<Vec<HeaderName>>>,
+    {
+        self.expose_headers = Some(match headers.into().0 {
+            AnyOrInner::Any => "*".parse().unwrap(),
+            AnyOrInner::Value(headers) => separated_by_commas(headers),
+        });
+        self
+    }
+}
+
+/// Represents a wildcard value (`*`) used with some CORS headers such as
+/// [`CorsLayer::allow_methods`].
+#[derive(Debug, Clone, Copy)]
+pub struct Any;
+
+/// Used to make methods like [`CorsLayer::allow_methods`] more convenient to call.
+///
+/// You shouldn't have to use this type directly.
+#[derive(Debug, Clone, Copy)]
+pub struct AnyOr<T>(AnyOrInner<T>);
+
+#[derive(Debug, Clone, Copy)]
+enum AnyOrInner<T> {
+    Any,
+    Value(T),
+}
+
+impl From<Origin> for AnyOr<Origin> {
+    fn from(origin: Origin) -> Self {
+        AnyOr(AnyOrInner::Value(origin))
+    }
+}
+
+impl<T> From<Any> for AnyOr<T> {
+    fn from(_: Any) -> Self {
+        AnyOr(AnyOrInner::Any)
+    }
+}
+
+impl<I> From<I> for AnyOr<Vec<Method>>
+where
+    I: IntoIterator<Item = Method>,
+{
+    fn from(methods: I) -> Self {
+        AnyOr(AnyOrInner::Value(methods.into_iter().collect()))
+    }
+}
+
+impl<I> From<I> for AnyOr<Vec<HeaderName>>
+where
+    I: IntoIterator<Item = HeaderName>,
+{
+    fn from(headers: I) -> Self {
+        AnyOr(AnyOrInner::Value(headers.into_iter().collect()))
+    }
+}
+
+fn separated_by_commas<I>(into_iter: I) -> HeaderValue
+where
+    I: IntoIterator,
+    I::Item: ToString,
+{
+    let methods = into_iter
+        .into_iter()
+        .map(|item| item.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    HeaderValue::from_str(&methods).unwrap()
+}
+
+impl Default for CorsLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> Layer<S> for CorsLayer {
+    type Service = Cors<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Cors::new(inner)
+    }
+}
+
+/// Middleware which adds headers for [CORS][mdn].
+///
+/// See the [module docs](crate::cors) for an example.
+///
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+#[derive(Debug, Clone)]
+pub struct Cors<S> {
+    inner: S,
+    layer: CorsLayer,
+}
+
+impl<S> Cors<S> {
+    /// Create a new `Cors`.
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            layer: CorsLayer::new(),
+        }
+    }
+
+    define_inner_service_accessors!();
+
+    /// Returns a new [`Layer`] that wraps services with a [`Cors`] middleware.
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer() -> CorsLayer {
+        CorsLayer::new()
+    }
+
+    /// Set the value of the [`Access-Control-Allow-Credentials`][mdn] header.
+    ///
+    /// See [`CorsLayer::allow_credentials`] for more details.
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials
+    pub fn allow_credentials(self, allow_credentials: bool) -> Self {
+        self.update_layer(|layer| layer.allow_credentials(allow_credentials))
+    }
+
+    /// Set the value of the [`Access-Control-Allow-Headers`][mdn] header.
+    ///
+    /// See [`CorsLayer::allow_headers`] for more details.
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
+    pub fn allow_headers<I>(self, headers: I) -> Self
+    where
+        I: IntoIterator<Item = HeaderValue>,
+    {
+        self.update_layer(|layer| layer.allow_headers(headers))
+    }
+
+    /// Set the value of the [`Access-Control-Max-Age`][mdn] header.
+    ///
+    /// See [`CorsLayer::max_age`] for more details.
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
+    pub fn max_age(self, max_age: Duration) -> Self {
+        self.update_layer(|layer| layer.max_age(max_age))
+    }
+
+    /// Set the value of the [`Access-Control-Allow-Methods`][mdn] header.
+    ///
+    /// See [`CorsLayer::allow_methods`] for more details.
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
+    pub fn allow_methods<T>(self, methods: T) -> Self
+    where
+        T: Into<AnyOr<Vec<Method>>>,
+    {
+        self.update_layer(|layer| layer.allow_methods(methods))
+    }
+
+    /// Set the value of the [`Access-Control-Allow-Origin`][mdn] header.
+    ///
+    /// See [`CorsLayer::allow_origin`] for more details.
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+    pub fn allow_origin<T>(self, origin: T) -> Self
+    where
+        T: Into<AnyOr<Origin>>,
+    {
+        self.update_layer(|layer| layer.allow_origin(origin))
+    }
+
+    /// Set the value of the [`Access-Control-Expose-Headers`][mdn] header.
+    ///
+    /// See [`CorsLayer::expose_headers`] for more details.
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
+    pub fn expose_headers<I>(self, headers: I) -> Self
+    where
+        I: Into<AnyOr<Vec<HeaderName>>>,
+    {
+        self.update_layer(|layer| layer.expose_headers(headers))
+    }
+
+    fn update_layer<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(CorsLayer) -> CorsLayer,
+    {
+        self.layer = f(self.layer);
+        self
+    }
+
+    fn is_valid_origin(&self, origin: &HeaderValue) -> bool {
+        match &self.layer.allow_origin.0 {
+            AnyOrInner::Any => true,
+            AnyOrInner::Value(allow_origin) => match &allow_origin.0 {
+                OriginInner::Exact(s) => s == origin,
+                OriginInner::List(list) => list.contains(origin),
+            },
+        }
+    }
+
+    fn build_preflight_response<B>(&self, origin: HeaderValue) -> Response<B>
+    where
+        B: Default,
+    {
+        let mut response = Response::new(B::default());
+        response
+            .headers_mut()
+            .insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+
+        response.headers_mut().insert(
+            header::ACCESS_CONTROL_ALLOW_METHODS,
+            self.layer.allow_methods.clone(),
+        );
+
+        response.headers_mut().insert(
+            header::ACCESS_CONTROL_ALLOW_HEADERS,
+            self.layer.allow_headers.clone(),
+        );
+
+        response
+            .headers_mut()
+            .insert(header::ACCESS_CONTROL_MAX_AGE, self.layer.max_age.clone());
+
+        if let Some(allow_credentials) = self.layer.allow_credentials.clone() {
+            response
+                .headers_mut()
+                .insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, allow_credentials);
+        }
+
+        if let Some(expose_headers) = self.layer.expose_headers.clone() {
+            response
+                .headers_mut()
+                .insert(header::ACCESS_CONTROL_EXPOSE_HEADERS, expose_headers);
+        }
+
+        response
+    }
+}
+
+/// Represents a [`Access-Control-Allow-Origin`][mdn] header.
+///
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+#[derive(Clone, Debug)]
+pub struct Origin(OriginInner);
+
+impl Origin {
+    /// Set a single allow origin target
+    pub fn exact(origin: HeaderValue) -> Self {
+        Self(OriginInner::Exact(origin))
+    }
+
+    /// Set multiple allow origin targets
+    pub fn list<I>(origins: I) -> Self
+    where
+        I: IntoIterator<Item = HeaderValue>,
+    {
+        let origins = origins.into_iter().collect::<Vec<_>>().into();
+        Self(OriginInner::List(origins))
+    }
+}
+
+#[derive(Clone, Debug)]
+enum OriginInner {
+    Exact(HeaderValue),
+    List(Arc<[HeaderValue]>),
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for Cors<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    ResBody: Default,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future, ResBody>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let origin = req.headers().get(&header::ORIGIN).cloned();
+
+        let origin = if let Some(origin) = origin {
+            origin
+        } else {
+            // This is not a CORS request if there is no Origin header
+            return ResponseFuture {
+                inner: Kind::NonCorsCall(self.inner.call(req)),
+            };
+        };
+
+        if !self.is_valid_origin(&origin) {
+            return ResponseFuture {
+                inner: Kind::Error(Some(
+                    Response::builder()
+                        .status(StatusCode::UNAUTHORIZED)
+                        .body(ResBody::default())
+                        .unwrap(),
+                )),
+            };
+        }
+
+        // Return results immediately upon preflight request
+        if req.method() == Method::OPTIONS {
+            return ResponseFuture {
+                inner: Kind::Error(Some(self.build_preflight_response(origin))),
+            };
+        }
+
+        ResponseFuture {
+            inner: Kind::CorsCall {
+                future: self.inner.call(req),
+                allow_origin: Some(self.layer.allow_origin.clone()),
+                origin,
+                allow_credentials: self.layer.allow_credentials.clone(),
+                expose_headers: self.layer.expose_headers.clone(),
+            },
+        }
+    }
+}
+
+/// Response future for [`Cors`].
+#[pin_project]
+pub struct ResponseFuture<F, B> {
+    #[pin]
+    inner: Kind<F, B>,
+}
+
+#[pin_project(project = KindProj)]
+enum Kind<F, B> {
+    NonCorsCall(#[pin] F),
+    CorsCall {
+        #[pin]
+        future: F,
+        allow_origin: Option<AnyOr<Origin>>,
+        origin: HeaderValue,
+        allow_credentials: Option<HeaderValue>,
+        expose_headers: Option<HeaderValue>,
+    },
+    Error(Option<Response<B>>),
+}
+
+impl<F, B, E> Future for ResponseFuture<F, B>
+where
+    F: Future<Output = Result<Response<B>, E>>,
+{
+    type Output = Result<Response<B>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project().inner.project() {
+            KindProj::CorsCall {
+                future,
+                allow_origin,
+                origin,
+                allow_credentials,
+                expose_headers,
+            } => {
+                let mut response: Response<B> = ready!(future.poll(cx))?;
+
+                response.headers_mut().insert(
+                    header::ACCESS_CONTROL_ALLOW_ORIGIN,
+                    response_origin(allow_origin.take().unwrap(), origin),
+                );
+
+                if let Some(allow_credentials) = allow_credentials {
+                    response.headers_mut().insert(
+                        header::ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                        allow_credentials.clone(),
+                    );
+                }
+
+                if let Some(expose_headers) = expose_headers {
+                    response.headers_mut().insert(
+                        header::ACCESS_CONTROL_EXPOSE_HEADERS,
+                        expose_headers.clone(),
+                    );
+                }
+
+                Poll::Ready(Ok(response))
+            }
+            KindProj::NonCorsCall(future) => future.poll(cx),
+            KindProj::Error(res) => Poll::Ready(Ok(res.take().unwrap())),
+        }
+    }
+}
+
+fn response_origin(allow_origin: AnyOr<Origin>, origin: &HeaderValue) -> HeaderValue {
+    if let AnyOrInner::Any = allow_origin.0 {
+        WILDCARD.parse().unwrap()
+    } else {
+        origin.clone()
+    }
+}

--- a/tower-http/src/cors.rs
+++ b/tower-http/src/cors.rs
@@ -199,6 +199,19 @@ impl CorsLayer {
     /// ));
     /// ```
     ///
+    /// Multiple origins can be allowed with
+    ///
+    /// ```
+    /// use tower_http::cors::{CorsLayer, Origin};
+    ///
+    /// let origins = vec![
+    ///     "http://example.com".parse().unwrap(),
+    ///     "http://api.example.com".parse().unwrap(),
+    /// ];
+    ///
+    /// let layer = CorsLayer::new().allow_origin(Origin::list(origins));
+    /// ```
+    ///
     /// All origins can be allowed with
     ///
     /// ```

--- a/tower-http/src/cors.rs
+++ b/tower-http/src/cors.rs
@@ -314,7 +314,10 @@ impl<S> Layer<S> for CorsLayer {
     type Service = Cors<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        Cors::new(inner)
+        Cors {
+            inner,
+            layer: self.clone(),
+        }
     }
 }
 

--- a/tower-http/src/cors.rs
+++ b/tower-http/src/cors.rs
@@ -476,6 +476,10 @@ impl<S> Cors<S> {
     }
 
     fn is_valid_request_method(&self, method: &HeaderValue) -> bool {
+        if self.layer.allow_methods.as_bytes() == b"*" {
+            return true;
+        }
+
         self.layer
             .allow_methods
             .as_bytes()
@@ -727,12 +731,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_is_valid_origin() {
+    fn test_is_valid_request_method() {
         let cors = Cors::new(()).allow_methods(vec![Method::GET, Method::POST]);
         assert!(cors.is_valid_request_method(&HeaderValue::from_static("GET")));
         assert!(cors.is_valid_request_method(&HeaderValue::from_static("POST")));
 
         let cors = Cors::new(());
+        assert!(cors.is_valid_request_method(&HeaderValue::from_static("GET")));
+        assert!(cors.is_valid_request_method(&HeaderValue::from_static("POST")));
+        assert!(cors.is_valid_request_method(&HeaderValue::from_static("OPTIONS")));
+
+        let cors = Cors::new(()).allow_methods(Any);
         assert!(cors.is_valid_request_method(&HeaderValue::from_static("GET")));
         assert!(cors.is_valid_request_method(&HeaderValue::from_static("POST")));
         assert!(cors.is_valid_request_method(&HeaderValue::from_static("OPTIONS")));

--- a/tower-http/src/cors.rs
+++ b/tower-http/src/cors.rs
@@ -666,19 +666,8 @@ where
         if req.method() == Method::OPTIONS {
             // the method the real request will be made with
             match req.headers().get(header::ACCESS_CONTROL_REQUEST_METHOD) {
-                Some(request_method) => {
-                    if !self.is_valid_request_method(request_method) {
-                        return ResponseFuture {
-                            inner: Kind::Error(Some(
-                                Response::builder()
-                                    .status(StatusCode::OK)
-                                    .body(ResBody::default())
-                                    .unwrap(),
-                            )),
-                        };
-                    }
-                }
-                None => {
+                Some(request_method) if self.is_valid_request_method(request_method) => {}
+                _ => {
                     return ResponseFuture {
                         inner: Kind::Error(Some(
                             Response::builder()

--- a/tower-http/src/cors.rs
+++ b/tower-http/src/cors.rs
@@ -64,7 +64,7 @@ use std::{
 use tower_layer::Layer;
 use tower_service::Service;
 
-/// Layer that applies [`Cors`] which adds headers for [CORS][mdn].
+/// Layer that applies the [`Cors`] middleware which adds headers for [CORS][mdn].
 ///
 /// See the [module docs](crate::cors) for an example.
 ///
@@ -106,7 +106,7 @@ impl CorsLayer {
     /// - All headers exposed.
     /// - Max age set to 1 hour.
     ///
-    /// Note this is not recommended for production use
+    /// Note this is not recommended for production use.
     pub fn permissive() -> Self {
         Self::new()
             .allow_credentials(true)
@@ -578,17 +578,23 @@ impl<S> Cors<S> {
 
 /// Represents a [`Access-Control-Allow-Origin`][mdn] header.
 ///
+/// See [`CorsLayer::allow_origin`] for more details.
+///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
 #[derive(Clone, Debug)]
 pub struct Origin(OriginInner);
 
 impl Origin {
     /// Set a single allow origin target
+    ///
+    /// See [`CorsLayer::allow_origin`] for more details.
     pub fn exact(origin: HeaderValue) -> Self {
         Self(OriginInner::Exact(origin))
     }
 
     /// Set multiple allow origin targets
+    ///
+    /// See [`CorsLayer::allow_origin`] for more details.
     pub fn list<I>(origins: I) -> Self
     where
         I: IntoIterator<Item = HeaderValue>,
@@ -598,6 +604,8 @@ impl Origin {
     }
 
     /// Set the allowed origins from a predicate
+    ///
+    /// See [`CorsLayer::allow_origin`] for more details.
     pub fn predicate<F>(f: F) -> Self
     where
         F: Fn(&HeaderValue, &Parts) -> bool + Send + Sync + 'static,

--- a/tower-http/src/cors.rs
+++ b/tower-http/src/cors.rs
@@ -157,7 +157,7 @@ impl CorsLayer {
         I: Into<AnyOr<Vec<HeaderName>>>,
     {
         self.allow_headers = match headers.into().0 {
-            AnyOrInner::Any => Some("*".parse().unwrap()),
+            AnyOrInner::Any => Some(WILDCARD.parse().unwrap()),
             AnyOrInner::Value(headers) => Some(separated_by_commas(headers)),
         };
         self
@@ -211,7 +211,7 @@ impl CorsLayer {
         T: Into<AnyOr<Vec<Method>>>,
     {
         self.allow_methods = match methods.into().0 {
-            AnyOrInner::Any => Some("*".parse().unwrap()),
+            AnyOrInner::Any => Some(WILDCARD.parse().unwrap()),
             AnyOrInner::Value(methods) => Some(separated_by_commas(methods)),
         };
         self
@@ -299,7 +299,7 @@ impl CorsLayer {
         I: Into<AnyOr<Vec<HeaderName>>>,
     {
         self.expose_headers = Some(match headers.into().0 {
-            AnyOrInner::Any => "*".parse().unwrap(),
+            AnyOrInner::Any => WILDCARD.parse().unwrap(),
             AnyOrInner::Value(headers) => separated_by_commas(headers),
         });
         self
@@ -516,7 +516,7 @@ impl<S> Cors<S> {
 
     fn is_valid_request_method(&self, method: &HeaderValue) -> bool {
         if let Some(allow_methods) = &self.layer.allow_methods {
-            if allow_methods.as_bytes() == b"*" {
+            if allow_methods.as_bytes() == WILDCARD.as_bytes() {
                 return true;
             }
 

--- a/tower-http/src/cors.rs
+++ b/tower-http/src/cors.rs
@@ -6,7 +6,7 @@
 //! use http::{Request, Response, Method, header};
 //! use hyper::Body;
 //! use tower::{ServiceBuilder, ServiceExt, Service};
-//! use tower_http::cors::{CorsLayer, Any};
+//! use tower_http::cors::{CorsLayer, any};
 //! use std::convert::Infallible;
 //!
 //! async fn handle(request: Request<Body>) -> Result<Response<Body>, Infallible> {
@@ -19,7 +19,7 @@
 //!     // allow `GET` and `POST` when accessing the resource
 //!     .allow_methods(vec![Method::GET, Method::POST])
 //!     // allow requests from any origin
-//!     .allow_origin(Any);
+//!     .allow_origin(any());
 //!
 //! let mut service = ServiceBuilder::new()
 //!     .layer(cors)
@@ -110,10 +110,10 @@ impl CorsLayer {
     pub fn permissive() -> Self {
         Self::new()
             .allow_credentials(true)
-            .allow_headers(Any)
-            .allow_methods(Any)
-            .allow_origin(Any)
-            .expose_headers(Any)
+            .allow_headers(any())
+            .allow_methods(any())
+            .allow_origin(any())
+            .expose_headers(any())
             .max_age(Duration::from_secs(60 * 60))
     }
 
@@ -143,9 +143,9 @@ impl CorsLayer {
     /// All headers can be allowed with
     ///
     /// ```
-    /// use tower_http::cors::{CorsLayer, Any};
+    /// use tower_http::cors::{CorsLayer, any};
     ///
-    /// let layer = CorsLayer::new().allow_headers(Any);
+    /// let layer = CorsLayer::new().allow_headers(any());
     /// ```
     ///
     /// Note that multiple calls to this method will override any previous
@@ -200,9 +200,9 @@ impl CorsLayer {
     /// All methods can be allowed with
     ///
     /// ```
-    /// use tower_http::cors::{CorsLayer, Any};
+    /// use tower_http::cors::{CorsLayer, any};
     ///
-    /// let layer = CorsLayer::new().allow_methods(Any);
+    /// let layer = CorsLayer::new().allow_methods(any());
     /// ```
     ///
     /// Note that multiple calls to this method will override any previous
@@ -246,9 +246,9 @@ impl CorsLayer {
     /// All origins can be allowed with
     ///
     /// ```
-    /// use tower_http::cors::{CorsLayer, Any};
+    /// use tower_http::cors::{CorsLayer, any};
     ///
-    /// let layer = CorsLayer::new().allow_origin(Any);
+    /// let layer = CorsLayer::new().allow_origin(any());
     /// ```
     ///
     /// You can also use a closure
@@ -288,9 +288,9 @@ impl CorsLayer {
     /// All headers can be allowed with
     ///
     /// ```
-    /// use tower_http::cors::{CorsLayer, Any};
+    /// use tower_http::cors::{CorsLayer, any};
     ///
-    /// let layer = CorsLayer::new().expose_headers(Any);
+    /// let layer = CorsLayer::new().expose_headers(any());
     /// ```
     ///
     /// Note that multiple calls to this method will override any previous
@@ -311,8 +311,17 @@ impl CorsLayer {
 
 /// Represents a wildcard value (`*`) used with some CORS headers such as
 /// [`CorsLayer::allow_methods`].
+///
+/// Created with [`any`].
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub struct Any;
+
+/// Represents a wildcard value (`*`) used with some CORS headers such as
+/// [`CorsLayer::allow_methods`].
+pub fn any() -> Any {
+    Any
+}
 
 /// Used to make methods like [`CorsLayer::allow_methods`] more convenient to call.
 ///

--- a/tower-http/src/cors.rs
+++ b/tower-http/src/cors.rs
@@ -594,7 +594,7 @@ impl Origin {
         Self(OriginInner::List(origins))
     }
 
-    /// Set a allowed origins from a predicate
+    /// Set the allowed origins from a predicate
     pub fn predicate<F>(f: F) -> Self
     where
         F: Fn(&HeaderValue, &Parts) -> bool + Send + Sync + 'static,

--- a/tower-http/src/cors.rs
+++ b/tower-http/src/cors.rs
@@ -117,7 +117,7 @@ impl CorsLayer {
             .max_age(Duration::from_secs(60 * 60))
     }
 
-    /// Set the value of the [`Access-Control-Allow-Credentials`][mdn] header.
+    /// Set the [`Access-Control-Allow-Credentials`][mdn] header.
     ///
     /// ```
     /// use tower_http::cors::CorsLayer;
@@ -127,7 +127,7 @@ impl CorsLayer {
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials
     pub fn allow_credentials(mut self, allow_credentials: bool) -> Self {
-        self.allow_credentials = Some(allow_credentials.to_string().parse().unwrap());
+        self.allow_credentials = allow_credentials.then(|| HeaderValue::from_static("true"));
         self
     }
 
@@ -425,7 +425,7 @@ impl<S> Cors<S> {
         CorsLayer::new()
     }
 
-    /// Set the value of the [`Access-Control-Allow-Credentials`][mdn] header.
+    /// Set the [`Access-Control-Allow-Credentials`][mdn] header.
     ///
     /// See [`CorsLayer::allow_credentials`] for more details.
     ///

--- a/tower-http/src/cors.rs
+++ b/tower-http/src/cors.rs
@@ -678,7 +678,7 @@ where
                         return ResponseFuture {
                             inner: Kind::Error(Some(
                                 Response::builder()
-                                    .status(StatusCode::METHOD_NOT_ALLOWED)
+                                    .status(StatusCode::OK)
                                     .body(ResBody::default())
                                     .unwrap(),
                             )),
@@ -689,7 +689,7 @@ where
                     return ResponseFuture {
                         inner: Kind::Error(Some(
                             Response::builder()
-                                .status(StatusCode::UNAUTHORIZED)
+                                .status(StatusCode::OK)
                                 .body(ResBody::default())
                                 .unwrap(),
                         )),

--- a/tower-http/src/cors.rs
+++ b/tower-http/src/cors.rs
@@ -151,6 +151,9 @@ impl CorsLayer {
     /// Note that multiple calls to this method will override any previous
     /// calls.
     ///
+    /// Also note that `Access-Control-Allow-Headers` is required for requests that have
+    /// `Access-Control-Request-Headers`.
+    ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
     pub fn allow_headers<I>(mut self, headers: I) -> Self
     where

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -275,6 +275,10 @@ pub mod follow_redirect;
 #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
 pub mod metrics;
 
+#[cfg(feature = "cors")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cors")))]
+pub mod cors;
+
 pub mod classify;
 pub mod services;
 


### PR DESCRIPTION
Example usage:

```rust
use http::{Request, Response, Method, header};
use hyper::Body;
use tower::{ServiceBuilder, ServiceExt, Service};
use tower_http::cors::{CorsLayer, Any};
use std::convert::Infallible;

async fn handle(request: Request<Body>) -> Result<Response<Body>, Infallible> {
    Ok(Response::new(Body::empty()))
}

let cors = CorsLayer::new()
    .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS])
    .allow_origin(Any)
    .allow_credentials(false);

let mut service = ServiceBuilder::new()
    .layer(cors)
    .service_fn(handle);

let request = Request::builder()
    .header(header::ORIGIN, "https://example.com")
    .body(Body::empty())
    .unwrap();

let response = service
    .ready()
    .await?
    .call(request)
    .await?;

assert_eq!(
    response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN).unwrap(),
    "*",
);
```

Implementation is based on [`CorsMiddleware`](https://docs.rs/tide/0.16.0/tide/security/struct.CorsMiddleware.html#method.allow_credentials) from tide.