### PR TITLE
compression: Remove `ResBody::Error: Into<BoxError>` bounds

### DIFF
--- a/tower-http/src/compression/future.rs
+++ b/tower-http/src/compression/future.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 
 use super::{body::BodyInner, CompressionBody, Encoding};
-use crate::compression_utils::{supports_transparent_compression, BoxError, WrapBody};
+use crate::compression_utils::{supports_transparent_compression, WrapBody};
 use futures_util::ready;
 use http::{header, HeaderMap, HeaderValue, Response};
 use http_body::Body;

--- a/tower-http/src/compression/service.rs
+++ b/tower-http/src/compression/service.rs
@@ -1,5 +1,5 @@
 use super::{CompressionBody, CompressionLayer, Encoding, ResponseFuture};
-use crate::compression_utils::{AcceptEncoding, BoxError};
+use crate::compression_utils::AcceptEncoding;
 use http::{Request, Response};
 use http_body::Body;
 use std::task::{Context, Poll};
@@ -88,7 +88,6 @@ impl<ReqBody, ResBody, S> Service<Request<ReqBody>> for Compression<S>
 where
     S: Service<Request<ReqBody>, Response = Response<ResBody>>,
     ResBody: Body,
-    ResBody::Error: Into<BoxError>,
 {
     type Response = Response<CompressionBody<ResBody>>;
     type Error = S::Error;

--- a/tower-http/src/compression_utils.rs
+++ b/tower-http/src/compression_utils.rs
@@ -16,8 +16,6 @@ use tokio_util::io::{poll_read_buf, StreamReader};
 
 use crate::BodyOrIoError;
 
-pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync>;
-
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct AcceptEncoding {
     pub(crate) gzip: bool,

--- a/tower-http/src/decompression/future.rs
+++ b/tower-http/src/decompression/future.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 
 use super::{body::BodyInner, DecompressionBody};
-use crate::compression_utils::{AcceptEncoding, BoxError, WrapBody};
+use crate::compression_utils::{AcceptEncoding, WrapBody};
 use futures_util::ready;
 use http::{header, Response};
 use http_body::Body;
@@ -27,7 +27,6 @@ impl<F, B, E> Future for ResponseFuture<F>
 where
     F: Future<Output = Result<Response<B>, E>>,
     B: Body,
-    B::Error: Into<BoxError>,
 {
     type Output = Result<Response<DecompressionBody<B>>, E>;
 

--- a/tower-http/src/decompression/service.rs
+++ b/tower-http/src/decompression/service.rs
@@ -1,5 +1,5 @@
 use super::{DecompressionBody, DecompressionLayer, ResponseFuture};
-use crate::compression_utils::{supports_transparent_compression, AcceptEncoding, BoxError};
+use crate::compression_utils::{supports_transparent_compression, AcceptEncoding};
 use http::{
     header::{self, ACCEPT_ENCODING, RANGE},
     Request, Response,
@@ -91,7 +91,6 @@ impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for Decompression<S>
 where
     S: Service<Request<ReqBody>, Response = Response<ResBody>>,
     ResBody: Body,
-    ResBody::Error: Into<BoxError>,
 {
     type Response = Response<DecompressionBody<ResBody>>;
     type Error = S::Error;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

The `Into<BoxError>` trait bounds on the {de,}compression middlewares are unnecessarily strong requirements since the middlewares return the errors as-is without boxing.

## Solution

Remove the trait bounds.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
