### PR TITLE
permanent redir should avoid used when redir  foo-dir to foo-dir/

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- Enhancement: avoid using permanent redirection when redirect directory path without a trailing slash to the one has
 - Fix a [bug](https://github.com/tower-rs/tower-http/issues/121) which happens when `append_index_html_on_directories` is set to `false` in `ServeDir`.
 
 ## Breaking changes

--- a/tower-http/src/services/fs/serve_dir.rs
+++ b/tower-http/src/services/fs/serve_dir.rs
@@ -177,7 +177,7 @@ impl Future for ResponseFuture {
                     Ok(Output::Redirect(location)) => {
                         let res = Response::builder()
                             .header(http::header::LOCATION, location)
-                            .status(StatusCode::PERMANENT_REDIRECT)
+                            .status(StatusCode::TEMPORARY_REDIRECT)
                             .body(empty_body())
                             .unwrap();
                         return Poll::Ready(Ok(res));
@@ -299,7 +299,7 @@ mod tests {
         let req = Request::builder().uri("/src").body(Body::empty()).unwrap();
         let res = svc.oneshot(req).await.unwrap();
 
-        assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);
+        assert_eq!(res.status(), StatusCode::TEMPORARY_REDIRECT);
 
         let location = &res.headers()[http::header::LOCATION];
         assert_eq!(location, "/src/");


### PR DESCRIPTION
## Motivation

The problem is about default browser behavior like Chrome.

for example the root dir has a sub dir named `foo` and it does exists.

when user agent access `/foo`, by default, tower `ServeDir` will redirect it to `/foo/`

this is OK.

but somehow, you moved the `foo` dir to other place. and you wnat't to put a file named `foo`

yes, they have the same name.

then if you try to access the uri again: `/foo`, Chrome will not contact the http server again

and just do a client side redirect since you tell Chrome that it is `permanent` redirect.

![image](https://user-images.githubusercontent.com/41882455/131015503-3305aae9-7d01-46e7-89d7-eae87a0c004e.png)

yes, it shows `Status Code: 308 Permanent Redirect (from disk cache)`

you'll never have the chance to access the file named `foo` if you don't do a `Empty Cache and Hard Reload` operation.  (`Hard Reload` and `Normal Reload` can not clean a Permanent Redirect)

## Solution

use temporay redirect.
