### PR TITLE
Remove duplicate code from compression/layer.rs

### DIFF
--- a/tower-http/src/compression/layer.rs
+++ b/tower-http/src/compression/layer.rs
@@ -1,5 +1,4 @@
 use super::Compression;
-use crate::compression_utils::AcceptEncoding;
 use tower_layer::Layer;
 
 /// Compress response bodies of the underlying service.
@@ -11,7 +10,6 @@ use tower_layer::Layer;
 #[derive(Clone, Debug, Default)]
 pub struct CompressionLayer {
     _priv: (),
-    accept: AcceptEncoding,
 }
 
 impl<S> Layer<S> for CompressionLayer {
@@ -26,53 +24,5 @@ impl CompressionLayer {
     /// Create a new [`CompressionLayer`]
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Sets whether to enable the gzip encoding.
-    #[cfg(feature = "compression-gzip")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compression-gzip")))]
-    pub fn gzip(self, enable: bool) -> Self {
-        self.accept.set_gzip(enable);
-        self
-    }
-
-    /// Sets whether to enable the Deflate encoding.
-    #[cfg(feature = "compression-deflate")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compression-deflate")))]
-    pub fn deflate(self, enable: bool) -> Self {
-        self.accept.set_deflate(enable);
-        self
-    }
-
-    /// Sets whether to enable the Brotli encoding.
-    #[cfg(feature = "compression-br")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compression-br")))]
-    pub fn br(self, enable: bool) -> Self {
-        self.accept.set_br(enable);
-        self
-    }
-
-    /// Disables the gzip encoding.
-    ///
-    /// This method is available even if the `gzip` crate feature is disabled.
-    pub fn no_gzip(self) -> Self {
-        self.accept.set_gzip(false);
-        self
-    }
-
-    /// Disables the Deflate encoding.
-    ///
-    /// This method is available even if the `deflate` crate feature is disabled.
-    pub fn no_deflate(self) -> Self {
-        self.accept.set_deflate(false);
-        self
-    }
-
-    /// Disables the Brotli encoding.
-    ///
-    /// This method is available even if the `br` crate feature is disabled.
-    pub fn no_br(self) -> Self {
-        self.accept.set_br(false);
-        self
     }
 }


### PR DESCRIPTION
struct `Compression` and struct `CompressionLayer` has a exactly same set of methods.

[CompressionLayer code](https://github.com/tower-rs/tower-http/blob/e25d4f099e792e38daafac74bf6238b3f855774a/tower-http/src/compression/layer.rs#L32-L77)

[Compression code](https://github.com/tower-rs/tower-http/blob/e25d4f099e792e38daafac74bf6238b3f855774a/tower-http/src/compression/service.rs#L38-L84)

It turns out `CompressionLayer`'s set of methods are not used anywhere and they are not in the documentation or any API. Removing them doesn't impact things and tidies up the code.

In fact, `CompressionLayer::new()` returns a `Compression` instance and those methods only need to exist there.
