### PR TITLE
Bug fix: [de]compression layers ignore configuration

### DIFF
--- a/tower-http/src/compression/layer.rs
+++ b/tower-http/src/compression/layer.rs
@@ -18,7 +18,10 @@ impl<S> Layer<S> for CompressionLayer {
     type Service = Compression<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        Compression::new(inner)
+        let mut outer = Compression::new(inner);
+        println!("layer's accept: {:?}", self.accept);
+        outer.accept = self.accept;
+        outer
     }
 }
 
@@ -31,7 +34,7 @@ impl CompressionLayer {
     /// Sets whether to enable the gzip encoding.
     #[cfg(feature = "compression-gzip")]
     #[cfg_attr(docsrs, doc(cfg(feature = "compression-gzip")))]
-    pub fn gzip(self, enable: bool) -> Self {
+    pub fn gzip(mut self, enable: bool) -> Self {
         self.accept.set_gzip(enable);
         self
     }
@@ -39,7 +42,7 @@ impl CompressionLayer {
     /// Sets whether to enable the Deflate encoding.
     #[cfg(feature = "compression-deflate")]
     #[cfg_attr(docsrs, doc(cfg(feature = "compression-deflate")))]
-    pub fn deflate(self, enable: bool) -> Self {
+    pub fn deflate(mut self, enable: bool) -> Self {
         self.accept.set_deflate(enable);
         self
     }
@@ -47,7 +50,7 @@ impl CompressionLayer {
     /// Sets whether to enable the Brotli encoding.
     #[cfg(feature = "compression-br")]
     #[cfg_attr(docsrs, doc(cfg(feature = "compression-br")))]
-    pub fn br(self, enable: bool) -> Self {
+    pub fn br(mut self, enable: bool) -> Self {
         self.accept.set_br(enable);
         self
     }
@@ -55,7 +58,7 @@ impl CompressionLayer {
     /// Disables the gzip encoding.
     ///
     /// This method is available even if the `gzip` crate feature is disabled.
-    pub fn no_gzip(self) -> Self {
+    pub fn no_gzip(mut self) -> Self {
         self.accept.set_gzip(false);
         self
     }
@@ -63,7 +66,7 @@ impl CompressionLayer {
     /// Disables the Deflate encoding.
     ///
     /// This method is available even if the `deflate` crate feature is disabled.
-    pub fn no_deflate(self) -> Self {
+    pub fn no_deflate(mut self) -> Self {
         self.accept.set_deflate(false);
         self
     }
@@ -71,8 +74,106 @@ impl CompressionLayer {
     /// Disables the Brotli encoding.
     ///
     /// This method is available even if the `br` crate feature is disabled.
-    pub fn no_br(self) -> Self {
+    pub fn no_br(mut self) -> Self {
         self.accept.set_br(false);
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::fs::File;
+    use http::{Request, Response, header::ACCEPT_ENCODING};
+    use hyper::Body;
+    use http_body::Body as _;
+    // for Body::data
+    use std::convert::Infallible;
+    use tokio_util::io::ReaderStream;
+    use tower::{Service, ServiceExt, ServiceBuilder};
+    use bytes::{Bytes, BytesMut};
+
+    async fn handle(_req: Request<Body>) -> Result<Response<Body>, Infallible> {
+        // Open the file.
+        let file = File::open("Cargo.toml").await.expect("file missing");
+        // Convert the file into a `Stream`.
+        let stream = ReaderStream::new(file);
+        // Convert the `Stream` into a `Body`.
+        let body = Body::wrap_stream(stream);
+        // Create response.
+        Ok(Response::new(body))
+    }
+
+    #[tokio::test]
+    async fn accept_encoding_configuration_works() -> Result<(), Box<dyn std::error::Error>> {
+        let deflate_only_layer = CompressionLayer::new().no_br().no_gzip();
+        println!("layer's accept right after setting: {:?}", deflate_only_layer.accept);
+
+        let mut service = ServiceBuilder::new()
+            // Compress responses based on the `Accept-Encoding` header.
+            .layer(deflate_only_layer)
+            .service_fn(handle);
+
+        // Call the service with the deflate only layer
+        let request = Request::builder()
+            .header(ACCEPT_ENCODING, "gzip, deflate, br")
+            .body(Body::empty())?;
+
+        let response = service
+            .ready()
+            .await?
+            .call(request)
+            .await?;
+
+        assert_eq!(response.headers()["content-encoding"], "deflate");
+
+        // Read the body
+        let mut body = response.into_body();
+        let mut bytes = BytesMut::new();
+        while let Some(chunk) = body.data().await {
+            let chunk = chunk?;
+            bytes.extend_from_slice(&chunk[..]);
+        }
+        let bytes: Bytes = bytes.freeze();
+
+        let deflate_bytes_len = bytes.len();
+
+
+        let br_only_layer = CompressionLayer::new().no_gzip().no_deflate();
+
+        let mut service = ServiceBuilder::new()
+            // Compress responses based on the `Accept-Encoding` header.
+            .layer(br_only_layer)
+            .service_fn(handle);
+
+        // Call the service with the br only layer
+        let request = Request::builder()
+            .header(ACCEPT_ENCODING, "gzip, deflate, br")
+            .body(Body::empty())?;
+
+        let response = service
+            .ready()
+            .await?
+            .call(request)
+            .await?;
+
+        assert_eq!(response.headers()["content-encoding"], "br");
+
+        // Read the body
+        let mut body = response.into_body();
+        let mut bytes = BytesMut::new();
+        while let Some(chunk) = body.data().await {
+            let chunk = chunk?;
+            bytes.extend_from_slice(&chunk[..]);
+        }
+        let bytes: Bytes = bytes.freeze();
+
+        let br_byte_length = bytes.len();
+
+        // check the corresponding algorithms are actually used
+        // br should compresses better than deflate
+        assert!(br_byte_length < deflate_bytes_len * 9 / 10);
+
+        Ok(())
     }
 }

--- a/tower-http/src/compression/layer.rs
+++ b/tower-http/src/compression/layer.rs
@@ -19,7 +19,6 @@ impl<S> Layer<S> for CompressionLayer {
 
     fn layer(&self, inner: S) -> Self::Service {
         let mut outer = Compression::new(inner);
-        println!("layer's accept: {:?}", self.accept);
         outer.accept = self.accept;
         outer
     }
@@ -107,7 +106,6 @@ mod tests {
     #[tokio::test]
     async fn accept_encoding_configuration_works() -> Result<(), Box<dyn std::error::Error>> {
         let deflate_only_layer = CompressionLayer::new().no_br().no_gzip();
-        println!("layer's accept right after setting: {:?}", deflate_only_layer.accept);
 
         let mut service = ServiceBuilder::new()
             // Compress responses based on the `Accept-Encoding` header.

--- a/tower-http/src/compression/layer.rs
+++ b/tower-http/src/compression/layer.rs
@@ -18,9 +18,7 @@ impl<S> Layer<S> for CompressionLayer {
     type Service = Compression<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        let mut outer = Compression::new(inner);
-        outer.accept = self.accept;
-        outer
+        Compression { inner, accept: self.accept }
     }
 }
 

--- a/tower-http/src/compression/mod.rs
+++ b/tower-http/src/compression/mod.rs
@@ -138,7 +138,6 @@ impl Encoding {
 
 // based on https://github.com/http-rs/accept-encoding
 fn encodings(headers: &HeaderMap, accept: AcceptEncoding) -> Vec<(Encoding, f32)> {
-    println!("{:?}", accept);
     let ret = headers
         .get_all(header::ACCEPT_ENCODING)
         .iter()
@@ -169,7 +168,6 @@ fn encodings(headers: &HeaderMap, accept: AcceptEncoding) -> Vec<(Encoding, f32)
         })
         .collect::<Vec<(Encoding, f32)>>();
 
-    println!("{:?}", ret);
 
     ret
 }

--- a/tower-http/src/compression/mod.rs
+++ b/tower-http/src/compression/mod.rs
@@ -138,7 +138,8 @@ impl Encoding {
 
 // based on https://github.com/http-rs/accept-encoding
 fn encodings(headers: &HeaderMap, accept: AcceptEncoding) -> Vec<(Encoding, f32)> {
-    headers
+    println!("{:?}", accept);
+    let ret = headers
         .get_all(header::ACCEPT_ENCODING)
         .iter()
         .filter_map(|hval| hval.to_str().ok())
@@ -166,7 +167,11 @@ fn encodings(headers: &HeaderMap, accept: AcceptEncoding) -> Vec<(Encoding, f32)
 
             Some((encoding, qval))
         })
-        .collect::<Vec<(Encoding, f32)>>()
+        .collect::<Vec<(Encoding, f32)>>();
+
+    println!("{:?}", ret);
+
+    ret
 }
 
 #[cfg(test)]

--- a/tower-http/src/compression/mod.rs
+++ b/tower-http/src/compression/mod.rs
@@ -138,7 +138,7 @@ impl Encoding {
 
 // based on https://github.com/http-rs/accept-encoding
 fn encodings(headers: &HeaderMap, accept: AcceptEncoding) -> Vec<(Encoding, f32)> {
-    let ret = headers
+    headers
         .get_all(header::ACCEPT_ENCODING)
         .iter()
         .filter_map(|hval| hval.to_str().ok())
@@ -166,10 +166,7 @@ fn encodings(headers: &HeaderMap, accept: AcceptEncoding) -> Vec<(Encoding, f32)
 
             Some((encoding, qval))
         })
-        .collect::<Vec<(Encoding, f32)>>();
-
-
-    ret
+        .collect::<Vec<(Encoding, f32)>>()
 }
 
 #[cfg(test)]

--- a/tower-http/src/compression/service.rs
+++ b/tower-http/src/compression/service.rs
@@ -38,7 +38,7 @@ impl<S> Compression<S> {
     /// Sets whether to enable the gzip encoding.
     #[cfg(feature = "compression-gzip")]
     #[cfg_attr(docsrs, doc(cfg(feature = "compression-gzip")))]
-    pub fn gzip(self, enable: bool) -> Self {
+    pub fn gzip(mut self, enable: bool) -> Self {
         self.accept.set_gzip(enable);
         self
     }
@@ -46,7 +46,7 @@ impl<S> Compression<S> {
     /// Sets whether to enable the Deflate encoding.
     #[cfg(feature = "compression-deflate")]
     #[cfg_attr(docsrs, doc(cfg(feature = "compression-deflate")))]
-    pub fn deflate(self, enable: bool) -> Self {
+    pub fn deflate(mut self, enable: bool) -> Self {
         self.accept.set_deflate(enable);
         self
     }
@@ -54,7 +54,7 @@ impl<S> Compression<S> {
     /// Sets whether to enable the Brotli encoding.
     #[cfg(feature = "compression-br")]
     #[cfg_attr(docsrs, doc(cfg(feature = "compression-br")))]
-    pub fn br(self, enable: bool) -> Self {
+    pub fn br(mut self, enable: bool) -> Self {
         self.accept.set_br(enable);
         self
     }
@@ -62,7 +62,7 @@ impl<S> Compression<S> {
     /// Disables the gzip encoding.
     ///
     /// This method is available even if the `gzip` crate feature is disabled.
-    pub fn no_gzip(self) -> Self {
+    pub fn no_gzip(mut self) -> Self {
         self.accept.set_gzip(false);
         self
     }
@@ -70,7 +70,7 @@ impl<S> Compression<S> {
     /// Disables the Deflate encoding.
     ///
     /// This method is available even if the `deflate` crate feature is disabled.
-    pub fn no_deflate(self) -> Self {
+    pub fn no_deflate(mut self) -> Self {
         self.accept.set_deflate(false);
         self
     }
@@ -78,7 +78,7 @@ impl<S> Compression<S> {
     /// Disables the Brotli encoding.
     ///
     /// This method is available even if the `br` crate feature is disabled.
-    pub fn no_br(self) -> Self {
+    pub fn no_br(mut self) -> Self {
         self.accept.set_br(false);
         self
     }

--- a/tower-http/src/compression_utils.rs
+++ b/tower-http/src/compression_utils.rs
@@ -78,21 +78,18 @@ impl AcceptEncoding {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn set_gzip(mut self, enable: bool) -> Self {
+    pub(crate) fn set_gzip(& mut self, enable: bool) {
         self.gzip = enable;
-        self
     }
 
     #[allow(dead_code)]
-    pub(crate) fn set_deflate(mut self, enable: bool) -> Self {
+    pub(crate) fn set_deflate(& mut self, enable: bool) {
         self.deflate = enable;
-        self
     }
 
     #[allow(dead_code)]
-    pub(crate) fn set_br(mut self, enable: bool) -> Self {
+    pub(crate) fn set_br(& mut self, enable: bool) {
         self.br = enable;
-        self
     }
 }
 

--- a/tower-http/src/compression_utils.rs
+++ b/tower-http/src/compression_utils.rs
@@ -76,17 +76,17 @@ impl AcceptEncoding {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn set_gzip(& mut self, enable: bool) {
+    pub(crate) fn set_gzip(&mut self, enable: bool) {
         self.gzip = enable;
     }
 
     #[allow(dead_code)]
-    pub(crate) fn set_deflate(& mut self, enable: bool) {
+    pub(crate) fn set_deflate(&mut self, enable: bool) {
         self.deflate = enable;
     }
 
     #[allow(dead_code)]
-    pub(crate) fn set_br(& mut self, enable: bool) {
+    pub(crate) fn set_br(&mut self, enable: bool) {
         self.br = enable;
     }
 }

--- a/tower-http/src/decompression/layer.rs
+++ b/tower-http/src/decompression/layer.rs
@@ -33,7 +33,7 @@ impl DecompressionLayer {
     /// Sets whether to request the gzip encoding.
     #[cfg(feature = "decompression-gzip")]
     #[cfg_attr(docsrs, doc(cfg(feature = "decompression-gzip")))]
-    pub fn gzip(self, enable: bool) -> Self {
+    pub fn gzip(mut self, enable: bool) -> Self {
         self.accept.set_gzip(enable);
         self
     }
@@ -41,7 +41,7 @@ impl DecompressionLayer {
     /// Sets whether to request the Deflate encoding.
     #[cfg(feature = "decompression-deflate")]
     #[cfg_attr(docsrs, doc(cfg(feature = "decompression-deflate")))]
-    pub fn deflate(self, enable: bool) -> Self {
+    pub fn deflate(mut self, enable: bool) -> Self {
         self.accept.set_deflate(enable);
         self
     }
@@ -49,7 +49,7 @@ impl DecompressionLayer {
     /// Sets whether to request the Brotli encoding.
     #[cfg(feature = "decompression-br")]
     #[cfg_attr(docsrs, doc(cfg(feature = "decompression-br")))]
-    pub fn br(self, enable: bool) -> Self {
+    pub fn br(mut self, enable: bool) -> Self {
         self.accept.set_br(enable);
         self
     }
@@ -57,7 +57,7 @@ impl DecompressionLayer {
     /// Disables the gzip encoding.
     ///
     /// This method is available even if the `gzip` crate feature is disabled.
-    pub fn no_gzip(self) -> Self {
+    pub fn no_gzip(mut self) -> Self {
         self.accept.set_gzip(false);
         self
     }
@@ -65,7 +65,7 @@ impl DecompressionLayer {
     /// Disables the Deflate encoding.
     ///
     /// This method is available even if the `deflate` crate feature is disabled.
-    pub fn no_deflate(self) -> Self {
+    pub fn no_deflate(mut self) -> Self {
         self.accept.set_deflate(false);
         self
     }
@@ -73,7 +73,7 @@ impl DecompressionLayer {
     /// Disables the Brotli encoding.
     ///
     /// This method is available even if the `br` crate feature is disabled.
-    pub fn no_br(self) -> Self {
+    pub fn no_br(mut self) -> Self {
         self.accept.set_br(false);
         self
     }

--- a/tower-http/src/decompression/service.rs
+++ b/tower-http/src/decompression/service.rs
@@ -41,7 +41,7 @@ impl<S> Decompression<S> {
     /// Sets whether to request the gzip encoding.
     #[cfg(feature = "decompression-gzip")]
     #[cfg_attr(docsrs, doc(cfg(feature = "decompression-gzip")))]
-    pub fn gzip(self, enable: bool) -> Self {
+    pub fn gzip(mut self, enable: bool) -> Self {
         self.accept.set_gzip(enable);
         self
     }
@@ -49,7 +49,7 @@ impl<S> Decompression<S> {
     /// Sets whether to request the Deflate encoding.
     #[cfg(feature = "decompression-deflate")]
     #[cfg_attr(docsrs, doc(cfg(feature = "decompression-deflate")))]
-    pub fn deflate(self, enable: bool) -> Self {
+    pub fn deflate(mut self, enable: bool) -> Self {
         self.accept.set_deflate(enable);
         self
     }
@@ -57,7 +57,7 @@ impl<S> Decompression<S> {
     /// Sets whether to request the Brotli encoding.
     #[cfg(feature = "decompression-br")]
     #[cfg_attr(docsrs, doc(cfg(feature = "decompression-br")))]
-    pub fn br(self, enable: bool) -> Self {
+    pub fn br(mut self, enable: bool) -> Self {
         self.accept.set_br(enable);
         self
     }
@@ -65,7 +65,7 @@ impl<S> Decompression<S> {
     /// Disables the gzip encoding.
     ///
     /// This method is available even if the `gzip` crate feature is disabled.
-    pub fn no_gzip(self) -> Self {
+    pub fn no_gzip(mut self) -> Self {
         self.accept.set_gzip(false);
         self
     }
@@ -73,7 +73,7 @@ impl<S> Decompression<S> {
     /// Disables the Deflate encoding.
     ///
     /// This method is available even if the `deflate` crate feature is disabled.
-    pub fn no_deflate(self) -> Self {
+    pub fn no_deflate(mut self) -> Self {
         self.accept.set_deflate(false);
         self
     }
@@ -81,7 +81,7 @@ impl<S> Decompression<S> {
     /// Disables the Brotli encoding.
     ///
     /// This method is available even if the `br` crate feature is disabled.
-    pub fn no_br(self) -> Self {
+    pub fn no_br(mut self) -> Self {
         self.accept.set_br(false);
         self
     }


### PR DESCRIPTION
* Decompression layer and compression layer now accepts encoding configuration

* Added regression test to make sure compression layer registers configuration

whoa, so compression layers and decompression layers just ignored those `.set_br`/`.no_br` calls...I fixed it! 