### PR TITLE
ServeDir: reuse buf and reponse Stream, optimize the default chunk buf size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,7 @@ members = [
   "examples/warp-key-value-store",
   "examples/tonic-key-value-store",
 ]
+
+[patch.crates-io]
+tokio = { git = "https://github.com/tokio-rs/tokio.git", branch = "master"}
+tokio-util = { git = "https://github.com/tokio-rs/tokio.git", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,3 @@ members = [
   "examples/warp-key-value-store",
   "examples/tonic-key-value-store",
 ]
-
-[patch.crates-io]
-tokio = { git = "https://github.com/tokio-rs/tokio.git", branch = "master"}
-tokio-util = { git = "https://github.com/tokio-rs/tokio.git", branch = "master" }

--- a/tower-http/src/services/fs/serve_dir.rs
+++ b/tower-http/src/services/fs/serve_dir.rs
@@ -55,7 +55,9 @@ impl ServeDir {
         self
     }
 
-    /// set custom buffer chunk size.
+    /// Set a specific read buffer chunk size.
+    ///
+    /// The default capacity is 64kb.
     pub fn with_buf_chunk_size(mut self, chunk_size: usize) -> Self {
         self.buf_chunk_size = chunk_size;
         self

--- a/tower-http/src/services/fs/serve_dir.rs
+++ b/tower-http/src/services/fs/serve_dir.rs
@@ -277,6 +277,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn with_custom_chunk_size() {
+        let svc = ServeDir::new("..").with_buf_chunk_size(1024 * 32);
+
+        let req = Request::builder()
+            .uri("/README.md")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.headers()["content-type"], "text/markdown");
+
+        let body = body_into_text(res.into_body()).await;
+
+        let contents = std::fs::read_to_string("../README.md").unwrap();
+        assert_eq!(body, contents);
+    }
+
+    #[tokio::test]
     async fn access_to_sub_dirs() {
         let svc = ServeDir::new("..");
 

--- a/tower-http/src/services/fs/serve_file.rs
+++ b/tower-http/src/services/fs/serve_file.rs
@@ -65,7 +65,9 @@ impl ServeFile {
         }
     }
 
-    /// set custom buffer chunk size.
+    /// Set a specific read buffer chunk size.
+    ///
+    /// The default capacity is 64kb.
     pub fn with_buf_chunk_size(mut self, chunk_size: usize) -> Self {
         self.buf_chunk_size = chunk_size;
         self

--- a/tower-http/src/services/fs/serve_file.rs
+++ b/tower-http/src/services/fs/serve_file.rs
@@ -1,6 +1,7 @@
 //! Service that serves a file.
 
 use super::AsyncReadBody;
+use crate::services::fs::DEFAULT_CAPACITY;
 use bytes::Bytes;
 use futures_util::ready;
 use http::{header, HeaderValue, Response};
@@ -21,6 +22,7 @@ use tower_service::Service;
 pub struct ServeFile {
     path: PathBuf,
     mime: HeaderValue,
+    buf_chunk_size: usize,
 }
 
 impl ServeFile {
@@ -38,7 +40,11 @@ impl ServeFile {
 
         let path = path.as_ref().to_owned();
 
-        Self { path, mime }
+        Self {
+            path,
+            mime,
+            buf_chunk_size: DEFAULT_CAPACITY,
+        }
     }
 
     /// Create a new [`ServeFile`] with a specific mime type.
@@ -52,7 +58,17 @@ impl ServeFile {
         let mime = HeaderValue::from_str(mime.as_ref()).expect("mime isn't a valid header value");
         let path = path.as_ref().to_owned();
 
-        Self { path, mime }
+        Self {
+            path,
+            mime,
+            buf_chunk_size: DEFAULT_CAPACITY,
+        }
+    }
+
+    /// set custom buffer chunk size.
+    pub fn with_buf_chunk_size(mut self, chunk_size: usize) -> Self {
+        self.buf_chunk_size = chunk_size;
+        self
     }
 }
 
@@ -72,6 +88,7 @@ impl<R> Service<R> for ServeFile {
         ResponseFuture {
             open_file_future,
             mime: Some(self.mime.clone()),
+            buf_chunk_size: self.buf_chunk_size,
         }
     }
 }
@@ -80,6 +97,7 @@ impl<R> Service<R> for ServeFile {
 pub struct ResponseFuture {
     open_file_future: Pin<Box<dyn Future<Output = io::Result<File>> + Send + Sync + 'static>>,
     mime: Option<HeaderValue>,
+    buf_chunk_size: usize,
 }
 
 impl Future for ResponseFuture {
@@ -97,7 +115,8 @@ impl Future for ResponseFuture {
             }
         };
 
-        let body = AsyncReadBody::new(file).boxed();
+        let chunk_size = self.buf_chunk_size;
+        let body = AsyncReadBody::with_capacity(file, chunk_size).boxed();
         let body = ResponseBody(body);
 
         let mut res = Response::new(body);
@@ -125,6 +144,20 @@ mod tests {
     #[tokio::test]
     async fn basic() {
         let svc = ServeFile::new("../README.md");
+
+        let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
+
+        assert_eq!(res.headers()["content-type"], "text/markdown");
+
+        let body = res.into_body().data().await.unwrap().unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(body.starts_with("# Tower HTTP"));
+    }
+
+    #[tokio::test]
+    async fn with_custom_chunk_size() {
+        let svc = ServeFile::new("../README.md").with_buf_chunk_size(1024 * 32);
 
         let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
 


### PR DESCRIPTION

~~we need wait tokio release the next version of `tokio-util` since this PR depends on the commit https://github.com/tokio-rs/tokio/commit/d0dd74a0583b3ed7c8c7f68a4279fe9709bbf158~~

`tokio-util` 0.6.8 has been released (https://crates.io/crates/tokio-util/0.6.8)

## Motivation

With this PR, the `ServeDir` file sending speed up from `6MiB/s` to `1318M/s` on my machine (target `release` build).

The default buf size changed to `64KiB`, which is a reasonable value in some other popular Rust web framework. I think we are ok with this value.

## Solution

1. reuse the buf ( do not `new` on every `poll`)
2. change the default buffer chunk size to a rather reasonable value
3. add `with_capacity()` method allow to customize the buffer capacity (currently this method is internal use only)
