### PR TITLE
feat: Allow specifying a minimum body size for compression

### DIFF
--- a/tower-http/src/compression/future.rs
+++ b/tower-http/src/compression/future.rs
@@ -21,7 +21,7 @@ pub struct ResponseFuture<F> {
     #[pin]
     pub(crate) inner: F,
     pub(crate) encoding: Encoding,
-    pub(crate) min_size: u64,
+    pub(crate) min_size: u16,
 }
 
 impl<F, B, E> Future for ResponseFuture<F>
@@ -45,7 +45,7 @@ where
                 .and_then(|val| val.parse().ok())
         });
         let content_size_less_than_min = match content_size {
-            Some(size) if size < self.min_size => true,
+            Some(size) if size < (self.min_size as u64) => true,
             _ => false,
         };
 

--- a/tower-http/src/compression/layer.rs
+++ b/tower-http/src/compression/layer.rs
@@ -11,7 +11,7 @@ use tower_layer::Layer;
 #[derive(Clone, Debug, Default)]
 pub struct CompressionLayer {
     accept: AcceptEncoding,
-    min_size: u64,
+    min_size: u16,
 }
 
 impl<S> Layer<S> for CompressionLayer {
@@ -89,7 +89,7 @@ impl CompressionLayer {
     /// Passing `0` makes the layer compress every response.
     ///
     /// The default is 32 bytes.
-    pub fn min_size(mut self, min: u64) -> Self {
+    pub fn min_size(mut self, min: u16) -> Self {
         self.min_size = min;
         self
     }

--- a/tower-http/src/compression/layer.rs
+++ b/tower-http/src/compression/layer.rs
@@ -1,4 +1,4 @@
-use super::Compression;
+use super::{Compression, MIN_SIZE_DEFAULT};
 use crate::compression_utils::AcceptEncoding;
 use tower_layer::Layer;
 
@@ -10,8 +10,8 @@ use tower_layer::Layer;
 /// See the [module docs](crate::compression) for more details.
 #[derive(Clone, Debug, Default)]
 pub struct CompressionLayer {
-    _priv: (),
     accept: AcceptEncoding,
+    min_size: u64,
 }
 
 impl<S> Layer<S> for CompressionLayer {
@@ -25,7 +25,10 @@ impl<S> Layer<S> for CompressionLayer {
 impl CompressionLayer {
     /// Create a new [`CompressionLayer`]
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            accept: Default::default(),
+            min_size: MIN_SIZE_DEFAULT,
+        }
     }
 
     /// Sets whether to enable the gzip encoding.
@@ -73,6 +76,21 @@ impl CompressionLayer {
     /// This method is available even if the `br` crate feature is disabled.
     pub fn no_br(self) -> Self {
         self.accept.set_br(false);
+        self
+    }
+
+    /// Configures the minimum size at which the layer starts compressing response
+    /// bodies.
+    ///
+    /// Any response smaller than `min` will not be compressed. The response size
+    /// is determined by inspecting [`Body::size_hint()`] and the `content-length`
+    /// header.
+    ///
+    /// Passing `0` makes the layer compress every response.
+    ///
+    /// The default is 32 bytes.
+    pub fn min_size(mut self, min: u64) -> Self {
+        self.min_size = min;
         self
     }
 }

--- a/tower-http/src/compression/layer.rs
+++ b/tower-http/src/compression/layer.rs
@@ -8,10 +8,16 @@ use tower_layer::Layer;
 /// `Content-Encoding` header to responses.
 ///
 /// See the [module docs](crate::compression) for more details.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct CompressionLayer {
     accept: AcceptEncoding,
     min_size: u16,
+}
+
+impl Default for CompressionLayer {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<S> Layer<S> for CompressionLayer {

--- a/tower-http/src/compression/mod.rs
+++ b/tower-http/src/compression/mod.rs
@@ -1,5 +1,8 @@
 //! Middleware that compresses response bodies.
 //!
+//! The middleware will only compress response bodies above a certain size. By default,
+//! this lower limit is 32 bytes.
+//!
 //! # Example
 //!
 //! Example showing how to respond with the compressed contents of a file.
@@ -78,7 +81,7 @@ pub use self::{
 /// The default minimum size a body needs to have for us to compress it.
 ///
 /// Used to stop the layer from compressing 0-sized responses.
-const MIN_SIZE_DEFAULT: u64 = 32;
+const MIN_SIZE_DEFAULT: u16 = 32;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Encoding {

--- a/tower-http/src/compression/service.rs
+++ b/tower-http/src/compression/service.rs
@@ -15,7 +15,7 @@ use tower_service::Service;
 pub struct Compression<S> {
     pub(crate) inner: S,
     pub(crate) accept: AcceptEncoding,
-    pub(crate) min_size: u64,
+    pub(crate) min_size: u16,
 }
 
 impl<S> Compression<S> {
@@ -95,7 +95,7 @@ impl<S> Compression<S> {
     /// Passing `0` makes the service compress every response.
     ///
     /// The default is 32 bytes.
-    pub fn min_size(mut self, min: u64) -> Self {
+    pub fn min_size(mut self, min: u16) -> Self {
         self.min_size = min;
         self
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

Closes #139 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

The layer now inspects the response body's `size_hint` (only if exact) and `content-length` header to measure the size of the content. If it's below a preconfigured threshold (default: 32 bytes) compression won't happen.

Now, the only remaining question I have is what the default should be. I think having a default `> 0` is very helpful, because it stops the layer from wasting time compressing 0-sized and "very-small" responses. The only question is, what's "very-small"? nginx uses a default of 20 bytes, and I used 32 because it's a power of two and close to 20. Alternatives I see:
- 0 bytes, keep the behavior identical to the current implementation. Users need to actively "do something" though to improve behavior on empty responses, whereas with a `> 0` default they get that "for free".
- 1 byte, just to save us from compressing 0-sized responses
- 256 / 512 / 1024, a bit larger, low risk of wasting bandwith on http / text files

~~Lastly, do we really need a `u64` for the limit? A `u16` would probably suffice, given that it would be odd to have a minimum size above 65k.~~ Did that now.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
