### PR TITLE
Improve set header

### DIFF
--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -99,7 +99,7 @@
 //! };
 //! use tower::{ServiceBuilder, Service, ServiceExt};
 //! use hyper::Body;
-//! use http::{Request, Response, HeaderValue, header::USER_AGENT};
+//! use http::{Request, HeaderValue, header::USER_AGENT};
 //!
 //! #[tokio::main]
 //! async fn main() {

--- a/tower-http/src/services/redirect.rs
+++ b/tower-http/src/services/redirect.rs
@@ -47,6 +47,7 @@ use tower_service::Service;
 pub struct Redirect<ResBody> {
     status_code: StatusCode,
     location: HeaderValue,
+    // Covariant over ResBody, no dropping of ResBody
     _marker: PhantomData<fn() -> ResBody>,
 }
 
@@ -134,6 +135,7 @@ impl<ResBody> Clone for Redirect<ResBody> {
 pub struct ResponseFuture<ResBody> {
     location: Option<HeaderValue>,
     status_code: StatusCode,
+    // Covariant over ResBody, no dropping of ResBody
     _marker: PhantomData<fn() -> ResBody>,
 }
 

--- a/tower-http/src/set_header/request.rs
+++ b/tower-http/src/set_header/request.rs
@@ -120,20 +120,25 @@ impl<M, T> SetRequestHeaderLayer<M, T>
 where
     M: MakeHeaderValue<T>,
 {
-    /// Create a new [`SetRequestHeaderLayer`]. If a previous value exists for the same header, it
-    /// is removed and replaced with the new header value.
+    /// Create a new [`SetRequestHeaderLayer`].
+    ///
+    /// If a previous value exists for the same header, it is removed and replaced with the new
+    /// header value.
     pub fn overriding(header_name: HeaderName, make: M) -> Self {
         Self::new(header_name, make, InsertHeaderMode::Override)
     }
 
-    /// Create a new [`SetRequestHeaderLayer`]. The new header is always added, preserving any
-    /// existing values. If previous values exist, the header will have multiple values.
+    /// Create a new [`SetRequestHeaderLayer`].
+    ///
+    /// The new header is always added, preserving any existing values. If previous values exist,
+    /// the header will have multiple values.
     pub fn appending(header_name: HeaderName, make: M) -> Self {
         Self::new(header_name, make, InsertHeaderMode::Append)
     }
 
-    /// Create a new [`SetRequestHeaderLayer`]. If a previous value exists for the header, the new
-    /// value is not inserted.
+    /// Create a new [`SetRequestHeaderLayer`].
+    ///
+    /// If a previous value exists for the header, the new value is not inserted.
     pub fn if_not_present(header_name: HeaderName, make: M) -> Self {
         Self::new(header_name, make, InsertHeaderMode::IfNotPresent)
     }
@@ -191,20 +196,25 @@ pub struct SetRequestHeader<S, M> {
 }
 
 impl<S, M> SetRequestHeader<S, M> {
-    /// Create a new [`SetRequestHeader`]. If a previous value exists for the same header, it is
-    /// removed and replaced with the new header value.
+    /// Create a new [`SetRequestHeader`].
+    ///
+    /// If a previous value exists for the same header, it is removed and replaced with the new
+    /// header value.
     pub fn overriding(inner: S, header_name: HeaderName, make: M) -> Self {
         Self::new(inner, header_name, make, InsertHeaderMode::Override)
     }
 
-    /// Create a new [`SetRequestHeader`]. The new header is always added, preserving any existing
-    /// values. If previous values exist, the header will have multiple values.
+    /// Create a new [`SetRequestHeader`].
+    ///
+    /// The new header is always added, preserving any existing values. If previous values exist,
+    /// the header will have multiple values.
     pub fn appending(inner: S, header_name: HeaderName, make: M) -> Self {
         Self::new(inner, header_name, make, InsertHeaderMode::Append)
     }
 
-    /// Create a new [`SetRequestHeader`]. If a previous value exists for the header, the new
-    /// value is not inserted.
+    /// Create a new [`SetRequestHeader`].
+    ///
+    /// If a previous value exists for the header, the new value is not inserted.
     pub fn if_not_present(inner: S, header_name: HeaderName, make: M) -> Self {
         Self::new(inner, header_name, make, InsertHeaderMode::IfNotPresent)
     }

--- a/tower-http/src/set_header/request.rs
+++ b/tower-http/src/set_header/request.rs
@@ -102,6 +102,7 @@ pub struct SetRequestHeaderLayer<M, T> {
     header_name: HeaderName,
     make: M,
     mode: InsertHeaderMode,
+    // Covariant over T, no dropping of T
     _marker: PhantomData<fn() -> T>,
 }
 

--- a/tower-http/src/set_header/request.rs
+++ b/tower-http/src/set_header/request.rs
@@ -143,10 +143,7 @@ where
         Self::new(header_name, make, InsertHeaderMode::IfNotPresent)
     }
 
-    fn new(header_name: HeaderName, make: M, mode: InsertHeaderMode) -> Self
-    where
-        M: MakeHeaderValue<T>,
-    {
+    fn new(header_name: HeaderName, make: M, mode: InsertHeaderMode) -> Self {
         Self {
             make,
             header_name,
@@ -158,7 +155,7 @@ where
 
 impl<T, S, M> Layer<S> for SetRequestHeaderLayer<M, T>
 where
-    M: MakeHeaderValue<T> + Clone,
+    M: Clone,
 {
     type Service = SetRequestHeader<S, M>;
 
@@ -248,7 +245,7 @@ where
 impl<ReqBody, S, M> Service<Request<ReqBody>> for SetRequestHeader<S, M>
 where
     S: Service<Request<ReqBody>>,
-    M: MakeHeaderValue<Request<ReqBody>> + Clone,
+    M: MakeHeaderValue<Request<ReqBody>>,
 {
     type Response = S::Response;
     type Error = S::Error;

--- a/tower-http/src/set_header/response.rs
+++ b/tower-http/src/set_header/response.rs
@@ -115,6 +115,7 @@ pub struct SetResponseHeaderLayer<M, T> {
     header_name: HeaderName,
     make: M,
     mode: InsertHeaderMode,
+    // Covariant over T, no dropping of T
     _marker: PhantomData<fn() -> T>,
 }
 

--- a/tower-http/src/set_header/response.rs
+++ b/tower-http/src/set_header/response.rs
@@ -156,10 +156,7 @@ where
         Self::new(header_name, make, InsertHeaderMode::IfNotPresent)
     }
 
-    fn new(header_name: HeaderName, make: M, mode: InsertHeaderMode) -> Self
-    where
-        M: MakeHeaderValue<T>,
-    {
+    fn new(header_name: HeaderName, make: M, mode: InsertHeaderMode) -> Self {
         Self {
             make,
             header_name,
@@ -171,7 +168,7 @@ where
 
 impl<T, S, M> Layer<S> for SetResponseHeaderLayer<M, T>
 where
-    M: MakeHeaderValue<T> + Clone,
+    M: Clone,
 {
     type Service = SetResponseHeader<S, M>;
 

--- a/tower-http/src/set_header/response.rs
+++ b/tower-http/src/set_header/response.rs
@@ -133,20 +133,25 @@ impl<M, T> SetResponseHeaderLayer<M, T>
 where
     M: MakeHeaderValue<T>,
 {
-    /// Create a new [`SetResponseHeaderLayer`]. If a previous value exists for the same header, it
-    /// is removed and replaced with the new header value.
+    /// Create a new [`SetResponseHeaderLayer`].
+    ///
+    /// If a previous value exists for the same header, it is removed and replaced with the new
+    /// header value.
     pub fn overriding(header_name: HeaderName, make: M) -> Self {
         Self::new(header_name, make, InsertHeaderMode::Override)
     }
 
-    /// Create a new [`SetResponseHeaderLayer`]. The new header is always added, preserving any
-    /// existing values. If previous values exist, the header will have multiple values.
+    /// Create a new [`SetResponseHeaderLayer`].
+    ///
+    /// The new header is always added, preserving any existing values. If previous values exist,
+    /// the header will have multiple values.
     pub fn appending(header_name: HeaderName, make: M) -> Self {
         Self::new(header_name, make, InsertHeaderMode::Append)
     }
 
-    /// Create a new [`SetResponseHeaderLayer`]. If a previous value exists for the header, the new
-    /// value is not inserted.
+    /// Create a new [`SetResponseHeaderLayer`].
+    ///
+    /// If a previous value exists for the header, the new value is not inserted.
     pub fn if_not_present(header_name: HeaderName, make: M) -> Self {
         Self::new(header_name, make, InsertHeaderMode::IfNotPresent)
     }
@@ -204,20 +209,25 @@ pub struct SetResponseHeader<S, M> {
 }
 
 impl<S, M> SetResponseHeader<S, M> {
-    /// Create a new [`SetResponseHeader`]. If a previous value exists for the same header, it is
-    /// removed and replaced with the new header value.
+    /// Create a new [`SetResponseHeader`].
+    ///
+    /// If a previous value exists for the same header, it is removed and replaced with the new
+    /// header value.
     pub fn overriding(inner: S, header_name: HeaderName, make: M) -> Self {
         Self::new(inner, header_name, make, InsertHeaderMode::Override)
     }
 
-    /// Create a new [`SetResponseHeader`]. The new header is always added, preserving any existing
-    /// values. If previous values exist, the header will have multiple values.
+    /// Create a new [`SetResponseHeader`].
+    ///
+    /// The new header is always added, preserving any existing values. If previous values exist,
+    /// the header will have multiple values.
     pub fn appending(inner: S, header_name: HeaderName, make: M) -> Self {
         Self::new(inner, header_name, make, InsertHeaderMode::Append)
     }
 
-    /// Create a new [`SetResponseHeader`]. If a previous value exists for the header, the new
-    /// value is not inserted.
+    /// Create a new [`SetResponseHeader`].
+    ///
+    /// If a previous value exists for the header, the new value is not inserted.
     pub fn if_not_present(inner: S, header_name: HeaderName, make: M) -> Self {
         Self::new(inner, header_name, make, InsertHeaderMode::IfNotPresent)
     }


### PR DESCRIPTION
## Motivation

Makes the code more maintainable, and docs neater (providing rustdoc with a clear tagline / rest of the docs for overview pages).

## Solution

Refactor stuff.

## Other

I didn't rename `T` in `Set{Request,Response}HeaderLayer` to `ReqBody` / `ResBody` here, but I think that might also make sense.

All of this refactoring happened in an attempt to fix #127, which I still believe is possible but I've spent enough time on this for now.