### PR TITLE
Fix build warning

### DIFF
--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -210,7 +210,7 @@
     nonstandard_style,
     missing_docs
 )]
-#![deny(unreachable_pub, broken_intra_doc_links, private_in_public)]
+#![deny(unreachable_pub, rustdoc::broken_intra_doc_links, private_in_public)]
 #![allow(
     elided_lifetimes_in_paths,
     // TODO: Remove this once the MSRV bumps to 1.42.0 or above.


### PR DESCRIPTION
## Motivation

The build should be warning-free.

## Solution

Fixed warning about renamed lint by using the new name.