### PR TITLE
ServeDir & ServeFile last modified headers handling

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -35,6 +35,7 @@ tokio = { version = "1", optional = true, default_features = false }
 tokio-util = { version = "0.6.8", optional = true, default_features = false, features = ["io"] }
 tower = { version = "0.4.1", optional = true }
 tracing = { version = "0.1", default_features = false, optional = true }
+httpdate = { version = "1.0", optional = true }
 
 [dev-dependencies]
 bytes = "1"
@@ -74,7 +75,7 @@ add-extension = []
 auth = ["base64"]
 cors = []
 follow-redirect = ["iri-string", "tower/util"]
-fs = ["tokio/fs", "tokio-util/io", "tokio/io-util", "mime_guess", "mime", "percent-encoding"]
+fs = ["tokio/fs", "tokio-util/io", "tokio/io-util", "mime_guess", "mime", "percent-encoding", "httpdate"]
 map-request-body = []
 map-response-body = []
 metrics = ["tokio/time"]

--- a/tower-http/src/services/fs/mod.rs
+++ b/tower-http/src/services/fs/mod.rs
@@ -226,8 +226,7 @@ impl IfModifiedSince {
     fn from_header_value(value: &http::header::HeaderValue) -> Option<IfModifiedSince> {
         String::from_utf8(value.as_bytes().to_vec())
             .ok()
-            .map(|value| httpdate::parse_http_date(&value).ok())
-            .flatten()
+            .and_then(|value| httpdate::parse_http_date(&value).ok())
             .map(|time| IfModifiedSince(time.into()))
     }
 }

--- a/tower-http/src/services/fs/mod.rs
+++ b/tower-http/src/services/fs/mod.rs
@@ -248,7 +248,7 @@ impl IfUnmodifiedSince {
 }
 
 fn check_modified_headers(
-    modified: &Option<LastModified>,
+    modified: Option<&LastModified>,
     if_unmodified_since: Option<IfUnmodifiedSince>,
     if_modified_since: Option<IfModifiedSince>,
 ) -> Option<StatusCode> {

--- a/tower-http/src/services/fs/mod.rs
+++ b/tower-http/src/services/fs/mod.rs
@@ -1,8 +1,10 @@
 //! File system related services.
 
 use bytes::Bytes;
-use http::{HeaderMap, Response, StatusCode};
+use futures_util::Stream;
+use http::{HeaderMap, HeaderValue, Response, StatusCode};
 use http_body::{combinators::BoxBody, Body, Empty};
+use httpdate::HttpDate;
 use pin_project_lite::pin_project;
 use std::fs::Metadata;
 use std::{ffi::OsStr, path::PathBuf};
@@ -10,12 +12,11 @@ use std::{
     io,
     pin::Pin,
     task::{Context, Poll},
+    time::SystemTime,
 };
 use tokio::fs::File;
 use tokio::io::{AsyncRead, AsyncReadExt, Take};
 use tokio_util::io::ReaderStream;
-
-use futures_util::Stream;
 
 mod serve_dir;
 mod serve_file;
@@ -202,4 +203,77 @@ fn response_from_io_error(
         }
         _ => Err(err),
     }
+}
+
+struct LastModified(HttpDate);
+
+impl From<SystemTime> for LastModified {
+    fn from(time: SystemTime) -> Self {
+        LastModified(time.into())
+    }
+}
+
+struct IfUnmodifiedSince(HttpDate);
+struct IfModifiedSince(HttpDate);
+
+impl IfModifiedSince {
+    /// Check if the supplied time means the resource has been modified.
+    fn is_modified(&self, last_modified: &LastModified) -> bool {
+        self.0 < last_modified.0
+    }
+
+    /// convert a header value into a IfModifiedSince, invalid values are silentely ignored
+    fn from_header_value(value: &http::header::HeaderValue) -> Option<IfModifiedSince> {
+        String::from_utf8(value.as_bytes().to_vec())
+            .ok()
+            .map(|value| httpdate::parse_http_date(&value).ok())
+            .flatten()
+            .map(|time| IfModifiedSince(time.into()))
+    }
+}
+
+impl IfUnmodifiedSince {
+    /// Check if the supplied time passes the precondtion.
+    fn precondition_passes(&self, last_modified: &LastModified) -> bool {
+        self.0 >= last_modified.0
+    }
+
+    /// convert a header value into a IfModifiedSince, invalid values are silentely ignored
+    fn from_header_value(value: &http::header::HeaderValue) -> Option<IfUnmodifiedSince> {
+        String::from_utf8(value.as_bytes().to_vec())
+            .ok()
+            .map(|value| httpdate::parse_http_date(&value).ok())
+            .flatten()
+            .map(|time| IfUnmodifiedSince(time.into()))
+    }
+}
+
+fn check_modified_headers(
+    modified: &Option<LastModified>,
+    if_unmodified_since: Option<IfUnmodifiedSince>,
+    if_modified_since: Option<IfModifiedSince>,
+) -> Option<StatusCode> {
+    if let Some(since) = if_unmodified_since {
+        let precondition = modified
+            .as_ref()
+            .map(|time| since.precondition_passes(time))
+            .unwrap_or(false);
+
+        if !precondition {
+            return Some(StatusCode::PRECONDITION_FAILED);
+        }
+    }
+
+    if let Some(since) = if_modified_since {
+        let unmodified = modified
+            .as_ref()
+            .map(|time| !since.is_modified(&time))
+            // no last_modified means its always modified
+            .unwrap_or(false);
+        if unmodified {
+            return Some(StatusCode::NOT_MODIFIED);
+        }
+    }
+
+    None
 }

--- a/tower-http/src/services/fs/mod.rs
+++ b/tower-http/src/services/fs/mod.rs
@@ -242,8 +242,7 @@ impl IfUnmodifiedSince {
     fn from_header_value(value: &http::header::HeaderValue) -> Option<IfUnmodifiedSince> {
         String::from_utf8(value.as_bytes().to_vec())
             .ok()
-            .map(|value| httpdate::parse_http_date(&value).ok())
-            .flatten()
+            .and_then(|value| httpdate::parse_http_date(&value).ok())
             .map(|time| IfUnmodifiedSince(time.into()))
     }
 }

--- a/tower-http/src/services/fs/mod.rs
+++ b/tower-http/src/services/fs/mod.rs
@@ -2,7 +2,7 @@
 
 use bytes::Bytes;
 use futures_util::Stream;
-use http::{HeaderMap, HeaderValue, Response, StatusCode};
+use http::{HeaderMap, Response, StatusCode};
 use http_body::{combinators::BoxBody, Body, Empty};
 use httpdate::HttpDate;
 use pin_project_lite::pin_project;

--- a/tower-http/src/services/fs/mod.rs
+++ b/tower-http/src/services/fs/mod.rs
@@ -224,7 +224,7 @@ impl IfModifiedSince {
 
     /// convert a header value into a IfModifiedSince, invalid values are silentely ignored
     fn from_header_value(value: &http::header::HeaderValue) -> Option<IfModifiedSince> {
-        String::from_utf8(value.as_bytes().to_vec())
+        std::str::from_utf8(value.as_bytes())
             .ok()
             .and_then(|value| httpdate::parse_http_date(&value).ok())
             .map(|time| IfModifiedSince(time.into()))
@@ -239,7 +239,7 @@ impl IfUnmodifiedSince {
 
     /// convert a header value into a IfModifiedSince, invalid values are silentely ignored
     fn from_header_value(value: &http::header::HeaderValue) -> Option<IfUnmodifiedSince> {
-        String::from_utf8(value.as_bytes().to_vec())
+        std::str::from_utf8(value.as_bytes())
             .ok()
             .and_then(|value| httpdate::parse_http_date(&value).ok())
             .map(|time| IfUnmodifiedSince(time.into()))

--- a/tower-http/src/services/fs/serve_dir.rs
+++ b/tower-http/src/services/fs/serve_dir.rs
@@ -354,7 +354,7 @@ impl<ReqBody> Service<Request<ReqBody>> for ServeDir {
 
                     let last_modified = meta.modified().ok().map(LastModified::from);
                     if let Some(status_code) = check_modified_headers(
-                        &last_modified,
+                        last_modified.as_ref(),
                         if_unmodified_since,
                         if_modified_since,
                     ) {
@@ -377,7 +377,7 @@ impl<ReqBody> Service<Request<ReqBody>> for ServeDir {
                     let meta = file.metadata().await?;
                     let last_modified = meta.modified().ok().map(LastModified::from);
                     if let Some(status_code) = check_modified_headers(
-                        &last_modified,
+                        last_modified.as_ref(),
                         if_unmodified_since,
                         if_modified_since,
                     ) {

--- a/tower-http/src/services/fs/serve_dir.rs
+++ b/tower-http/src/services/fs/serve_dir.rs
@@ -1186,6 +1186,8 @@ mod tests {
 
         let res = svc.oneshot(req).await.unwrap();
         assert_eq!(res.status(), StatusCode::NOT_MODIFIED);
+        let body = res.into_body().data().await;
+        assert!(body.is_none());
 
         let svc = ServeDir::new("..");
         let req = Request::builder()
@@ -1196,6 +1198,9 @@ mod tests {
 
         let res = svc.oneshot(req).await.unwrap();
         assert_eq!(res.status(), StatusCode::OK);
+        let readme_bytes = include_bytes!("../../../../README.md");
+        let body = res.into_body().data().await.unwrap().unwrap();
+        assert_eq!(body.as_ref(), readme_bytes);
 
         // -- If-Unmodified-Since
 
@@ -1208,6 +1213,8 @@ mod tests {
 
         let res = svc.oneshot(req).await.unwrap();
         assert_eq!(res.status(), StatusCode::OK);
+        let body = res.into_body().data().await.unwrap().unwrap();
+        assert_eq!(body.as_ref(), readme_bytes);
 
         let svc = ServeDir::new("..");
         let req = Request::builder()
@@ -1218,5 +1225,7 @@ mod tests {
 
         let res = svc.oneshot(req).await.unwrap();
         assert_eq!(res.status(), StatusCode::PRECONDITION_FAILED);
+        let body = res.into_body().data().await;
+        assert!(body.is_none());
     }
 }

--- a/tower-http/src/services/fs/serve_dir.rs
+++ b/tower-http/src/services/fs/serve_dir.rs
@@ -787,6 +787,7 @@ mod tests {
             .unwrap();
         let res = svc.oneshot(request).await.unwrap();
 
+        assert_eq!(res.headers()["content-type"], "text/plain");
         assert_eq!(res.headers()["content-encoding"], "deflate");
 
         let body = res.into_body().data().await.unwrap().unwrap();

--- a/tower-http/src/services/fs/serve_dir.rs
+++ b/tower-http/src/services/fs/serve_dir.rs
@@ -310,13 +310,11 @@ impl<ReqBody> Service<Request<ReqBody>> for ServeDir {
         let if_unmodified_since = req
             .headers()
             .get(header::IF_UNMODIFIED_SINCE)
-            .map(IfUnmodifiedSince::from_header_value)
-            .flatten();
+            .and_then(IfUnmodifiedSince::from_header_value);
         let if_modified_since = req
             .headers()
             .get(header::IF_MODIFIED_SINCE)
-            .map(IfModifiedSince::from_header_value)
-            .flatten();
+            .and_then(IfModifiedSince::from_header_value);
 
         let request_method = req.method().clone();
         let variant = self.variant.clone();

--- a/tower-http/src/services/fs/serve_file.rs
+++ b/tower-http/src/services/fs/serve_file.rs
@@ -470,6 +470,8 @@ mod tests {
 
         let res = svc.oneshot(req).await.unwrap();
         assert_eq!(res.status(), StatusCode::NOT_MODIFIED);
+        let body = res.into_body().data().await;
+        assert!(body.is_none());
 
         let svc = ServeFile::new("../README.md");
         let req = Request::builder()
@@ -479,6 +481,9 @@ mod tests {
 
         let res = svc.oneshot(req).await.unwrap();
         assert_eq!(res.status(), StatusCode::OK);
+        let readme_bytes = include_bytes!("../../../../README.md");
+        let body = res.into_body().data().await.unwrap().unwrap();
+        assert_eq!(body.as_ref(), readme_bytes);
 
         // -- If-Unmodified-Since
 
@@ -490,6 +495,8 @@ mod tests {
 
         let res = svc.oneshot(req).await.unwrap();
         assert_eq!(res.status(), StatusCode::OK);
+        let body = res.into_body().data().await.unwrap().unwrap();
+        assert_eq!(body.as_ref(), readme_bytes);
 
         let svc = ServeFile::new("../README.md");
         let req = Request::builder()
@@ -499,5 +506,7 @@ mod tests {
 
         let res = svc.oneshot(req).await.unwrap();
         assert_eq!(res.status(), StatusCode::PRECONDITION_FAILED);
+        let body = res.into_body().data().await;
+        assert!(body.is_none());
     }
 }

--- a/tower-http/src/services/fs/serve_file.rs
+++ b/tower-http/src/services/fs/serve_file.rs
@@ -1,3 +1,5 @@
+//! Service that serves a file.
+
 use super::ServeDir;
 use http::{HeaderValue, Request};
 use mime::Mime;

--- a/tower-http/src/services/fs/serve_file.rs
+++ b/tower-http/src/services/fs/serve_file.rs
@@ -3,7 +3,6 @@
 use super::ServeDir;
 use http::{HeaderValue, Request};
 use mime::Mime;
-use std::convert::TryInto;
 use std::{
     path::Path,
     task::{Context, Poll},


### PR DESCRIPTION
~Note: This PR also includes https://github.com/tower-rs/tower-http/pull/137, I will modify it when it will be merged~

## Motivation

ServeDir & ServeFile should respect http caching best practice by setting `Last-Modified` response header and handling `If-Modified_since` & `If-Unmodified-Since` requests headers.

## Solution

The `Last-Modified` header is added on responses of ServeFile & ServeDir. 

`If-Modified_since` & `If-Unmodified-Since` requests headers are handled so the service will respond `NOT_MODIFIED` or `PRECONDITION_FAILED` depending on values set into the headers.
