### PR TITLE
Update trait bounds of Set{Request,Response}HeaderLayer constructors

### DIFF
--- a/tower-http/src/set_header/request.rs
+++ b/tower-http/src/set_header/request.rs
@@ -118,7 +118,7 @@ impl<M, T> fmt::Debug for SetRequestHeaderLayer<M, T> {
 
 impl<M, T> SetRequestHeaderLayer<M, T>
 where
-    M: MakeHeaderValue<T>,
+    M: MakeHeaderValue<Request<T>> + Clone,
 {
     /// Create a new [`SetRequestHeaderLayer`].
     ///

--- a/tower-http/src/set_header/response.rs
+++ b/tower-http/src/set_header/response.rs
@@ -131,7 +131,7 @@ impl<M, T> fmt::Debug for SetResponseHeaderLayer<M, T> {
 
 impl<M, T> SetResponseHeaderLayer<M, T>
 where
-    M: MakeHeaderValue<T>,
+    M: MakeHeaderValue<Response<T>> + Clone,
 {
     /// Create a new [`SetResponseHeaderLayer`].
     ///


### PR DESCRIPTION
 #143 plus breaking change. I'll rebase once that is merged (just so GitHub doesn't show #143's commits as being part of this one anymore).