### PR TITLE
Remove unnecessary generic parameter from Set{Request,Response}HeaderLayer

### DIFF
--- a/examples/tonic-key-value-store/src/main.rs
+++ b/examples/tonic-key-value-store/src/main.rs
@@ -280,7 +280,7 @@ async fn make_client(
         // Decompress response bodies
         .layer(DecompressionLayer::new())
         // Set a `User-Agent` header
-        .layer(SetRequestHeaderLayer::<_, Request<BoxBody>>::overriding(
+        .layer(SetRequestHeaderLayer::overriding(
             header::USER_AGENT,
             HeaderValue::from_static("tonic-key-value-store"),
         ))

--- a/examples/warp-key-value-store/src/main.rs
+++ b/examples/warp-key-value-store/src/main.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use hyper::{
     body::HttpBody,
     header::{self, HeaderValue},
-    Body, Request, Response, Server, StatusCode,
+    Body, Response, Server, StatusCode,
 };
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -89,7 +89,7 @@ async fn serve_forever(listener: TcpListener) -> Result<(), hyper::Error> {
             content_length_from_response,
         ))
         // Set a `Content-Type` if there isn't one already.
-        .layer(SetResponseHeaderLayer::<_, Request<Body>>::if_not_present(
+        .layer(SetResponseHeaderLayer::if_not_present(
             header::CONTENT_TYPE,
             HeaderValue::from_static("application/octet-stream"),
         ))

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ServeDir` and `ServeFile`: Ability to serve precompressed files ([#156])
 - `Trace`: Add `DefaultMakeSpan::level` to make log level of tracing spans easily configurable ([#124])
+- `SetRequestHeaderLayer`, `SetResponseHeaderLayer`: Remove unnecessary generic parameter ([#148])
+  
+  This removes the need (and possibility) to specify a body type for these layers.
 
 [#124]: https://github.com/tower-rs/tower-http/pull/124
 [#156]: https://github.com/tower-rs/tower-http/pull/156

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -110,7 +110,7 @@
 //!             StatusInRangeAsFailures::new(400..=599).into_make_classifier()
 //!         ))
 //!         // Set a `User-Agent` header on all requests.
-//!         .layer(SetRequestHeaderLayer::<_, Body>::overriding(
+//!         .layer(SetRequestHeaderLayer::overriding(
 //!             USER_AGENT,
 //!             HeaderValue::from_static("tower-http demo")
 //!         ))

--- a/tower-http/src/set_header/response.rs
+++ b/tower-http/src/set_header/response.rs
@@ -24,12 +24,9 @@
 //!     .layer(
 //!         // Layer that sets `Content-Type: text/html` on responses.
 //!         //
-//!         // We have to add `::<_, Body>` since Rust cannot infer the body type when
-//!         // we don't use a closure to produce the header value.
-//!         //
 //!         // `if_not_present` will only insert the header if it does not already
 //!         // have a value.
-//!         SetResponseHeaderLayer::<_, Body>::if_not_present(
+//!         SetResponseHeaderLayer::if_not_present(
 //!             header::CONTENT_TYPE,
 //!             HeaderValue::from_static("text/html"),
 //!         )
@@ -101,25 +98,23 @@ use http::{header::HeaderName, Response};
 use pin_project::pin_project;
 use std::{
     fmt,
+    future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
-use std::{future::Future, marker::PhantomData};
 use tower_layer::Layer;
 use tower_service::Service;
 
 /// Layer that applies [`SetResponseHeader`] which adds a response header.
 ///
 /// See [`SetResponseHeader`] for more details.
-pub struct SetResponseHeaderLayer<M, T> {
+pub struct SetResponseHeaderLayer<M> {
     header_name: HeaderName,
     make: M,
     mode: InsertHeaderMode,
-    // Covariant over T, no dropping of T
-    _marker: PhantomData<fn() -> T>,
 }
 
-impl<M, T> fmt::Debug for SetResponseHeaderLayer<M, T> {
+impl<M> fmt::Debug for SetResponseHeaderLayer<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SetResponseHeaderLayer")
             .field("header_name", &self.header_name)
@@ -129,10 +124,7 @@ impl<M, T> fmt::Debug for SetResponseHeaderLayer<M, T> {
     }
 }
 
-impl<M, T> SetResponseHeaderLayer<M, T>
-where
-    M: MakeHeaderValue<T>,
-{
+impl<M> SetResponseHeaderLayer<M> {
     /// Create a new [`SetResponseHeaderLayer`].
     ///
     /// If a previous value exists for the same header, it is removed and replaced with the new
@@ -161,12 +153,11 @@ where
             make,
             header_name,
             mode,
-            _marker: PhantomData,
         }
     }
 }
 
-impl<T, S, M> Layer<S> for SetResponseHeaderLayer<M, T>
+impl<S, M> Layer<S> for SetResponseHeaderLayer<M>
 where
     M: Clone,
 {
@@ -182,7 +173,7 @@ where
     }
 }
 
-impl<M, T> Clone for SetResponseHeaderLayer<M, T>
+impl<M> Clone for SetResponseHeaderLayer<M>
 where
     M: Clone,
 {
@@ -191,7 +182,6 @@ where
             make: self.make.clone(),
             header_name: self.header_name.clone(),
             mode: self.mode,
-            _marker: PhantomData,
         }
     }
 }


### PR DESCRIPTION
## Motivation

Currently, `SetRequestHeaderLayer` and `SetResponseHeaderLayer` have to have a turbofish supplied when used with a plain `HeaderValue` (or `Option<HeaderValue>`) instead of a closure, which is annoying.

## Solution

Adjust the generics to make things work out :)

Unfortunately, this conflicts with #147 and as such error messages from closures with wrong parameter types will continue to be reported rather late somewhere in the usage of these layers rather than at the construction site. However, I consider this change to be more valuable than #147.

This is a breaking change because it changes the number of generic parameters and previous `::<_, Body>` turbofish usage will thus become invalid.

Properly fixes #127