### PR TITLE
Switch from pin-project to pin-project-lite

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -17,7 +17,7 @@ futures-core = "0.3"
 futures-util = { version = "0.3", default_features = false, features = [] }
 http = "0.2"
 http-body = "0.4.1"
-pin-project = "1"
+pin-project-lite = "0.2.7"
 tower-layer = "0.3"
 tower-service = "0.3"
 

--- a/tower-http/src/auth/async_require_authorization.rs
+++ b/tower-http/src/auth/async_require_authorization.rs
@@ -69,7 +69,7 @@
 use futures_core::ready;
 use http::{Request, Response};
 use http_body::Body;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
@@ -167,30 +167,33 @@ where
     }
 }
 
-#[pin_project(project = StateProj)]
-enum State<A, ReqBody, SFut> {
-    Authorize {
-        #[pin]
-        authorize: A,
-        req: Option<Request<ReqBody>>,
-    },
-    Authorized {
-        #[pin]
-        fut: SFut,
-    },
+pin_project! {
+    #[project = StateProj]
+    enum State<A, ReqBody, SFut> {
+        Authorize {
+            #[pin]
+            authorize: A,
+            req: Option<Request<ReqBody>>,
+        },
+        Authorized {
+            #[pin]
+            fut: SFut,
+        },
+    }
 }
 
-/// Response future for [`AsyncRequireAuthorization`].
-#[pin_project]
-pub struct ResponseFuture<Auth, S, ReqBody>
-where
-    Auth: AsyncAuthorizeRequest,
-    S: Service<Request<ReqBody>>,
-{
-    auth: Auth,
-    #[pin]
-    state: State<Auth::Future, ReqBody, S::Future>,
-    service: S,
+pin_project! {
+    /// Response future for [`AsyncRequireAuthorization`].
+    pub struct ResponseFuture<Auth, S, ReqBody>
+    where
+        Auth: AsyncAuthorizeRequest,
+        S: Service<Request<ReqBody>>,
+    {
+        auth: Auth,
+        #[pin]
+        state: State<Auth::Future, ReqBody, S::Future>,
+        service: S,
+    }
 }
 
 impl<Auth, S, ReqBody, B> Future for ResponseFuture<Auth, S, ReqBody>

--- a/tower-http/src/compression_utils.rs
+++ b/tower-http/src/compression_utils.rs
@@ -6,7 +6,7 @@ use futures_core::Stream;
 use futures_util::ready;
 use http::{header, HeaderMap, HeaderValue};
 use http_body::Body;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     io,
     pin::Pin,
@@ -120,11 +120,12 @@ pub(crate) trait DecorateAsyncRead {
     fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input>;
 }
 
-/// `Body` that has been decorated by an `AsyncRead`
-#[pin_project]
-pub(crate) struct WrapBody<M: DecorateAsyncRead> {
-    #[pin]
-    pub(crate) read: M::Output,
+pin_project! {
+    /// `Body` that has been decorated by an `AsyncRead`
+    pub(crate) struct WrapBody<M: DecorateAsyncRead> {
+        #[pin]
+        pub(crate) read: M::Output,
+    }
 }
 
 impl<M: DecorateAsyncRead> WrapBody<M> {
@@ -207,11 +208,12 @@ where
     }
 }
 
-// When https://github.com/hyperium/http-body/pull/36 is merged we can remove this
-#[pin_project]
-pub(crate) struct BodyIntoStream<B> {
-    #[pin]
-    body: B,
+pin_project! {
+    // When https://github.com/hyperium/http-body/pull/36 is merged we can remove this
+    pub(crate) struct BodyIntoStream<B> {
+        #[pin]
+        body: B,
+    }
 }
 
 #[allow(dead_code)]
@@ -252,11 +254,12 @@ where
     }
 }
 
-#[pin_project]
-pub(crate) struct StreamErrorIntoIoError<S, E> {
-    #[pin]
-    inner: S,
-    error: Option<E>,
+pin_project! {
+    pub(crate) struct StreamErrorIntoIoError<S, E> {
+        #[pin]
+        inner: S,
+        error: Option<E>,
+    }
 }
 
 impl<S, E> StreamErrorIntoIoError<S, E> {

--- a/tower-http/src/decompression/future.rs
+++ b/tower-http/src/decompression/future.rs
@@ -6,22 +6,23 @@ use crate::content_encoding::SupportedEncodings;
 use futures_util::ready;
 use http::{header, Response};
 use http_body::Body;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
 
-/// Response future of [`Decompression`].
-///
-/// [`Decompression`]: super::Decompression
-#[pin_project]
-#[derive(Debug)]
-pub struct ResponseFuture<F> {
-    #[pin]
-    pub(crate) inner: F,
-    pub(crate) accept: AcceptEncoding,
+pin_project! {
+    /// Response future of [`Decompression`].
+    ///
+    /// [`Decompression`]: super::Decompression
+    #[derive(Debug)]
+    pub struct ResponseFuture<F> {
+        #[pin]
+        pub(crate) inner: F,
+        pub(crate) accept: AcceptEncoding,
+    }
 }
 
 impl<F, B, E> Future for ResponseFuture<F>
@@ -41,23 +42,23 @@ where
                 let body = match entry.get().as_bytes() {
                     #[cfg(feature = "decompression-gzip")]
                     b"gzip" if self.accept.gzip() => {
-                        DecompressionBody(BodyInner::Gzip(WrapBody::new(body)))
+                        DecompressionBody::new(BodyInner::gzip(WrapBody::new(body)))
                     }
 
                     #[cfg(feature = "decompression-deflate")]
                     b"deflate" if self.accept.deflate() => {
-                        DecompressionBody(BodyInner::Deflate(WrapBody::new(body)))
+                        DecompressionBody::new(BodyInner::deflate(WrapBody::new(body)))
                     }
 
                     #[cfg(feature = "decompression-br")]
                     b"br" if self.accept.br() => {
-                        DecompressionBody(BodyInner::Brotli(WrapBody::new(body)))
+                        DecompressionBody::new(BodyInner::brotli(WrapBody::new(body)))
                     }
 
                     _ => {
                         return Poll::Ready(Ok(Response::from_parts(
                             parts,
-                            DecompressionBody(BodyInner::Identity(body)),
+                            DecompressionBody::new(BodyInner::identity(body)),
                         )))
                     }
                 };
@@ -67,7 +68,7 @@ where
 
                 Response::from_parts(parts, body)
             } else {
-                Response::from_parts(parts, DecompressionBody(BodyInner::Identity(body)))
+                Response::from_parts(parts, DecompressionBody::new(BodyInner::identity(body)))
             };
 
         Poll::Ready(Ok(res))

--- a/tower-http/src/follow_redirect/mod.rs
+++ b/tower-http/src/follow_redirect/mod.rs
@@ -103,7 +103,7 @@ use iri_string::{
     spec::UriSpec,
     types::{RiAbsoluteString, RiReferenceStr},
 };
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     convert::TryFrom,
     future::Future,
@@ -227,22 +227,23 @@ where
     }
 }
 
-/// Response future for [`FollowRedirect`].
-#[pin_project]
-#[derive(Debug)]
-pub struct ResponseFuture<S, B, P>
-where
-    S: Service<Request<B>>,
-{
-    #[pin]
-    future: Either<S::Future, Oneshot<S, Request<B>>>,
-    service: S,
-    policy: P,
-    method: Method,
-    uri: Uri,
-    version: Version,
-    headers: HeaderMap<HeaderValue>,
-    body: BodyRepr<B>,
+pin_project! {
+    /// Response future for [`FollowRedirect`].
+    #[derive(Debug)]
+    pub struct ResponseFuture<S, B, P>
+    where
+        S: Service<Request<B>>,
+    {
+        #[pin]
+        future: Either<S::Future, Oneshot<S, Request<B>>>,
+        service: S,
+        policy: P,
+        method: Method,
+        uri: Uri,
+        version: Version,
+        headers: HeaderMap<HeaderValue>,
+        body: BodyRepr<B>,
+    }
 }
 
 impl<S, ReqBody, ResBody, P> Future for ResponseFuture<S, ReqBody, P>

--- a/tower-http/src/map_response_body.rs
+++ b/tower-http/src/map_response_body.rs
@@ -77,7 +77,7 @@
 
 use futures_core::ready;
 use http::Response;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::future::Future;
 use std::{
     fmt,
@@ -183,12 +183,13 @@ where
     }
 }
 
-/// Response future for [`MapResponseBody`].
-#[pin_project]
-pub struct ResponseFuture<Fut, F> {
-    #[pin]
-    inner: Fut,
-    f: F,
+pin_project! {
+    /// Response future for [`MapResponseBody`].
+    pub struct ResponseFuture<Fut, F> {
+        #[pin]
+        inner: Fut,
+        f: F,
+    }
 }
 
 impl<Fut, F, ResBody, E, NewResBody> Future for ResponseFuture<Fut, F>

--- a/tower-http/src/metrics/in_flight_requests.rs
+++ b/tower-http/src/metrics/in_flight_requests.rs
@@ -53,7 +53,7 @@
 use futures_util::ready;
 use http::Response;
 use http_body::Body;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
@@ -225,12 +225,13 @@ where
     }
 }
 
-/// Response future for [`InFlightRequests`].
-#[pin_project]
-pub struct ResponseFuture<F> {
-    #[pin]
-    inner: F,
-    guard: Option<IncrementGuard>,
+pin_project! {
+    /// Response future for [`InFlightRequests`].
+    pub struct ResponseFuture<F> {
+        #[pin]
+        inner: F,
+        guard: Option<IncrementGuard>,
+    }
 }
 
 impl<F, B, E> Future for ResponseFuture<F>
@@ -249,12 +250,13 @@ where
     }
 }
 
-/// Response body for [`InFlightRequests`].
-#[pin_project]
-pub struct ResponseBody<B> {
-    #[pin]
-    inner: B,
-    guard: IncrementGuard,
+pin_project! {
+    /// Response body for [`InFlightRequests`].
+    pub struct ResponseBody<B> {
+        #[pin]
+        inner: B,
+        guard: IncrementGuard,
+    }
 }
 
 impl<B> Body for ResponseBody<B>

--- a/tower-http/src/propagate_header.rs
+++ b/tower-http/src/propagate_header.rs
@@ -36,7 +36,7 @@
 
 use futures_util::ready;
 use http::{header::HeaderName, HeaderValue, Request, Response};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::future::Future;
 use std::{
     pin::Pin,
@@ -125,13 +125,14 @@ where
     }
 }
 
-/// Response future for [`PropagateHeader`].
-#[pin_project]
-#[derive(Debug)]
-pub struct ResponseFuture<F> {
-    #[pin]
-    future: F,
-    header_and_value: Option<(HeaderName, HeaderValue)>,
+pin_project! {
+    /// Response future for [`PropagateHeader`].
+    #[derive(Debug)]
+    pub struct ResponseFuture<F> {
+        #[pin]
+        future: F,
+        header_and_value: Option<(HeaderName, HeaderValue)>,
+    }
 }
 
 impl<F, ResBody, E> Future for ResponseFuture<F>

--- a/tower-http/src/sensitive_headers.rs
+++ b/tower-http/src/sensitive_headers.rs
@@ -84,7 +84,7 @@
 
 use futures_util::ready;
 use http::{header::HeaderName, Request, Response};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
@@ -341,13 +341,14 @@ where
     }
 }
 
-/// Response future for [`SetSensitiveResponseHeaders`].
-#[pin_project]
-#[derive(Debug)]
-pub struct SetSensitiveResponseHeadersResponseFuture<F> {
-    #[pin]
-    future: F,
-    headers: Arc<[HeaderName]>,
+pin_project! {
+    /// Response future for [`SetSensitiveResponseHeaders`].
+    #[derive(Debug)]
+    pub struct SetSensitiveResponseHeadersResponseFuture<F> {
+        #[pin]
+        future: F,
+        headers: Arc<[HeaderName]>,
+    }
 }
 
 impl<F, ResBody, E> Future for SetSensitiveResponseHeadersResponseFuture<F>

--- a/tower-http/src/services/fs/mod.rs
+++ b/tower-http/src/services/fs/mod.rs
@@ -3,7 +3,7 @@
 use bytes::Bytes;
 use http::{HeaderMap, Response, StatusCode};
 use http_body::{combinators::BoxBody, Body, Empty};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     io,
     pin::Pin,
@@ -62,13 +62,14 @@ impl SupportedEncodings for PrecompressedVariants {
     }
 }
 
-// NOTE: This could potentially be upstreamed to `http-body`.
-/// Adapter that turns an `impl AsyncRead` to an `impl Body`.
-#[pin_project]
-#[derive(Debug)]
-pub struct AsyncReadBody<T> {
-    #[pin]
-    reader: ReaderStream<T>,
+pin_project! {
+    // NOTE: This could potentially be upstreamed to `http-body`.
+    /// Adapter that turns an `impl AsyncRead` to an `impl Body`.
+    #[derive(Debug)]
+    pub struct AsyncReadBody<T> {
+        #[pin]
+        reader: ReaderStream<T>,
+    }
 }
 
 impl<T> AsyncReadBody<T>

--- a/tower-http/src/services/fs/serve_dir.rs
+++ b/tower-http/src/services/fs/serve_dir.rs
@@ -354,12 +354,13 @@ impl Future for ResponseFuture {
 
                         Err(err) => {
                             return Poll::Ready(
-                                super::response_from_io_error(err).map(|res| res.map(ResponseBody)),
+                                super::response_from_io_error(err)
+                                    .map(|res| res.map(ResponseBody::new)),
                             )
                         }
                     };
                 let body = AsyncReadBody::with_capacity(file, chunk_size).boxed();
-                let body = ResponseBody(body);
+                let body = ResponseBody::new(body);
 
                 let mut res = Response::new(body);
                 res.headers_mut().insert(header::CONTENT_TYPE, mime);
@@ -385,7 +386,7 @@ impl Future for ResponseFuture {
 
 fn empty_body() -> ResponseBody {
     let body = Empty::new().map_err(|err| match err {}).boxed();
-    ResponseBody(body)
+    ResponseBody::new(body)
 }
 
 opaque_body! {

--- a/tower-http/src/services/fs/serve_file.rs
+++ b/tower-http/src/services/fs/serve_file.rs
@@ -190,14 +190,14 @@ impl Future for ResponseFuture {
             Ok(file) => file,
             Err(err) => {
                 return Poll::Ready(
-                    super::response_from_io_error(err).map(|res| res.map(ResponseBody)),
+                    super::response_from_io_error(err).map(|res| res.map(ResponseBody::new)),
                 )
             }
         };
 
         let chunk_size = self.buf_chunk_size;
         let body = AsyncReadBody::with_capacity(file, chunk_size).boxed();
-        let body = ResponseBody(body);
+        let body = ResponseBody::new(body);
 
         let mut res = Response::new(body);
         res.headers_mut()

--- a/tower-http/src/set_header/response.rs
+++ b/tower-http/src/set_header/response.rs
@@ -95,7 +95,7 @@
 use super::{InsertHeaderMode, MakeHeaderValue};
 use futures_util::ready;
 use http::{header::HeaderName, Response};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     fmt,
     future::Future,
@@ -269,15 +269,16 @@ where
     }
 }
 
-/// Response future for [`SetResponseHeader`].
-#[pin_project]
-#[derive(Debug)]
-pub struct ResponseFuture<F, M> {
-    #[pin]
-    future: F,
-    header_name: HeaderName,
-    make: M,
-    mode: InsertHeaderMode,
+pin_project! {
+    /// Response future for [`SetResponseHeader`].
+    #[derive(Debug)]
+    pub struct ResponseFuture<F, M> {
+        #[pin]
+        future: F,
+        header_name: HeaderName,
+        make: M,
+        mode: InsertHeaderMode,
+    }
 }
 
 impl<F, ResBody, E, M> Future for ResponseFuture<F, M>

--- a/tower-http/src/trace/body.rs
+++ b/tower-http/src/trace/body.rs
@@ -3,7 +3,7 @@ use crate::classify::ClassifyEos;
 use futures_core::ready;
 use http::HeaderMap;
 use http_body::Body;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     fmt,
     pin::Pin,
@@ -12,19 +12,20 @@ use std::{
 };
 use tracing::Span;
 
-/// Response body for [`Trace`].
-///
-/// [`Trace`]: super::Trace
-#[pin_project]
-pub struct ResponseBody<B, C, OnBodyChunk, OnEos, OnFailure> {
-    #[pin]
-    pub(crate) inner: B,
-    pub(crate) classify_eos: Option<C>,
-    pub(crate) on_eos: Option<(OnEos, Instant)>,
-    pub(crate) on_body_chunk: OnBodyChunk,
-    pub(crate) on_failure: Option<OnFailure>,
-    pub(crate) start: Instant,
-    pub(crate) span: Span,
+pin_project! {
+    /// Response body for [`Trace`].
+    ///
+    /// [`Trace`]: super::Trace
+    pub struct ResponseBody<B, C, OnBodyChunk, OnEos, OnFailure> {
+        #[pin]
+        pub(crate) inner: B,
+        pub(crate) classify_eos: Option<C>,
+        pub(crate) on_eos: Option<(OnEos, Instant)>,
+        pub(crate) on_body_chunk: OnBodyChunk,
+        pub(crate) on_failure: Option<OnFailure>,
+        pub(crate) start: Instant,
+        pub(crate) span: Span,
+    }
 }
 
 impl<B, C, OnBodyChunkT, OnEosT, OnFailureT> Body

--- a/tower-http/src/trace/future.rs
+++ b/tower-http/src/trace/future.rs
@@ -2,7 +2,7 @@ use super::{OnBodyChunk, OnEos, OnFailure, OnResponse, ResponseBody};
 use crate::classify::{ClassifiedResponse, ClassifyResponse};
 use http::Response;
 use http_body::Body;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
@@ -11,20 +11,21 @@ use std::{
 };
 use tracing::Span;
 
-/// Response future for [`Trace`].
-///
-/// [`Trace`]: super::Trace
-#[pin_project]
-pub struct ResponseFuture<F, C, OnResponse, OnBodyChunk, OnEos, OnFailure> {
-    #[pin]
-    pub(crate) inner: F,
-    pub(crate) span: Span,
-    pub(crate) classifier: Option<C>,
-    pub(crate) on_response: Option<OnResponse>,
-    pub(crate) on_body_chunk: Option<OnBodyChunk>,
-    pub(crate) on_eos: Option<OnEos>,
-    pub(crate) on_failure: Option<OnFailure>,
-    pub(crate) start: Instant,
+pin_project! {
+    /// Response future for [`Trace`].
+    ///
+    /// [`Trace`]: super::Trace
+    pub struct ResponseFuture<F, C, OnResponse, OnBodyChunk, OnEos, OnFailure> {
+        #[pin]
+        pub(crate) inner: F,
+        pub(crate) span: Span,
+        pub(crate) classifier: Option<C>,
+        pub(crate) on_response: Option<OnResponse>,
+        pub(crate) on_body_chunk: Option<OnBodyChunk>,
+        pub(crate) on_eos: Option<OnEos>,
+        pub(crate) on_failure: Option<OnFailure>,
+        pub(crate) start: Instant,
+    }
 }
 
 impl<Fut, ResBody, E, C, OnResponseT, OnBodyChunkT, OnEosT, OnFailureT> Future


### PR DESCRIPTION
Fixes #115.

Contains a decent amount of duplicated code, most of which can be removed once https://github.com/rust-lang/rust/issues/51085 is stable. It might be possible to reduce this duplication using a macro (but I'm not sure whether macros are allowed to take the place of entire match arms, rather than just patterns / expressions), if you want I'll look into that.