### PR TITLE
Remove unused optional hyper dependency

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -25,7 +25,6 @@ tower-service = "0.3"
 # optional dependencies
 async-compression = { version = "0.3", optional = true, features = ["tokio"] }
 base64 = { version = "0.13", optional = true }
-hyper = { version = "0.14", optional = true, default_features = false, features = ["stream"] }
 iri-string = { version = "0.4", optional = true }
 mime = { version = "0.3", optional = true, default_features = false }
 mime_guess = { version = "2", optional = true, default_features = false }


### PR DESCRIPTION
tower-http had an optional dependency on hyper but it doesn't seem like
it was used anywhere. So can be safely removed.