### PR TITLE
Change compression body error type to `BoxError`

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -12,12 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change the response body error type of `Compression` and `Decompression` to
   `Box<dyn std::error::Error + Send + Sync>`. This makes them usable if the body
   they're wrapping uses `Box<dyn std::error::Error + Send + Sync>` as its error
-  type which they previously weren't
+  type which they previously weren't ([#166])
 - Remove `BodyOrIoError`. Its been replaced with `Box<dyn std::error::Error +
-  Send + Sync>`
+  Send + Sync>` ([#166])
 
 [#124]: https://github.com/tower-rs/tower-http/pull/124
 [#156]: https://github.com/tower-rs/tower-http/pull/156
+[#166]: https://github.com/tower-rs/tower-http/pull/166
 
 # 0.1.2 (November 13, 2021)
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#124]: https://github.com/tower-rs/tower-http/pull/124
 [#156]: https://github.com/tower-rs/tower-http/pull/156
 [#166]: https://github.com/tower-rs/tower-http/pull/166
+[#148]: https://github.com/tower-rs/tower-http/pull/148
 
 # 0.1.2 (November 13, 2021)
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ServeDir` and `ServeFile`: Ability to serve precompressed files ([#156])
 - `Trace`: Add `DefaultMakeSpan::level` to make log level of tracing spans easily configurable ([#124])
+- Change the response body error type of `Compression` and `Decompression` to
+  `Box<dyn std::error::Error + Send + Sync>`. This makes them usable if the body
+  they're wrapping uses `Box<dyn std::error::Error + Send + Sync>` as its error
+  type which they previously weren't
+- Remove `BodyOrIoError`. Its been replaced with `Box<dyn std::error::Error +
+  Send + Sync>`
 
 [#124]: https://github.com/tower-rs/tower-http/pull/124
 [#156]: https://github.com/tower-rs/tower-http/pull/156

--- a/tower-http/src/compression/layer.rs
+++ b/tower-http/src/compression/layer.rs
@@ -105,7 +105,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn accept_encoding_configuration_works() -> Result<(), Box<dyn std::error::Error>> {
+    async fn accept_encoding_configuration_works() -> Result<(), crate::BoxError> {
         let deflate_only_layer = CompressionLayer::new().no_br().no_gzip();
 
         let mut service = ServiceBuilder::new()

--- a/tower-http/src/compression/mod.rs
+++ b/tower-http/src/compression/mod.rs
@@ -13,10 +13,10 @@
 //! use tokio::fs::{self, File};
 //! use tokio_util::io::ReaderStream;
 //! use tower::{Service, ServiceExt, ServiceBuilder, service_fn};
-//! use tower_http::compression::CompressionLayer;
+//! use tower_http::{compression::CompressionLayer, BoxError};
 //!
 //! # #[tokio::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # async fn main() -> Result<(), BoxError> {
 //! async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
 //!     // Open the file.
 //!     let file = File::open("Cargo.toml").await.expect("file missing");

--- a/tower-http/src/decompression/body.rs
+++ b/tower-http/src/decompression/body.rs
@@ -1,7 +1,9 @@
 #![allow(unused_imports)]
 
-use crate::compression_utils::{AsyncReadBody, BodyIntoStream, DecorateAsyncRead, WrapBody};
-use crate::BodyOrIoError;
+use crate::{
+    compression_utils::{AsyncReadBody, BodyIntoStream, DecorateAsyncRead, WrapBody},
+    BoxError,
+};
 #[cfg(feature = "decompression-br")]
 use async_compression::tokio::bufread::BrotliDecoder;
 #[cfg(feature = "decompression-gzip")]
@@ -132,9 +134,10 @@ where
 impl<B> Body for DecompressionBody<B>
 where
     B: Body,
+    B::Error: Into<BoxError>,
 {
     type Data = Bytes;
-    type Error = BodyOrIoError<B::Error>;
+    type Error = BoxError;
 
     fn poll_data(
         self: Pin<&mut Self>,
@@ -152,7 +155,7 @@ where
                     let bytes = buf.copy_to_bytes(buf.remaining());
                     Poll::Ready(Some(Ok(bytes)))
                 }
-                Some(Err(err)) => Poll::Ready(Some(Err(BodyOrIoError::Body(err)))),
+                Some(Err(err)) => Poll::Ready(Some(Err(err.into()))),
                 None => Poll::Ready(None),
             },
         }
@@ -169,7 +172,7 @@ where
             BodyInnerProj::Deflate(inner) => inner.poll_trailers(cx),
             #[cfg(feature = "decompression-br")]
             BodyInnerProj::Brotli(inner) => inner.poll_trailers(cx),
-            BodyInnerProj::Identity(body) => body.poll_trailers(cx).map_err(BodyOrIoError::Body),
+            BodyInnerProj::Identity(body) => body.poll_trailers(cx).map_err(Into::into),
         }
     }
 }

--- a/tower-http/src/decompression/mod.rs
+++ b/tower-http/src/decompression/mod.rs
@@ -9,10 +9,10 @@
 //! use hyper::Body;
 //! use std::convert::Infallible;
 //! use tower::{Service, ServiceExt, ServiceBuilder, service_fn};
-//! use tower_http::{compression::Compression, decompression::DecompressionLayer};
+//! use tower_http::{compression::Compression, decompression::DecompressionLayer, BoxError};
 //! #
 //! # #[tokio::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # async fn main() -> Result<(), tower_http::BoxError> {
 //! # async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
 //! #     let body = Body::from("Hello, World!");
 //! #     Ok(Response::new(body))
@@ -45,7 +45,7 @@
 //!     let chunk = chunk?;
 //!     bytes.extend_from_slice(&chunk[..]);
 //! }
-//! let body = String::from_utf8(bytes.to_vec())?;
+//! let body = String::from_utf8(bytes.to_vec()).map_err(Into::<BoxError>::into)?;
 //!
 //! assert_eq!(body, "Hello, World!");
 //! #

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -285,52 +285,6 @@ pub mod cors;
 pub mod classify;
 pub mod services;
 
-/// Error type containing either a body error or an IO error.
-///
-/// This type is used to combine errors produced by response bodies with compression or
-/// decompression applied. The body itself can produce errors of type `E` whereas compression or
-/// decompression can produce [`io::Error`]s.
-///
-/// [`io::Error`]: std::io::Error
-#[cfg(any(feature = "compression", feature = "decompression"))]
-#[cfg_attr(
-    docsrs,
-    doc(cfg(any(feature = "compression", feature = "decompression")))
-)]
-#[derive(Debug)]
-pub enum BodyOrIoError<E> {
-    /// Errors produced by the body.
-    Body(E),
-    /// IO errors produced by compression or decompression.
-    Io(std::io::Error),
-}
-
-#[cfg(any(feature = "compression", feature = "decompression"))]
-impl<E> std::fmt::Display for BodyOrIoError<E>
-where
-    E: std::fmt::Display,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            BodyOrIoError::Io(inner) => inner.fmt(f),
-            BodyOrIoError::Body(inner) => inner.fmt(f),
-        }
-    }
-}
-
-#[cfg(any(feature = "compression", feature = "decompression"))]
-impl<E> std::error::Error for BodyOrIoError<E>
-where
-    E: std::error::Error,
-{
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            BodyOrIoError::Io(inner) => inner.source(),
-            BodyOrIoError::Body(inner) => inner.source(),
-        }
-    }
-}
-
 /// The latency unit used to report latencies by middleware.
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug)]
@@ -342,3 +296,6 @@ pub enum LatencyUnit {
     /// Use nanoseconds.
     Nanos,
 }
+
+/// Alias for a type-erased error type.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;


### PR DESCRIPTION
The compression related middleware would previously use `BodyOrIoError`
as the body error type. That only implemented `std::error::Error` if the
inner error did as well. Since `Box<dyn std::error::Error + Send + Sync>`
does not implement `std::error::Error` `Compression` and
`Decompression` wouldn't be usable with hyper if the body they wrapped
had that error type.

This changes the middleware to use `BoxError` as the error type which
resolves the issue. Its also consistent with other middleware.

Reimplementation of #107 on top of latest `master`.