### PR TITLE
ServeDir/File: add check_precompressed_file to serve precompressed files

### DIFF
--- a/test-files/only_uncompressed.txt
+++ b/test-files/only_uncompressed.txt
@@ -1,0 +1,1 @@
+"This is a test file!"


### PR DESCRIPTION
I'm wondering if it is a design problem that ServeDir/File will fail when precompressed_gzip enabled and path/file.ext.gz not exists but path/file.ext exists, this should works without content-encoding. **It is very common that small files and image/movie files should remaind uncompressed(only uncompressed files exist) while large files have precompressed and uncompressed copies coexist.** [This PR is my solution to fix this problem](https://github.com/tower-rs/tower-http/pull/174).

