### PR TITLE
Fallback to uncompressed file version if precompressed can't be found

### DIFF
--- a/test-files/missing_precompressed.txt
+++ b/test-files/missing_precompressed.txt
@@ -1,0 +1,1 @@
+Test file!


### PR DESCRIPTION
## Motivation

Prevents 404s when `.precompressed_gzip()` and family is specified but no precompressed version is found. Mostly useful for the `ServeDir` use case.

## Solution
Simply remove the extension and retry if an encoding is specified but no file is found.
