### PR TITLE
ServeDir/File: Modified open_file_with_fallback to support multiple precompressed

### DIFF
--- a/test-files/precompressed_br.txt
+++ b/test-files/precompressed_br.txt
@@ -1,0 +1,1 @@
+"This is a test file!"

--- a/test-files/precompressed_br.txt.br
+++ b/test-files/precompressed_br.txt.br
@@ -1,0 +1,2 @@
+€"This is a test file!"
+

--- a/tower-http/src/services/fs/mod.rs
+++ b/tower-http/src/services/fs/mod.rs
@@ -86,7 +86,6 @@ impl EncodingCandidates {
     }
 }
 
-
 #[derive(Clone, Copy, Debug)]
 struct PrecompressedVariants {
     gzip: bool,

--- a/tower-http/src/services/fs/mod.rs
+++ b/tower-http/src/services/fs/mod.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use http::{HeaderMap, Response, StatusCode};
 use http_body::{combinators::BoxBody, Body, Empty};
 use pin_project_lite::pin_project;
-use std::{ffi::OsStr, future::Future, path::PathBuf};
+use std::{future::Future, path::PathBuf};
 use std::{
     io,
     pin::Pin,
@@ -22,7 +22,7 @@ mod serve_file;
 // default capacity 64KiB
 const DEFAULT_CAPACITY: usize = 65536;
 
-use crate::content_encoding::{Encoding, SupportedEncodings};
+use crate::content_encoding::{encodings, preferred_encoding, Encoding, SupportedEncodings};
 
 pub use self::{
     serve_dir::{
@@ -32,6 +32,60 @@ pub use self::{
         ResponseBody as ServeFileResponseBody, ResponseFuture as ServeFileResponseFuture, ServeFile,
     },
 };
+
+#[derive(Clone, Debug)]
+struct EncodingCandidates {
+    precompressed_variants: Option<PrecompressedVariants>,
+    acceptted_encodings: Vec<(Encoding, f32)>,
+}
+
+impl EncodingCandidates {
+    fn new(precompressed_variants: Option<PrecompressedVariants>, headers: &HeaderMap) -> Self {
+        let acceptted_encodings = if let Some(precompressed_variants) = precompressed_variants {
+            encodings(headers, precompressed_variants)
+        } else {
+            Vec::new()
+        };
+        Self {
+            precompressed_variants,
+            acceptted_encodings,
+        }
+    }
+    fn negotiated_first(&self) -> Option<Encoding> {
+        preferred_encoding(self.acceptted_encodings.iter())
+    }
+    fn negotiated_second(&self) -> Option<Encoding> {
+        if let Some(first) = self.negotiated_first() {
+            let acceptted_encodings = self.acceptted_encodings.iter().filter(|x| x.0 != first);
+            preferred_encoding(acceptted_encodings)
+        } else {
+            None
+        }
+    }
+    fn negotiated_third(&self) -> Option<Encoding> {
+        if let Some(first) = self.negotiated_first() {
+            if let Some(second) = self.negotiated_second() {
+                let acceptted_encodings = self
+                    .acceptted_encodings
+                    .iter()
+                    .filter(|x| x.0 != first && x.0 != second);
+                preferred_encoding(acceptted_encodings)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+    fn negotiated_encodings(&self) -> (Option<Encoding>, Option<Encoding>, Option<Encoding>) {
+        (
+            self.negotiated_first(),
+            self.negotiated_second(),
+            self.negotiated_third(),
+        )
+    }
+}
+
 
 #[derive(Clone, Copy, Debug)]
 struct PrecompressedVariants {
@@ -67,31 +121,48 @@ impl SupportedEncodings for PrecompressedVariants {
 type FileFuture =
     Pin<Box<dyn Future<Output = io::Result<(File, Option<Encoding>)>> + Send + Sync + 'static>>;
 
-// Attempts to open the file with corresponding encoding but
+// Attempts to open the file with negitiated encoding cascading but
 // fallbacks to the uncompressed variant if it can't be found
 async fn open_file_with_fallback(
-    mut path: PathBuf,
-    mut precompressed_encoding: Option<Encoding>,
+    uncompressed_path: PathBuf,
+    negitiated_encodings: (Option<Encoding>, Option<Encoding>, Option<Encoding>),
 ) -> io::Result<(File, Option<Encoding>)> {
-    let file = loop {
+    let mut loop_count = 0;
+    let result = loop {
+        let mut path = uncompressed_path.clone();
+        let negotiated_encoding = if loop_count == 0 {
+            negitiated_encodings.0
+        } else if loop_count == 1 {
+            negitiated_encodings.1
+        } else if loop_count == 2 {
+            negitiated_encodings.2
+        } else {
+            None
+        };
+        if let Some(file_extension) =
+            negotiated_encoding.and_then(|encoding| encoding.to_file_extension())
+        {
+            let new_extension = uncompressed_path
+                .extension()
+                .map(|extension| {
+                    let mut os_string = extension.to_os_string();
+                    os_string.push(file_extension);
+                    os_string
+                })
+                .unwrap_or_else(|| file_extension.to_os_string());
+            path.set_extension(new_extension);
+        };
         match File::open(&path).await {
-            Ok(file) => break file,
-            Err(err)
-                if err.kind() == io::ErrorKind::NotFound && precompressed_encoding.is_some() =>
-            {
-                // Remove the extension corresponding to a precompressed file (.gz, .br, .zz)
-                // to fallback to the uncompressed version
-                path.set_extension(OsStr::new(""));
-                // Remove the encoding to make sure the correct content encoding header is set
-                precompressed_encoding.take();
+            Ok(file) => break (file, negotiated_encoding),
+            Err(err) if err.kind() == io::ErrorKind::NotFound && negotiated_encoding.is_some() => {
+                loop_count += 1;
                 continue;
             }
             Err(err) => return Err(err),
         };
     };
-    Ok((file, precompressed_encoding))
+    Ok(result)
 }
-
 pin_project! {
     // NOTE: This could potentially be upstreamed to `http-body`.
     /// Adapter that turns an `impl AsyncRead` to an `impl Body`.

--- a/tower-http/src/services/fs/serve_file.rs
+++ b/tower-http/src/services/fs/serve_file.rs
@@ -1,7 +1,8 @@
 //! Service that serves a file.
 
-use super::{open_file_with_fallback, AsyncReadBody, FileFuture, PrecompressedVariants};
-use crate::content_encoding::Encoding;
+use super::{
+    open_file_with_fallback, AsyncReadBody, EncodingCandidates, FileFuture, PrecompressedVariants,
+};
 use crate::services::fs::DEFAULT_CAPACITY;
 use bytes::Bytes;
 use futures_util::ready;
@@ -139,28 +140,13 @@ impl<ReqBody> Service<Request<ReqBody>> for ServeFile {
     }
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        let mut path = self.path.clone();
+        let path = self.path.clone();
 
-        let negotiated_encoding = self
-            .precompressed_variants
-            .map(|precompressed| Encoding::from_headers(req.headers(), precompressed))
-            .filter(|encoding| *encoding != Encoding::Identity);
+        let negotiated_encodings =
+            EncodingCandidates::new(self.precompressed_variants, req.headers())
+                .negotiated_encodings();
 
-        if let Some(file_extension) =
-            negotiated_encoding.and_then(|encoding| encoding.to_file_extension())
-        {
-            let new_extension = path
-                .extension()
-                .map(|extension| {
-                    let mut os_string = extension.to_os_string();
-                    os_string.push(file_extension);
-                    os_string
-                })
-                .unwrap_or_else(|| file_extension.to_os_string());
-            path.set_extension(new_extension);
-        }
-
-        let open_file_future = Box::pin(open_file_with_fallback(path, negotiated_encoding));
+        let open_file_future = Box::pin(open_file_with_fallback(path, negotiated_encodings));
 
         ResponseFuture {
             open_file_future,
@@ -330,6 +316,26 @@ mod tests {
 
         let request = Request::builder()
             .header("Accept-Encoding", "gzip,br")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.oneshot(request).await.unwrap();
+
+        assert_eq!(res.headers()["content-type"], "text/plain");
+        assert_eq!(res.headers()["content-encoding"], "br");
+
+        let body = res.into_body().data().await.unwrap().unwrap();
+        let mut decompressed = Vec::new();
+        BrotliDecompress(&mut &body[..], &mut decompressed).unwrap();
+        let decompressed = String::from_utf8(decompressed.to_vec()).unwrap();
+        assert!(decompressed.starts_with("\"This is a test file!\""));
+    }
+
+    #[tokio::test]
+    async fn precompressed_fallback_br() {
+        let svc = ServeFile::new("../test-files/precompressed_br.txt").precompressed_gzip().precompressed_deflate().precompressed_br();
+
+        let request = Request::builder()
+            .header("Accept-Encoding", "gzip,deflate,br")
             .body(Body::empty())
             .unwrap();
         let res = svc.oneshot(request).await.unwrap();


### PR DESCRIPTION
[PR 175](https://github.com/tower-rs/tower-http/pull/175) introduced a problem, that is, when br and gzip both enabled and client-accepted, negotiated_encoding may be gzip only, when path/file.ext.gz not exists but path/file.ext.br exists, it will  fallback to uncompressed, not br. [This PR 177](https://github.com/tower-rs/tower-http/pull/177) is managing to fix this problem. **Specifically considered for Chrome: It will feed Chrome with br if posible**. Chrome usually has a header value "Accept-Encoding: gzip, deflate, br" ,here quota of all accepted encodings equals, the last one selected.