### PR TITLE
Add `LatencyUnit::Seconds`

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   be used instead. ([#170])
 - Add `ServiceBuilderExt` which adds methods to `tower::ServiceBuilder` for
   adding middleware from tower-http.
+- Add `LatencyUnit::Seconds` for formatting latencies as seconds.
 
 [#124]: https://github.com/tower-rs/tower-http/pull/124
 [#156]: https://github.com/tower-rs/tower-http/pull/156

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -333,6 +333,8 @@ pub use self::builder::ServiceBuilderExt;
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug)]
 pub enum LatencyUnit {
+    /// Use seconds.
+    Seconds,
     /// Use milliseconds.
     Millis,
     /// Use microseconds.

--- a/tower-http/src/trace/on_eos.rs
+++ b/tower-http/src/trace/on_eos.rs
@@ -95,6 +95,22 @@ macro_rules! log_pattern_match {
     ) => {
         match ($this.level, $this.latency_unit, $status) {
             $(
+                (Level::$level, LatencyUnit::Seconds, None) => {
+                    tracing::event!(
+                        Level::$level,
+                        stream_duration = format_args!("{} s", $stream_duration.as_secs_f64()),
+                        "end of stream"
+                    );
+                }
+                (Level::$level, LatencyUnit::Seconds, Some(status)) => {
+                    tracing::event!(
+                        Level::$level,
+                        stream_duration = format_args!("{} s", $stream_duration.as_secs_f64()),
+                        status = status,
+                        "end of stream"
+                    );
+                }
+
                 (Level::$level, LatencyUnit::Millis, None) => {
                     tracing::event!(
                         Level::$level,

--- a/tower-http/src/trace/on_failure.rs
+++ b/tower-http/src/trace/on_failure.rs
@@ -92,6 +92,14 @@ macro_rules! log_pattern_match {
     ) => {
         match ($this.level, $this.latency_unit) {
             $(
+                (Level::$level, LatencyUnit::Seconds) => {
+                    tracing::event!(
+                        Level::$level,
+                        classification = tracing::field::display($failure_classification),
+                        latency = format_args!("{} s", $latency.as_secs_f64()),
+                        "response failed"
+                    );
+                }
                 (Level::$level, LatencyUnit::Millis) => {
                     tracing::event!(
                         Level::$level,

--- a/tower-http/src/trace/on_response.rs
+++ b/tower-http/src/trace/on_response.rs
@@ -113,6 +113,39 @@ macro_rules! log_pattern_match {
     ) => {
         match ($this.level, $include_headers, $this.latency_unit, status($res)) {
             $(
+                (Level::$level, true, LatencyUnit::Seconds, None) => {
+                    tracing::event!(
+                        Level::$level,
+                        latency = format_args!("{} s", $latency.as_secs_f64()),
+                        response_headers = ?$res.headers(),
+                        "finished processing request"
+                    );
+                }
+                (Level::$level, false, LatencyUnit::Seconds, None) => {
+                    tracing::event!(
+                        Level::$level,
+                        latency = format_args!("{} s", $latency.as_secs_f64()),
+                        "finished processing request"
+                    );
+                }
+                (Level::$level, true, LatencyUnit::Seconds, Some(status)) => {
+                    tracing::event!(
+                        Level::$level,
+                        latency = format_args!("{} s", $latency.as_secs_f64()),
+                        status = status,
+                        response_headers = ?$res.headers(),
+                        "finished processing request"
+                    );
+                }
+                (Level::$level, false, LatencyUnit::Seconds, Some(status)) => {
+                    tracing::event!(
+                        Level::$level,
+                        latency = format_args!("{} s", $latency.as_secs_f64()),
+                        status = status,
+                        "finished processing request"
+                    );
+                }
+
                 (Level::$level, true, LatencyUnit::Millis, None) => {
                     tracing::event!(
                         Level::$level,


### PR DESCRIPTION
For formatting latencies as seconds when using `TraceLayer`:

```rust
.layer(TraceLayer::new_for_http().latency_unit(LatencyUnit::Seconds))
```

which gives this output:

```
Nov 19 16:45:53.003 DEBUG request{method=GET uri=/ version=HTTP/1.1}: tower_http::trace::on_response: finished processing request latency=0.000626625 s status=405
```