### PR TITLE
WIP: Make `Trace` compatible with OpenTelemetry

### DIFF
--- a/examples/axum-key-value-store/Cargo.toml
+++ b/examples/axum-key-value-store/Cargo.toml
@@ -13,5 +13,10 @@ tokio = { version = "1.2.0", features = ["full"] }
 tower = { version = "0.4.5", features = ["full"] }
 tower-http = { path = "../../tower-http", features = ["full"] }
 tracing = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 axum = "0.3"
+uuid = { version = "0.8", features = ["v4"] }
+
+opentelemetry = { version = "0.16", features = ["rt-tokio"] }
+opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio"] }
+tracing-opentelemetry = "0.16"

--- a/examples/axum-key-value-store/Cargo.toml
+++ b/examples/axum-key-value-store/Cargo.toml
@@ -7,16 +7,15 @@ publish = false
 license = "MIT"
 
 [dependencies]
+axum = "0.3"
 hyper = { version = "0.14.15", features = ["full"] }
+opentelemetry = { version = "0.16", features = ["rt-tokio"] }
+opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio"] }
 structopt = "0.3.21"
 tokio = { version = "1.2.0", features = ["full"] }
 tower = { version = "0.4.5", features = ["full"] }
 tower-http = { path = "../../tower-http", features = ["full"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-axum = "0.3"
-uuid = { version = "0.8", features = ["v4"] }
-
-opentelemetry = { version = "0.16", features = ["rt-tokio"] }
-opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio"] }
 tracing-opentelemetry = "0.16"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+uuid = { version = "0.8", features = ["v4"] }

--- a/examples/axum-key-value-store/README.md
+++ b/examples/axum-key-value-store/README.md
@@ -13,3 +13,21 @@ This examples contains a simple key/value store with an HTTP API built using axu
 RUST_LOG=axum_key_value_store=trace,tower_http=trace \
     cargo run --bin axum-key-value-store
 ```
+
+## Enabling OpenTelemetry
+
+Run Jaeger, or whatever trace collector you want to use:
+
+```
+docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest
+```
+
+Go to `localhost:16686`.
+
+Run the application with OpenTelemetry enabled:
+
+```
+RUST_LOG=axum_key_value_store=trace,tower_http=trace \
+    cargo run --bin axum-key-value-store -- --otel
+```
+

--- a/examples/axum-key-value-store/src/main.rs
+++ b/examples/axum-key-value-store/src/main.rs
@@ -1,8 +1,8 @@
 use axum::{
-    body::Bytes,
+    body::{Bytes, Full},
     error_handling::HandleErrorLayer,
     extract::{ConnectInfo, Extension, MatchedPath, Path},
-    http::{header, uri::Uri, Extensions, HeaderMap, HeaderValue, Request, StatusCode},
+    http::{header, uri::Uri, Extensions, HeaderMap, HeaderValue, Request, Response, StatusCode},
     response::IntoResponse,
     routing::get,
     BoxError, Router,
@@ -10,6 +10,7 @@ use axum::{
 use std::{
     borrow::Cow,
     collections::HashMap,
+    fmt,
     net::SocketAddr,
     sync::{Arc, RwLock},
     time::Duration,
@@ -17,9 +18,10 @@ use std::{
 use structopt::StructOpt;
 use tower::ServiceBuilder;
 use tower_http::{
+    classify::{ClassifiedResponse, ClassifyResponse, NeverClassifyEos, SharedClassifier},
     request_id::{MakeRequestId, RequestId},
     trace::{
-        otel::server::{ExtractClientIp, ExtractMatchedPath, OtelConfig, SetOtelParent},
+        otel::server::{FailureDetails, OtelConfig},
         TraceLayer,
     },
     ServiceBuilderExt,
@@ -78,29 +80,14 @@ async fn main() {
         .expect("server error");
 }
 
-fn handle_errors(err: BoxError) -> (StatusCode, String) {
-    if err.is::<tower::timeout::error::Elapsed>() {
-        (
-            StatusCode::REQUEST_TIMEOUT,
-            "Request took too long".to_string(),
-        )
-    } else {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Unhandled internal error: {}", err),
-        )
-    }
-}
-
 fn app() -> Router {
     // Build our database for holding the key/value pairs
     let state = State {
         db: Arc::new(RwLock::new(HashMap::new())),
     };
 
-    let sensitive_headers: Arc<[_]> = vec![header::AUTHORIZATION, header::COOKIE].into();
-
-    let otel_config = AxumOtelConfig;
+    let sensitive_headers: Arc<[_]> =
+        vec![header::AUTHORIZATION, header::COOKIE, header::SET_COOKIE].into();
 
     // Build our middleware stack
     let middleware = ServiceBuilder::new()
@@ -110,11 +97,11 @@ fn app() -> Router {
         .sensitive_request_headers(sensitive_headers.clone())
         // Add high level tracing/logging to all requests
         .layer(
-            TraceLayer::new_for_http().opentelemetry_server(
+            TraceLayer::new(SharedClassifier::new(MyResponseClassifier)).opentelemetry_server(
                 OtelConfig::default()
-                    .extract_matched_path_with(otel_config)
-                    .extract_client_ip_with(otel_config)
-                    .set_otel_parent_with(otel_config),
+                    .extract_matched_path_with(extract_matched_path)
+                    .extract_client_ip_with(extract_client_ip)
+                    .set_otel_parent_with(set_otel_parent),
             ),
         )
         .sensitive_response_headers(sensitive_headers)
@@ -137,8 +124,11 @@ fn app() -> Router {
     // Build route service
     Router::new()
         .route("/:key", get(get_key).post(set_key))
+        .route("/test-error", get(test_error))
         .layer(middleware)
 }
+
+// --- routes
 
 async fn get_key(path: Path<String>, state: Extension<State>) -> impl IntoResponse {
     let state = state.db.read().unwrap();
@@ -155,58 +145,158 @@ async fn set_key(Path(path): Path<String>, state: Extension<State>, value: Bytes
     state.insert(path, value);
 }
 
-#[derive(Copy, Clone)]
-struct AxumOtelConfig;
+async fn test_error() -> AppError {
+    AppError::SomethingWentWrong
+}
 
-impl ExtractMatchedPath for AxumOtelConfig {
-    fn extract_matched_path<'a>(&self, uri: &'a Uri, extensions: &'a Extensions) -> Cow<'a, str> {
-        if let Some(matched_path) = extensions.get::<MatchedPath>() {
-            matched_path.as_str().into()
+fn handle_errors(err: BoxError) -> (StatusCode, String) {
+    if err.is::<tower::timeout::error::Elapsed>() {
+        (
+            StatusCode::REQUEST_TIMEOUT,
+            "Request took too long".to_string(),
+        )
+    } else {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Unhandled internal error: {}", err),
+        )
+    }
+}
+
+// --- opentelemetry customization
+
+fn extract_matched_path<'a>(
+    uri: &'a Uri,
+    _headers: &'a HeaderMap,
+    extensions: &'a Extensions,
+) -> Cow<'a, str> {
+    if let Some(matched_path) = extensions.get::<MatchedPath>() {
+        matched_path.as_str().into()
+    } else {
+        uri.path().to_owned().into()
+    }
+}
+
+fn extract_client_ip<'a>(
+    _uri: &'a Uri,
+    _headers: &'a HeaderMap,
+    extensions: &'a Extensions,
+) -> Option<Cow<'a, str>> {
+    extensions
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ConnectInfo(addr)| addr.to_string().into())
+}
+
+fn set_otel_parent(_uri: &Uri, headers: &HeaderMap, _extensions: &Extensions, span: &Span) {
+    use opentelemetry::trace::TraceContextExt as _;
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    struct RequestHeaderExtractor<'a>(&'a HeaderMap);
+
+    impl<'a> opentelemetry::propagation::Extractor for RequestHeaderExtractor<'a> {
+        fn get(&self, key: &str) -> Option<&str> {
+            self.0.get(key).and_then(|v| v.to_str().ok())
+        }
+
+        fn keys(&self) -> Vec<&str> {
+            self.0.keys().map(|header| header.as_str()).collect()
+        }
+    }
+
+    let parent_context = opentelemetry::global::get_text_map_propagator(|propagator| {
+        propagator.extract(&RequestHeaderExtractor(headers))
+    });
+    span.set_parent(parent_context);
+    // If we have a remote parent span, this will be the parent's trace identifier.
+    // If not, it will be the newly generated trace identifier with this request as root span.
+    let trace_id = span.context().span().span_context().trace_id().to_hex();
+    span.record("trace_id", &tracing::field::display(trace_id));
+}
+
+// --- custom error type used in routes
+
+#[derive(Clone)]
+enum AppError {
+    SomethingWentWrong,
+    UnknownError(StatusCode),
+}
+
+impl fmt::Display for AppError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AppError::SomethingWentWrong => write!(f, "something went wrong"),
+            AppError::UnknownError(_) => write!(f, "unknown error"),
+        }
+    }
+}
+
+impl IntoResponse for AppError {
+    type Body = Full<Bytes>;
+    type BodyError = <Self::Body as axum::body::HttpBody>::Error;
+
+    fn into_response(self) -> Response<Self::Body> {
+        let body = Full::from(self.to_string());
+
+        let status = match self {
+            AppError::SomethingWentWrong => StatusCode::INTERNAL_SERVER_ERROR,
+            AppError::UnknownError(status) => status,
+        };
+
+        let mut response = (status, body).into_response();
+
+        // insert the error into response extensions such that the classifier
+        // can access the underlying error and provide more context
+        response.extensions_mut().insert(self);
+
+        response
+    }
+}
+
+// --- response classification that grabs error details
+
+#[derive(Clone, Copy)]
+struct MyResponseClassifier;
+
+impl ClassifyResponse for MyResponseClassifier {
+    type FailureClass = AppError;
+    type ClassifyEos = NeverClassifyEos<Self::FailureClass>;
+
+    fn classify_response<B>(
+        self,
+        res: &Response<B>,
+    ) -> ClassifiedResponse<Self::FailureClass, Self::ClassifyEos> {
+        let classification = if res.status().is_server_error() {
+            if let Some(error) = res.extensions().get::<AppError>() {
+                Err(error.clone())
+            } else {
+                Err(AppError::UnknownError(res.status()))
+            }
         } else {
-            uri.path().to_owned().into()
-        }
+            Ok(())
+        };
+        ClassifiedResponse::Ready(classification)
+    }
+
+    fn classify_error<E>(self, _error: &E) -> Self::FailureClass
+    where
+        E: std::fmt::Display + 'static,
+    {
+        // axum's error type is `Infallible` so this will never be called
+        unreachable!()
     }
 }
 
-impl ExtractClientIp for AxumOtelConfig {
-    fn extract_client_ip<'a>(
-        &self,
-        _headers: &'a HeaderMap,
-        extensions: &'a Extensions,
-    ) -> Option<Cow<'a, str>> {
-        extensions
-            .get::<ConnectInfo<SocketAddr>>()
-            .map(|ConnectInfo(addr)| addr.to_string().into())
+impl FailureDetails for AppError {
+    fn message(&self) -> Option<String> {
+        Some(self.to_string())
+    }
+
+    fn details(&self) -> Option<String> {
+        None
     }
 }
 
-impl SetOtelParent for AxumOtelConfig {
-    fn set_otel_parent(&self, headers: &HeaderMap, span: &Span) {
-        use opentelemetry::trace::TraceContextExt as _;
-        use tracing_opentelemetry::OpenTelemetrySpanExt as _;
-
-        struct RequestHeaderCarrier<'a>(&'a HeaderMap);
-
-        impl<'a> opentelemetry::propagation::Extractor for RequestHeaderCarrier<'a> {
-            fn get(&self, key: &str) -> Option<&str> {
-                self.0.get(key).and_then(|v| v.to_str().ok())
-            }
-
-            fn keys(&self) -> Vec<&str> {
-                self.0.keys().map(|header| header.as_str()).collect()
-            }
-        }
-
-        let parent_context = opentelemetry::global::get_text_map_propagator(|propagator| {
-            propagator.extract(&RequestHeaderCarrier(headers))
-        });
-        span.set_parent(parent_context);
-        // If we have a remote parent span, this will be the parent's trace identifier.
-        // If not, it will be the newly generated trace identifier with this request as root span.
-        let trace_id = span.context().span().span_context().trace_id().to_hex();
-        span.record("trace_id", &tracing::field::display(trace_id));
-    }
-}
+// --- request ids
 
 #[derive(Copy, Clone)]
 struct RequestUuid;
@@ -217,6 +307,8 @@ impl MakeRequestId for RequestUuid {
         Some(RequestId::new(uuid))
     }
 }
+
+// --- testing
 
 // See https://github.com/tokio-rs/axum/blob/main/examples/testing/src/main.rs for an example of
 // how to test axum apps

--- a/examples/axum-key-value-store/src/main.rs
+++ b/examples/axum-key-value-store/src/main.rs
@@ -1,13 +1,14 @@
 use axum::{
     body::Bytes,
     error_handling::HandleErrorLayer,
-    extract::{Extension, Path},
-    http::{header, HeaderValue, StatusCode},
+    extract::{ConnectInfo, Extension, MatchedPath, Path},
+    http::{header, uri::Uri, Extensions, HeaderMap, HeaderValue, Request, StatusCode},
     response::IntoResponse,
     routing::get,
     BoxError, Router,
 };
 use std::{
+    borrow::Cow,
     collections::HashMap,
     net::SocketAddr,
     sync::{Arc, RwLock},
@@ -16,9 +17,16 @@ use std::{
 use structopt::StructOpt;
 use tower::ServiceBuilder;
 use tower_http::{
-    trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer},
-    LatencyUnit, ServiceBuilderExt,
+    request_id::{MakeRequestId, RequestId},
+    trace::{
+        otel::server::{ExtractClientIp, ExtractMatchedPath, OtelConfig, SetOtelParent},
+        TraceLayer,
+    },
+    ServiceBuilderExt,
 };
+use tracing::Span;
+use tracing_subscriber::{prelude::*, EnvFilter};
+use uuid::Uuid;
 
 /// Simple key/value store with an HTTP API
 #[derive(Debug, StructOpt)]
@@ -26,6 +34,10 @@ struct Config {
     /// The port to listen on
     #[structopt(long, short = "p", default_value = "3000")]
     port: u16,
+
+    /// Setup opentelemetry
+    #[structopt(long)]
+    otel: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -35,17 +47,33 @@ struct State {
 
 #[tokio::main]
 async fn main() {
-    // Setup tracing
-    tracing_subscriber::fmt::init();
-
     // Parse command line arguments
     let config = Config::from_args();
+
+    // Setup opentelemetry
+    let otel_layer = config.otel.then(|| {
+        opentelemetry::global::set_text_map_propagator(
+            opentelemetry::sdk::propagation::TraceContextPropagator::new(),
+        );
+        let tracer = opentelemetry_jaeger::new_pipeline()
+            .with_service_name("server")
+            .install_batch(opentelemetry::runtime::Tokio)
+            .unwrap();
+        tracing_opentelemetry::layer().with_tracer(tracer)
+    });
+
+    // Setup tracing
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .with(otel_layer)
+        .init();
 
     // Run our service
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
     tracing::info!("Listening on {}", addr);
     axum::Server::bind(&addr)
-        .serve(app().into_make_service())
+        .serve(app().into_make_service_with_connect_info::<SocketAddr, _>())
         .await
         .expect("server error");
 }
@@ -72,20 +100,26 @@ fn app() -> Router {
 
     let sensitive_headers: Arc<[_]> = vec![header::AUTHORIZATION, header::COOKIE].into();
 
+    let otel_config = AxumOtelConfig;
+
     // Build our middleware stack
     let middleware = ServiceBuilder::new()
+        // Set `x-request-id`
+        .set_x_request_id(RequestUuid)
         // Mark the `Authorization` and `Cookie` headers as sensitive so it doesn't show in logs
         .sensitive_request_headers(sensitive_headers.clone())
         // Add high level tracing/logging to all requests
         .layer(
-            TraceLayer::new_for_http()
-                .on_body_chunk(|chunk: &Bytes, latency: Duration, _: &tracing::Span| {
-                    tracing::trace!(size_bytes = chunk.len(), latency = ?latency, "sending body chunk")
-                })
-                .make_span_with(DefaultMakeSpan::new().include_headers(true))
-                .on_response(DefaultOnResponse::new().include_headers(true).latency_unit(LatencyUnit::Micros)),
+            TraceLayer::new_for_http().opentelemetry_server(
+                OtelConfig::default()
+                    .extract_matched_path_with(otel_config)
+                    .extract_client_ip_with(otel_config)
+                    .set_otel_parent_with(otel_config),
+            ),
         )
         .sensitive_response_headers(sensitive_headers)
+        // Propagate `x-request-id` from requests to responses
+        .propagate_x_request_id()
         // Handle errors
         .layer(HandleErrorLayer::new(handle_errors))
         // Set a timeout
@@ -119,6 +153,69 @@ async fn get_key(path: Path<String>, state: Extension<State>) -> impl IntoRespon
 async fn set_key(Path(path): Path<String>, state: Extension<State>, value: Bytes) {
     let mut state = state.db.write().unwrap();
     state.insert(path, value);
+}
+
+#[derive(Copy, Clone)]
+struct AxumOtelConfig;
+
+impl ExtractMatchedPath for AxumOtelConfig {
+    fn extract_matched_path<'a>(&self, uri: &'a Uri, extensions: &'a Extensions) -> Cow<'a, str> {
+        if let Some(matched_path) = extensions.get::<MatchedPath>() {
+            matched_path.as_str().into()
+        } else {
+            uri.path().to_owned().into()
+        }
+    }
+}
+
+impl ExtractClientIp for AxumOtelConfig {
+    fn extract_client_ip<'a>(
+        &self,
+        _headers: &'a HeaderMap,
+        extensions: &'a Extensions,
+    ) -> Option<Cow<'a, str>> {
+        extensions
+            .get::<ConnectInfo<SocketAddr>>()
+            .map(|ConnectInfo(addr)| addr.to_string().into())
+    }
+}
+
+impl SetOtelParent for AxumOtelConfig {
+    fn set_otel_parent(&self, headers: &HeaderMap, span: &Span) {
+        use opentelemetry::trace::TraceContextExt as _;
+        use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+        struct RequestHeaderCarrier<'a>(&'a HeaderMap);
+
+        impl<'a> opentelemetry::propagation::Extractor for RequestHeaderCarrier<'a> {
+            fn get(&self, key: &str) -> Option<&str> {
+                self.0.get(key).and_then(|v| v.to_str().ok())
+            }
+
+            fn keys(&self) -> Vec<&str> {
+                self.0.keys().map(|header| header.as_str()).collect()
+            }
+        }
+
+        let parent_context = opentelemetry::global::get_text_map_propagator(|propagator| {
+            propagator.extract(&RequestHeaderCarrier(headers))
+        });
+        span.set_parent(parent_context);
+        // If we have a remote parent span, this will be the parent's trace identifier.
+        // If not, it will be the newly generated trace identifier with this request as root span.
+        let trace_id = span.context().span().span_context().trace_id().to_hex();
+        span.record("trace_id", &tracing::field::display(trace_id));
+    }
+}
+
+#[derive(Copy, Clone)]
+struct RequestUuid;
+
+impl MakeRequestId for RequestUuid {
+    fn make_request_id<B>(&mut self, _request: &Request<B>) -> Option<RequestId> {
+        let uuid = HeaderValue::from_str(&Uuid::new_v4().to_string()).unwrap();
+        Some(RequestId::new(uuid))
+    }
 }
 
 // See https://github.com/tokio-rs/axum/blob/main/examples/testing/src/main.rs for an example of

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -80,7 +80,7 @@ redirect = []
 request-id = []
 sensitive-headers = []
 set-header = []
-trace = ["tracing"]
+trace = ["tracing", "request-id"]
 util = ["tower"]
 
 compression-br = ["async-compression/brotli", "tokio-util", "tokio"]

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -371,6 +371,10 @@
 //! - [`TraceLayer::new_for_grpc`] classifies based on the gRPC protocol and supports streaming
 //! responses.
 //!
+//! # OpenTelemetry
+//!
+//! For using OpenTelemetry's conventional span fields see [`otel::server`].
+//!
 //! [tracing]: https://crates.io/crates/tracing
 //! [`Service`]: tower_service::Service
 //! [`Service::call`]: tower_service::Service::call

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -409,6 +409,8 @@ mod on_request;
 mod on_response;
 mod service;
 
+pub mod otel;
+
 const DEFAULT_MESSAGE_LEVEL: Level = Level::DEBUG;
 const DEFAULT_ERROR_LEVEL: Level = Level::ERROR;
 

--- a/tower-http/src/trace/otel/mod.rs
+++ b/tower-http/src/trace/otel/mod.rs
@@ -1,0 +1,3 @@
+#![allow(missing_docs)]
+
+pub mod server;

--- a/tower-http/src/trace/otel/server.rs
+++ b/tower-http/src/trace/otel/server.rs
@@ -1,0 +1,375 @@
+use crate::{
+    classify::{MakeClassifier, ServerErrorsFailureClass},
+    trace::{MakeSpan, OnBodyChunk, OnEos, OnFailure, OnRequest, OnResponse, TraceLayer},
+};
+use http::{
+    header, uri::Scheme, Extensions, HeaderMap, Method, Request, Response, StatusCode, Uri, Version,
+};
+use std::{borrow::Cow, sync::Arc, time::Duration};
+use tracing::{field::Empty, Span};
+
+pub struct Config {
+    scheme: Cow<'static, str>,
+    // these are trait objects such that we can add more callbacks without
+    // adding more type params, which would be a breaking change
+    extract_matched_path: Arc<dyn ExtractMatchedPath>,
+    extract_client_ip: Arc<dyn ExtractClientIp>,
+    set_otel_parent: Arc<dyn SetOtelParent>,
+}
+
+impl Config {
+    pub fn scheme(mut self, scheme: Scheme) -> Self {
+        self.scheme = http_scheme(&scheme);
+        self
+    }
+
+    pub fn extract_matched_path<T>(mut self, extract_matched_path: T) -> Config
+    where
+        T: ExtractMatchedPath,
+    {
+        self.extract_matched_path = Arc::new(extract_matched_path);
+        self
+    }
+
+    pub fn extract_client_ip<T>(mut self, extract_client_ip: T) -> Config
+    where
+        T: ExtractClientIp,
+    {
+        self.extract_client_ip = Arc::new(extract_client_ip);
+        self
+    }
+
+    pub fn set_otel_parent<T>(mut self, set_otel_parent: T) -> Config
+    where
+        T: SetOtelParent,
+    {
+        self.set_otel_parent = Arc::new(set_otel_parent);
+        self
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            scheme: http_scheme(&Scheme::HTTP),
+            extract_matched_path: Arc::new(DefaultExtractMatchedPath),
+            extract_client_ip: Arc::new(DefaultExtractClientIp),
+            set_otel_parent: Arc::new(DefaultSetOtelParent),
+        }
+    }
+}
+
+impl<M> TraceLayer<M> {
+    pub fn opentelemetry_server(
+        self,
+    ) -> TraceLayer<
+        M,
+        OtelMakeSpan,
+        OtelOnRequest,
+        OtelOnResponse,
+        OtelOnBodyChunk,
+        OtelOnEos,
+        OtelOnFailure,
+    >
+    where
+        M: MakeClassifier,
+        M::FailureClass: FailureDetails,
+    {
+        let config = Config::default();
+
+        TraceLayer {
+            make_classifier: self.make_classifier,
+            make_span: OtelMakeSpan {
+                scheme: config.scheme,
+                extract_matched_path: config.extract_matched_path,
+                extract_client_ip: config.extract_client_ip,
+                set_otel_parent: config.set_otel_parent,
+            },
+            on_request: OtelOnRequest,
+            on_response: OtelOnResponse,
+            on_body_chunk: OtelOnBodyChunk,
+            on_eos: OtelOnEos,
+            on_failure: OtelOnFailure,
+        }
+    }
+}
+
+impl<M>
+    TraceLayer<
+        M,
+        OtelMakeSpan,
+        OtelOnRequest,
+        OtelOnResponse,
+        OtelOnBodyChunk,
+        OtelOnEos,
+        OtelOnFailure,
+    >
+{
+    pub fn configure(
+        mut self,
+        config: Config,
+    ) -> TraceLayer<
+        M,
+        OtelMakeSpan,
+        OtelOnRequest,
+        OtelOnResponse,
+        OtelOnBodyChunk,
+        OtelOnEos,
+        OtelOnFailure,
+    >
+    where
+        M: MakeClassifier,
+        M::FailureClass: FailureDetails,
+    {
+        let Config {
+            scheme,
+            extract_matched_path,
+            extract_client_ip,
+            set_otel_parent,
+        } = config;
+
+        self.make_span.scheme = scheme;
+        self.make_span.extract_matched_path = extract_matched_path;
+        self.make_span.extract_client_ip = extract_client_ip;
+        self.make_span.set_otel_parent = set_otel_parent;
+
+        self
+    }
+}
+
+#[derive(Clone)]
+pub struct OtelMakeSpan {
+    scheme: Cow<'static, str>,
+    extract_matched_path: Arc<dyn ExtractMatchedPath>,
+    extract_client_ip: Arc<dyn ExtractClientIp>,
+    set_otel_parent: Arc<dyn SetOtelParent>,
+}
+
+impl<B> MakeSpan<B> for OtelMakeSpan {
+    fn make_span(&mut self, request: &Request<B>) -> Span {
+        let user_agent = request
+            .headers()
+            .get(header::USER_AGENT)
+            .map(|h| h.to_str().unwrap_or(""))
+            .unwrap_or("");
+
+        let host = request
+            .headers()
+            .get(header::HOST)
+            .map(|h| h.to_str().unwrap_or(""))
+            .unwrap_or("");
+
+        let http_route = self
+            .extract_matched_path
+            .extract_matched_path(request.uri(), request.extensions());
+
+        let client_ip = self
+            .extract_client_ip
+            .extract_client_ip(request.headers(), request.extensions())
+            .unwrap_or_default();
+
+        let span = tracing::info_span!(
+            "HTTP request",
+            http.method = %http_method(request.method()),
+            http.route = %http_route,
+            http.flavor = %http_flavor(request.version()),
+            http.scheme = %self.scheme,
+            http.host = %host,
+            http.client_ip = %client_ip,
+            http.user_agent = %user_agent,
+            http.target = %request.uri().path_and_query().map(|p| p.as_str()).unwrap_or(""),
+            http.status_code = Empty,
+            otel.kind = "server",
+            otel.status_code = Empty,
+            trace_id = Empty,
+            // requires https://github.com/tower-rs/tower-http/pull/150
+            // request_id = %request_id,
+            exception.message = Empty,
+            exception.details = Empty,
+        );
+
+        self.set_otel_parent
+            .set_otel_parent(request.headers(), &span);
+
+        span
+    }
+}
+
+fn http_method(method: &Method) -> Cow<'static, str> {
+    match method {
+        &Method::CONNECT => "CONNECT".into(),
+        &Method::DELETE => "DELETE".into(),
+        &Method::GET => "GET".into(),
+        &Method::HEAD => "HEAD".into(),
+        &Method::OPTIONS => "OPTIONS".into(),
+        &Method::PATCH => "PATCH".into(),
+        &Method::POST => "POST".into(),
+        &Method::PUT => "PUT".into(),
+        &Method::TRACE => "TRACE".into(),
+        other => other.to_string().into(),
+    }
+}
+
+pub trait ExtractMatchedPath: Send + Sync + 'static {
+    fn extract_matched_path<'a>(&self, uri: &'a Uri, extensions: &'a Extensions) -> Cow<'a, str>;
+}
+
+#[derive(Clone, Copy)]
+struct DefaultExtractMatchedPath;
+
+impl ExtractMatchedPath for DefaultExtractMatchedPath {
+    #[inline]
+    fn extract_matched_path<'a>(&self, uri: &'a Uri, _extensions: &'a Extensions) -> Cow<'a, str> {
+        uri.path().into()
+    }
+}
+
+pub trait ExtractClientIp: Send + Sync + 'static {
+    fn extract_client_ip<'a>(
+        &self,
+        headers: &'a HeaderMap,
+        extensions: &'a Extensions,
+    ) -> Option<Cow<'a, str>>;
+}
+
+#[derive(Clone, Copy)]
+struct DefaultExtractClientIp;
+
+impl ExtractClientIp for DefaultExtractClientIp {
+    #[inline]
+    fn extract_client_ip<'a>(
+        &self,
+        _headers: &'a HeaderMap,
+        _extensions: &'a Extensions,
+    ) -> Option<Cow<'a, str>> {
+        None
+    }
+}
+
+// NOTE: should also record trace_id on span a la
+// https://github.com/LukeMathWalker/tracing-actix-web/blob/352c274c8da1a9dec8757fc254deae5c689d408f/src/otel.rs#L43-L55
+pub trait SetOtelParent: Send + Sync + 'static {
+    fn set_otel_parent(&self, headers: &HeaderMap, span: &Span);
+}
+
+#[derive(Clone, Copy)]
+struct DefaultSetOtelParent;
+
+impl SetOtelParent for DefaultSetOtelParent {
+    #[inline]
+    fn set_otel_parent(&self, _headers: &HeaderMap, _span: &Span) {}
+}
+
+fn http_flavor(version: Version) -> Cow<'static, str> {
+    match version {
+        Version::HTTP_09 => "0.9".into(),
+        Version::HTTP_10 => "1.0".into(),
+        Version::HTTP_11 => "1.1".into(),
+        Version::HTTP_2 => "2.0".into(),
+        Version::HTTP_3 => "3.0".into(),
+        other => format!("{:?}", other).into(),
+    }
+}
+
+fn http_scheme(scheme: &Scheme) -> Cow<'static, str> {
+    if scheme == &Scheme::HTTP {
+        "http".into()
+    } else if scheme == &Scheme::HTTPS {
+        "https".into()
+    } else {
+        scheme.to_string().into()
+    }
+}
+
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct OtelOnRequest;
+
+impl<B> OnRequest<B> for OtelOnRequest {
+    fn on_request(&mut self, _request: &Request<B>, _span: &Span) {}
+}
+
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct OtelOnResponse;
+
+impl<B> OnResponse<B> for OtelOnResponse {
+    fn on_response(self, response: &Response<B>, _latency: Duration, span: &Span) {
+        let status = response.status().as_u16().to_string();
+        span.record("http.status_code", &tracing::field::display(status));
+    }
+}
+
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct OtelOnBodyChunk;
+
+impl<B> OnBodyChunk<B> for OtelOnBodyChunk {
+    #[inline]
+    fn on_body_chunk(&mut self, _chunk: &B, _latency: Duration, _span: &Span) {}
+}
+
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct OtelOnEos;
+
+impl OnEos for OtelOnEos {
+    #[inline]
+    fn on_eos(self, _trailers: Option<&HeaderMap>, _stream_duration: Duration, _span: &Span) {}
+}
+
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct OtelOnFailure;
+
+impl<E> OnFailure<E> for OtelOnFailure
+where
+    E: FailureDetails,
+{
+    fn on_failure(&mut self, failure: E, _latency: Duration, span: &Span) {
+        if let Some(status) = failure.status() {
+            if status.is_server_error() {
+                span.record("otel.status_code", &"ERROR");
+            }
+        } else {
+            span.record("otel.status_code", &"ERROR");
+        }
+
+        if let Some(message) = failure.message() {
+            span.record("exception.message", &tracing::field::display(message));
+        }
+
+        if let Some(details) = failure.details() {
+            span.record("exception.details", &tracing::field::display(details));
+        }
+    }
+}
+
+pub trait FailureDetails {
+    fn status(&self) -> Option<StatusCode>;
+
+    fn message(&self) -> Option<String>;
+
+    fn details(&self) -> Option<String>;
+}
+
+impl FailureDetails for ServerErrorsFailureClass {
+    fn status(&self) -> Option<StatusCode> {
+        match self {
+            ServerErrorsFailureClass::StatusCode(status) => Some(*status),
+            ServerErrorsFailureClass::Error(_) => None,
+        }
+    }
+
+    fn message(&self) -> Option<String> {
+        match self {
+            ServerErrorsFailureClass::StatusCode(_) => None,
+            ServerErrorsFailureClass::Error(err) => Some(err.to_owned()),
+        }
+    }
+
+    #[inline]
+    fn details(&self) -> Option<String> {
+        None
+    }
+}

--- a/tower-http/src/trace/otel/server.rs
+++ b/tower-http/src/trace/otel/server.rs
@@ -87,6 +87,15 @@ pub struct OtelConfig {
 }
 
 impl OtelConfig {
+    pub fn new() -> Self {
+        Self {
+            scheme: http_scheme(&Scheme::HTTP),
+            extract_matched_path: Arc::new(DefaultExtractMatchedPath),
+            extract_client_ip: Arc::new(DefaultExtractClientIp),
+            set_otel_parent: Arc::new(DefaultSetOtelParent),
+        }
+    }
+
     pub fn scheme(mut self, scheme: Scheme) -> Self {
         self.scheme = http_scheme(&scheme);
         self
@@ -119,12 +128,7 @@ impl OtelConfig {
 
 impl Default for OtelConfig {
     fn default() -> Self {
-        Self {
-            scheme: http_scheme(&Scheme::HTTP),
-            extract_matched_path: Arc::new(DefaultExtractMatchedPath),
-            extract_client_ip: Arc::new(DefaultExtractClientIp),
-            set_otel_parent: Arc::new(DefaultSetOtelParent),
-        }
+        Self::new()
     }
 }
 


### PR DESCRIPTION
OpenTelemetry defines a bunch of [conventions for HTTP
spans][conventions]. This makes adopting those conventions easy when
using `Trace`:

```rust
.layer(TraceLayer::new_for_http().opentelemetry_server())
```

This changes the span for the request to:

- Name: HTTP request
- Fields:
  - `http.flavor`: "1.1"
  - `http.host`: "localhost:3000"
  - `http.method`: "GET"
  - `http.route`: "/users/123". Can be configured by user to instead be
  the path pattern for the route, ie `/users/:id`
  - `http.scheme`: "http". Must be set by user as middleware don't know
  this
  - `http.target`: "/users/123"
  - `http.user_agent`: "curl/7.64.1"
  - `http.client_ip`: Must be extracted by user in a "make service"
  - `http.status_code`: 200
  - `request_id`: Requires #150.
  - `otel.kind`: "server"
  - `otel.status_code`: Unset or "ERROR"
  - `exception.message`: Set by user based on response classification.
  - `exception.details`: Set by user based on response classification.

The fields are a bit different for HTTP clients hence the name
`opentelemetry_server`. I don't think supporting clients initially is
required. We can always add it later.

TODO

- [x] Add `Trace::opentelemetry_server` method. Currently it only exists
  on the layer
- [ ] Docs, including getting request ids
- [x] Example using axum and `opentelemetry_jaeger`
- [ ] Changelog
- [x] Request id integration
- [x] Implement callbacks for functions

[conventions]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md