### PR TITLE
Fix warnings when building with certain combinations of features

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,6 +49,8 @@ jobs:
         curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
     - name: cargo hack check
       working-directory: ${{ matrix.subcrate }}
+      env:
+        RUSTFLAGS: "-D unused_imports -D dead_code -D unused_variables"
       run: cargo hack check --each-feature --no-dev-deps --workspace
 
   test-versions:

--- a/tower-http/src/builder.rs
+++ b/tower-http/src/builder.rs
@@ -1,9 +1,12 @@
-use std::sync::Arc;
-
-use crate::classify::{GrpcErrorsAsFailures, ServerErrorsAsFailures, SharedClassifier};
-use http::header::HeaderName;
 use tower::ServiceBuilder;
+
+#[cfg(feature = "trace")]
+use crate::classify::{GrpcErrorsAsFailures, ServerErrorsAsFailures, SharedClassifier};
+
+#[allow(unused_imports)]
 use tower_layer::Stack;
+#[allow(unused_imports)]
+use http::header::HeaderName;
 
 /// Extension trait that adds methods to [`tower::ServiceBuilder`] for adding middleware from
 /// tower-http.
@@ -199,7 +202,7 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> {
     #[cfg_attr(docsrs, doc(cfg(feature = "sensitive-headers")))]
     fn sensitive_request_headers(
         self,
-        headers: Arc<[HeaderName]>,
+        headers: std::sync::Arc<[HeaderName]>,
     ) -> ServiceBuilder<Stack<crate::sensitive_headers::SetSensitiveRequestHeadersLayer, L>>;
 
     /// Mark headers as [sensitive] on both responses.
@@ -212,7 +215,7 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> {
     #[cfg_attr(docsrs, doc(cfg(feature = "sensitive-headers")))]
     fn sensitive_response_headers(
         self,
-        headers: Arc<[HeaderName]>,
+        headers: std::sync::Arc<[HeaderName]>,
     ) -> ServiceBuilder<Stack<crate::sensitive_headers::SetSensitiveResponseHeadersLayer, L>>;
 
     /// Insert a header into the request.
@@ -418,7 +421,7 @@ impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
     #[cfg(feature = "sensitive-headers")]
     fn sensitive_request_headers(
         self,
-        headers: Arc<[HeaderName]>,
+        headers: std::sync::Arc<[HeaderName]>,
     ) -> ServiceBuilder<Stack<crate::sensitive_headers::SetSensitiveRequestHeadersLayer, L>> {
         self.layer(crate::sensitive_headers::SetSensitiveRequestHeadersLayer::from_shared(headers))
     }
@@ -426,7 +429,7 @@ impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
     #[cfg(feature = "sensitive-headers")]
     fn sensitive_response_headers(
         self,
-        headers: Arc<[HeaderName]>,
+        headers: std::sync::Arc<[HeaderName]>,
     ) -> ServiceBuilder<Stack<crate::sensitive_headers::SetSensitiveResponseHeadersLayer, L>> {
         self.layer(crate::sensitive_headers::SetSensitiveResponseHeadersLayer::from_shared(headers))
     }


### PR DESCRIPTION
Previously some combinations of features, such as just `util`, would result in dead code and unused import warnings.

This fixes that and adds some additional lints to the `cargo hack` CI step to make sure it doesn't happen again.

I fixed the things locally by running `RUSTFLAGS="-D unused_imports -D dead_code -D unused_variables" cargo hack check --each-feature --no-dev-deps --workspace` over and over and until I had the right combinations of features.