### PR TITLE
Make `GrpcErrorsAsFailures` more flexible

### DIFF
--- a/examples/tonic-key-value-store/src/main.rs
+++ b/examples/tonic-key-value-store/src/main.rs
@@ -29,7 +29,7 @@ use tokio_stream::{
 use tonic::{async_trait, body::BoxBody, transport::Channel, Code, Request, Response, Status};
 use tower::{BoxError, Service, ServiceBuilder};
 use tower_http::{
-    classify::{GrpcCodeBitmask, GrpcErrorsAsFailures, SharedClassifier},
+    classify::{GrpcCode, GrpcErrorsAsFailures, SharedClassifier},
     compression::CompressionLayer,
     decompression::DecompressionLayer,
     sensitive_headers::SetSensitiveHeadersLayer,
@@ -169,7 +169,8 @@ async fn serve_forever(listener: TcpListener) -> Result<(), Box<dyn std::error::
     // Response classifier that doesn't consider `Ok`, `Invalid Argument`, or `Not Found` as
     // failures
     let classifier = GrpcErrorsAsFailures::new()
-        .success_codes(GrpcCodeBitmask::INVALID_ARGUMENT | GrpcCodeBitmask::NOT_FOUND);
+        .with_success(GrpcCode::InvalidArgument)
+        .with_success(GrpcCode::NotFound);
 
     // Build our middleware stack
     let layer = ServiceBuilder::new()

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   adding middleware from tower-http.
 - Add `SetRequestId` and `PropagateRequestId` middleware ([#150])
 - Add `LatencyUnit::Seconds` for formatting latencies as seconds.
+- Support customizing which status codes are considered failures by `GrpcErrorsAsFailures` ([#189])
 
 [#124]: https://github.com/tower-rs/tower-http/pull/124
 [#148]: https://github.com/tower-rs/tower-http/pull/148
@@ -44,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#172]: https://github.com/tower-rs/tower-http/pull/172
 [#182]: https://github.com/tower-rs/tower-http/pull/182
 [#187]: https://github.com/tower-rs/tower-http/pull/187
+[#189]: https://github.com/tower-rs/tower-http/pull/189
 
 # 0.1.2 (November 13, 2021)
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["io", "async", "futures", "service", "http"]
 rust-version = "1.51"
 
 [dependencies]
+bitflags = "1.0"
 bytes = "1"
 futures-core = "0.3"
 futures-util = { version = "0.3", default_features = false, features = [] }

--- a/tower-http/src/classify/grpc_errors_as_failures.rs
+++ b/tower-http/src/classify/grpc_errors_as_failures.rs
@@ -1,0 +1,315 @@
+use super::{ClassifiedResponse, ClassifyEos, ClassifyResponse, SharedClassifier};
+use bitflags::bitflags;
+use http::{HeaderMap, Response};
+use std::{fmt, num::NonZeroI32};
+
+bitflags! {
+    /// Bitmask used to specify which gRPC status codes are considered successes.
+    ///
+    /// Used in [`GrpcErrorsAsFailures::success_codes`].
+    pub struct GrpcCodeBitmask: u32 {
+        /// The operation completed successfully.
+        const OK                  = 0b00000000000000001;
+        /// The operation was cancelled.
+        const CANCELLED           = 0b00000000000000010;
+        /// Unknown error.
+        const UNKNOWN             = 0b00000000000000100;
+        /// Client specified an invalid argument.
+        const INVALID_ARGUMENT    = 0b00000000000001000;
+        /// Deadline expired before operation could complete.
+        const DEADLINE_EXCEEDED   = 0b00000000000010000;
+        /// Some requested entity was not found.
+        const NOT_FOUND           = 0b00000000000100000;
+        /// Some entity that we attempted to create already exists.
+        const ALREADY_EXISTS      = 0b00000000001000000;
+        /// The caller does not have permission to execute the specified operation.
+        const PERMISSION_DENIED   = 0b00000000010000000;
+        /// Some resource has been exhausted.
+        const RESOURCE_EXHAUSTED  = 0b00000000100000000;
+        /// The system is not in a state required for the operation's execution.
+        const FAILED_PRECONDITION = 0b00000001000000000;
+        /// The operation was aborted.
+        const ABORTED             = 0b00000010000000000;
+        /// Operation was attempted past the valid range.
+        const OUT_OF_RANGE        = 0b00000100000000000;
+        /// Operation is not implemented or not supported.
+        const UNIMPLEMENTED       = 0b00001000000000000;
+        /// Internal error.
+        const INTERNAL            = 0b00010000000000000;
+        /// The service is currently unavailable.
+        const UNAVAILABLE         = 0b00100000000000000;
+        /// Unrecoverable data loss or corruption.
+        const DATA_LOSS           = 0b01000000000000000;
+        /// The request does not have valid authentication credentials
+        const UNAUTHENTICATED     = 0b10000000000000000;
+    }
+}
+
+impl GrpcCodeBitmask {
+    fn try_from_u32(code: u32) -> Option<Self> {
+        match code {
+            0 => Some(Self::OK),
+            1 => Some(Self::CANCELLED),
+            2 => Some(Self::UNKNOWN),
+            3 => Some(Self::INVALID_ARGUMENT),
+            4 => Some(Self::DEADLINE_EXCEEDED),
+            5 => Some(Self::NOT_FOUND),
+            6 => Some(Self::ALREADY_EXISTS),
+            7 => Some(Self::PERMISSION_DENIED),
+            8 => Some(Self::RESOURCE_EXHAUSTED),
+            9 => Some(Self::FAILED_PRECONDITION),
+            10 => Some(Self::ABORTED),
+            11 => Some(Self::OUT_OF_RANGE),
+            12 => Some(Self::UNIMPLEMENTED),
+            13 => Some(Self::INTERNAL),
+            14 => Some(Self::UNAVAILABLE),
+            15 => Some(Self::DATA_LOSS),
+            16 => Some(Self::UNAUTHENTICATED),
+            _ => None,
+        }
+    }
+}
+
+/// Response classifier for gRPC responses.
+///
+/// gRPC doesn't use normal HTTP statuses for indicating success or failure but instead a special
+/// header that might appear in a trailer.
+///
+/// Responses are considered successful if
+///
+/// - `grpc-status` header value matches [`GrpcErrorsAsFailures::success_codes`] (only `Ok` by
+/// default).
+/// - `grpc-status` header is missing.
+/// - `grpc-status` header value isn't a valid `String`.
+/// - `grpc-status` header value can't parsed into an `i32`.
+///
+/// All others are considered failures.
+#[derive(Debug, Clone)]
+pub struct GrpcErrorsAsFailures {
+    success_codes: GrpcCodeBitmask,
+}
+
+impl Default for GrpcErrorsAsFailures {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GrpcErrorsAsFailures {
+    /// Create a new [`GrpcErrorsAsFailures`].
+    pub fn new() -> Self {
+        Self {
+            success_codes: GrpcCodeBitmask::OK,
+        }
+    }
+
+    /// Change which gRPC codes are considered success.
+    ///
+    /// Defaults to only considering `Ok` as success.
+    ///
+    /// Calling this method multiple times overrides previous calls.
+    ///
+    /// Use `|` to combine multiple codes, ie `GrpcCodeBitmask::INVALID_ARGUMENT | GrpcCodeBitmask::NOT_FOUND`.
+    ///
+    /// `Ok` will always be considered a success.
+    ///
+    /// # Example
+    ///
+    /// Servers might not want to consider `Invalid Argument` or `Not Found` as failures since
+    /// thats likely the clients fault:
+    ///
+    /// ```rust
+    /// use tower_http::classify::{GrpcErrorsAsFailures, GrpcCodeBitmask};
+    ///
+    /// let classifier = GrpcErrorsAsFailures::new().success_codes(
+    ///     GrpcCodeBitmask::INVALID_ARGUMENT | GrpcCodeBitmask::NOT_FOUND,
+    /// );
+    /// ```
+    pub fn success_codes(mut self, codes: GrpcCodeBitmask) -> Self {
+        self.success_codes = GrpcCodeBitmask::OK | codes;
+        self
+    }
+
+    /// Returns a [`MakeClassifier`](super::MakeClassifier) that produces `GrpcErrorsAsFailures`.
+    ///
+    /// This is a convenience function that simply calls `SharedClassifier::new`.
+    pub fn make_classifier() -> SharedClassifier<Self> {
+        SharedClassifier::new(Self::new())
+    }
+}
+
+impl ClassifyResponse for GrpcErrorsAsFailures {
+    type FailureClass = GrpcFailureClass;
+    type ClassifyEos = GrpcEosErrorsAsFailures;
+
+    fn classify_response<B>(
+        self,
+        res: &Response<B>,
+    ) -> ClassifiedResponse<Self::FailureClass, Self::ClassifyEos> {
+        match classify_grpc_metadata(res.headers(), self.success_codes) {
+            ParsedGrpcStatus::Success
+            | ParsedGrpcStatus::HeaderNotString
+            | ParsedGrpcStatus::HeaderNotInt => ClassifiedResponse::Ready(Ok(())),
+            ParsedGrpcStatus::NonSuccess(status) => {
+                ClassifiedResponse::Ready(Err(GrpcFailureClass::Code(status)))
+            }
+            ParsedGrpcStatus::GrpcStatusHeaderMissing => {
+                ClassifiedResponse::RequiresEos(GrpcEosErrorsAsFailures {
+                    success_codes: self.success_codes,
+                })
+            }
+        }
+    }
+
+    fn classify_error<E>(self, error: &E) -> Self::FailureClass
+    where
+        E: fmt::Display + 'static,
+    {
+        GrpcFailureClass::Error(error.to_string())
+    }
+}
+
+/// The [`ClassifyEos`] for [`GrpcErrorsAsFailures`].
+#[derive(Debug, Clone)]
+pub struct GrpcEosErrorsAsFailures {
+    success_codes: GrpcCodeBitmask,
+}
+
+impl ClassifyEos for GrpcEosErrorsAsFailures {
+    type FailureClass = GrpcFailureClass;
+
+    fn classify_eos(self, trailers: Option<&HeaderMap>) -> Result<(), Self::FailureClass> {
+        if let Some(trailers) = trailers {
+            match classify_grpc_metadata(trailers, self.success_codes) {
+                ParsedGrpcStatus::Success
+                | ParsedGrpcStatus::GrpcStatusHeaderMissing
+                | ParsedGrpcStatus::HeaderNotString
+                | ParsedGrpcStatus::HeaderNotInt => Ok(()),
+                ParsedGrpcStatus::NonSuccess(status) => Err(GrpcFailureClass::Code(status)),
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    fn classify_error<E>(self, error: &E) -> Self::FailureClass
+    where
+        E: fmt::Display + 'static,
+    {
+        GrpcFailureClass::Error(error.to_string())
+    }
+}
+
+/// The failure class for [`GrpcErrorsAsFailures`].
+#[derive(Debug)]
+pub enum GrpcFailureClass {
+    /// A gRPC response was classified as a failure with the corresponding status.
+    Code(std::num::NonZeroI32),
+    /// A gRPC response was classified as an error with the corresponding error description.
+    Error(String),
+}
+
+impl fmt::Display for GrpcFailureClass {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Code(code) => write!(f, "Code: {}", code),
+            Self::Error(error) => write!(f, "Error: {}", error),
+        }
+    }
+}
+
+#[allow(clippy::if_let_some_result)]
+pub(crate) fn classify_grpc_metadata(
+    headers: &HeaderMap,
+    success_codes: GrpcCodeBitmask,
+) -> ParsedGrpcStatus {
+    macro_rules! or_else {
+        ($expr:expr, $other:ident) => {
+            if let Some(value) = $expr {
+                value
+            } else {
+                return ParsedGrpcStatus::$other;
+            }
+        };
+    }
+
+    let status = or_else!(headers.get("grpc-status"), GrpcStatusHeaderMissing);
+    let status = or_else!(status.to_str().ok(), HeaderNotString);
+    let status = or_else!(status.parse::<i32>().ok(), HeaderNotInt);
+
+    if GrpcCodeBitmask::try_from_u32(status as _)
+        .filter(|code| success_codes.contains(*code))
+        .is_some()
+    {
+        ParsedGrpcStatus::Success
+    } else {
+        ParsedGrpcStatus::NonSuccess(NonZeroI32::new(status).unwrap())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ParsedGrpcStatus {
+    Success,
+    NonSuccess(NonZeroI32),
+    GrpcStatusHeaderMissing,
+    // these two are treated as `Success` but kept separate for clarity
+    HeaderNotString,
+    HeaderNotInt,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! classify_grpc_metadata_test {
+        (
+            name: $name:ident,
+            status: $status:expr,
+            success_flags: $success_flags:expr,
+            expected: $expected:expr,
+        ) => {
+            #[test]
+            fn $name() {
+                let mut headers = HeaderMap::new();
+                headers.insert("grpc-status", $status.parse().unwrap());
+                let status = classify_grpc_metadata(&headers, $success_flags);
+                assert_eq!(status, $expected);
+            }
+        };
+    }
+
+    classify_grpc_metadata_test! {
+        name: basic_ok,
+        status: "0",
+        success_flags: GrpcCodeBitmask::OK,
+        expected: ParsedGrpcStatus::Success,
+    }
+
+    classify_grpc_metadata_test! {
+        name: basic_error,
+        status: "1",
+        success_flags: GrpcCodeBitmask::OK,
+        expected: ParsedGrpcStatus::NonSuccess(NonZeroI32::new(1).unwrap()),
+    }
+
+    classify_grpc_metadata_test! {
+        name: two_success_codes_first_matches,
+        status: "0",
+        success_flags: GrpcCodeBitmask::OK | GrpcCodeBitmask::INVALID_ARGUMENT,
+        expected: ParsedGrpcStatus::Success,
+    }
+
+    classify_grpc_metadata_test! {
+        name: two_success_codes_second_matches,
+        status: "3",
+        success_flags: GrpcCodeBitmask::OK | GrpcCodeBitmask::INVALID_ARGUMENT,
+        expected: ParsedGrpcStatus::Success,
+    }
+
+    classify_grpc_metadata_test! {
+        name: two_success_codes_none_matches,
+        status: "16",
+        success_flags: GrpcCodeBitmask::OK | GrpcCodeBitmask::INVALID_ARGUMENT,
+        expected: ParsedGrpcStatus::NonSuccess(NonZeroI32::new(16).unwrap()),
+    }
+}

--- a/tower-http/src/classify/mod.rs
+++ b/tower-http/src/classify/mod.rs
@@ -3,7 +3,7 @@
 use http::{HeaderMap, Request, Response, StatusCode};
 use std::{convert::Infallible, fmt, marker::PhantomData};
 
-mod grpc_errors_as_failures;
+pub(crate) mod grpc_errors_as_failures;
 mod map_failure_class;
 mod status_in_range_is_error;
 
@@ -14,8 +14,6 @@ pub use self::{
     map_failure_class::MapFailureClass,
     status_in_range_is_error::{StatusInRangeAsFailures, StatusInRangeFailureClass},
 };
-
-pub(crate) use self::grpc_errors_as_failures::{classify_grpc_metadata, ParsedGrpcStatus};
 
 /// Trait for producing response classifiers from a request.
 ///

--- a/tower-http/src/classify/mod.rs
+++ b/tower-http/src/classify/mod.rs
@@ -9,7 +9,7 @@ mod status_in_range_is_error;
 
 pub use self::{
     grpc_errors_as_failures::{
-        GrpcCodeBitmask, GrpcEosErrorsAsFailures, GrpcErrorsAsFailures, GrpcFailureClass,
+        GrpcCode, GrpcEosErrorsAsFailures, GrpcErrorsAsFailures, GrpcFailureClass,
     },
     map_failure_class::MapFailureClass,
     status_in_range_is_error::{StatusInRangeAsFailures, StatusInRangeFailureClass},

--- a/tower-http/src/compression/layer.rs
+++ b/tower-http/src/compression/layer.rs
@@ -86,7 +86,7 @@ impl CompressionLayer {
 
     /// Replace the current compression predicate.
     ///
-    /// See [`Compression::predicate`] for more details.
+    /// See [`Compression::compress_when`] for more details.
     pub fn compress_when<C>(self, predicate: C) -> CompressionLayer<C>
     where
         C: Predicate,

--- a/tower-http/src/trace/on_eos.rs
+++ b/tower-http/src/trace/on_eos.rs
@@ -168,7 +168,7 @@ impl OnEos for DefaultOnEos {
         let status = trailers.and_then(|trailers| {
             match crate::classify::grpc_errors_as_failures::classify_grpc_metadata(
                 trailers,
-                crate::classify::GrpcCodeBitmask::OK,
+                crate::classify::GrpcCode::Ok.into_bitmask(),
             ) {
                 ParsedGrpcStatus::Success
                 | ParsedGrpcStatus::HeaderNotString

--- a/tower-http/src/trace/on_eos.rs
+++ b/tower-http/src/trace/on_eos.rs
@@ -1,5 +1,5 @@
 use super::DEFAULT_MESSAGE_LEVEL;
-use crate::{classify::ParsedGrpcStatus, LatencyUnit};
+use crate::{classify::grpc_errors_as_failures::ParsedGrpcStatus, LatencyUnit};
 use http::header::HeaderMap;
 use std::time::Duration;
 use tracing::{Level, Span};
@@ -166,7 +166,7 @@ macro_rules! log_pattern_match {
 impl OnEos for DefaultOnEos {
     fn on_eos(self, trailers: Option<&HeaderMap>, stream_duration: Duration, _span: &Span) {
         let status = trailers.and_then(|trailers| {
-            match crate::classify::classify_grpc_metadata(
+            match crate::classify::grpc_errors_as_failures::classify_grpc_metadata(
                 trailers,
                 crate::classify::GrpcCodeBitmask::OK,
             ) {

--- a/tower-http/src/trace/on_response.rs
+++ b/tower-http/src/trace/on_response.rs
@@ -262,7 +262,7 @@ impl<B> OnResponse<B> for DefaultOnResponse {
 }
 
 fn status<B>(res: &Response<B>) -> Option<i32> {
-    use crate::classify::ParsedGrpcStatus;
+    use crate::classify::grpc_errors_as_failures::ParsedGrpcStatus;
 
     let is_grpc = res
         .headers()
@@ -270,7 +270,7 @@ fn status<B>(res: &Response<B>) -> Option<i32> {
         .map_or(false, |value| value == "application/grpc");
 
     if is_grpc {
-        match crate::classify::classify_grpc_metadata(
+        match crate::classify::grpc_errors_as_failures::classify_grpc_metadata(
             res.headers(),
             crate::classify::GrpcCodeBitmask::OK,
         ) {

--- a/tower-http/src/trace/on_response.rs
+++ b/tower-http/src/trace/on_response.rs
@@ -270,7 +270,10 @@ fn status<B>(res: &Response<B>) -> Option<i32> {
         .map_or(false, |value| value == "application/grpc");
 
     if is_grpc {
-        match crate::classify::classify_grpc_metadata(res.headers()) {
+        match crate::classify::classify_grpc_metadata(
+            res.headers(),
+            crate::classify::GrpcCodeBitmask::OK,
+        ) {
             ParsedGrpcStatus::Success
             | ParsedGrpcStatus::HeaderNotString
             | ParsedGrpcStatus::HeaderNotInt => Some(0),

--- a/tower-http/src/trace/on_response.rs
+++ b/tower-http/src/trace/on_response.rs
@@ -272,7 +272,7 @@ fn status<B>(res: &Response<B>) -> Option<i32> {
     if is_grpc {
         match crate::classify::grpc_errors_as_failures::classify_grpc_metadata(
             res.headers(),
-            crate::classify::GrpcCodeBitmask::OK,
+            crate::classify::GrpcCode::Ok.into_bitmask(),
         ) {
             ParsedGrpcStatus::Success
             | ParsedGrpcStatus::HeaderNotString


### PR DESCRIPTION
Previously `GrpcErrorsAsFailures` would only consider `Ok` as a success. However for servers it might be useful to also consider `Not Found` or `Invalid Arguments` as success (or at least not consider them failures) since they're likely caused by the client.

This PR adds `GrcpErrorsAsFailures::success_codes` which takes a bitmask of the codes that are considered successes. 

Example usage:

```rust
// Response classifier that doesn't consider `Ok`, `Invalid Argument`, or `Not Found` as
// failures
let classifier = GrpcErrorsAsFailures::new()
    .success_codes(GrpcCodeBitmask::INVALID_ARGUMENT | GrpcCodeBitmask::NOT_FOUND);

let service = ServiceBuilder::new()
    .layer(TraceLayer::new(SharedClassifier::new(classifier)))
    .service(service);
```

I went with the name `GrpcCodeBitmask` because I think it communicates quite somewhat clearly what it does. At least to people who know what a bitmask is. At first I considered just calling it `GrpcCode` but that might be confusing since its used to match multiple codes and doesn't just represent a single code.

Maybe the name `GrpcErrorsAsFailures` isn't very accurate anymore 🤔 Maybe just `GrpcClassifier` would be better. Although its more broad.

It does add a new public dependency on [`bitflags`](https://crates.io/crates/bitflags) but I'm okay with that. The crate is maintained by people from the Rust team, doesn't have dependencies, and has been 1.0 for over 4 years. axum also has a [public dependency on it](https://docs.rs/axum/0.3.4/axum/routing/struct.MethodFilter.html).

Fixes https://github.com/tower-rs/tower-http/issues/126