### PR TITLE
Simplify `AuthorizeRequest` and `AsyncAuthorizeRequest` traits

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   be used instead ([#170]) (BREAKING)
 - **fs**: Changed response body type of `ServeDir` and `ServeFile` to
   `ServeFileSystemResponseBody` and `ServeFileSystemResponseFuture` ([#187]) (BREAKING)
+- **auth**: Change `AuthorizeRequest` and `AsyncAuthorizeRequest` traits to be simpler ([#???]) (BREAKING)
 
 ## Removed
 

--- a/tower-http/src/auth/async_require_authorization.rs
+++ b/tower-http/src/auth/async_require_authorization.rs
@@ -73,7 +73,7 @@
 //! # }
 //! ```
 //!
-//! You can also authorize requests with an async closure:
+//! Or using a closure:
 //!
 //! ```
 //! use tower_http::auth::{AsyncRequireAuthorizationLayer, AsyncAuthorizeRequest};

--- a/tower-http/src/auth/require_authorization.rs
+++ b/tower-http/src/auth/require_authorization.rs
@@ -263,7 +263,6 @@ where
 impl<ReqBody, ResBody, S, T> Service<Request<ReqBody>> for RequireAuthorization<S, T>
 where
     S: Service<Request<ReqBody>, Response = Response<ResBody>>,
-    ResBody: Default,
     T: AuthorizeRequest<ResponseBody = ResBody>,
 {
     type Response = Response<ResBody>;

--- a/tower-http/src/auth/require_authorization.rs
+++ b/tower-http/src/auth/require_authorization.rs
@@ -260,10 +260,10 @@ where
     }
 }
 
-impl<ReqBody, ResBody, S, T> Service<Request<ReqBody>> for RequireAuthorization<S, T>
+impl<ReqBody, ResBody, S, Auth> Service<Request<ReqBody>> for RequireAuthorization<S, Auth>
 where
+    Auth: AuthorizeRequest<ResponseBody = ResBody>,
     S: Service<Request<ReqBody>, Response = Response<ResBody>>,
-    T: AuthorizeRequest<ResponseBody = ResBody>,
 {
     type Response = Response<ResBody>;
     type Error = S::Error;


### PR DESCRIPTION
Fixes #190

This changes the `AuthorizeRequest` and `AsyncAuthorizeRequest` traits to be quite a bit simpler I think.

## Sync

Before: https://github.com/tower-rs/tower-http/blob/master/tower-http/src/auth/async_require_authorization.rs#L234-L269

After

```rust
pub trait AuthorizeRequest<B> {
    type ResponseBody;

    fn authorize(
        &mut self,
        request: &mut Request<B>,
    ) -> Result<(), Response<Self::ResponseBody>>;
}
```

- `authorize` now returns `Result<(), Response>`
- `Ok(())` means the request was accepted and will be passed on the inner service
- `Err(response)` means the request couldn't be authorized and the response will be returned without calling the inner service.

## Async

Before: https://github.com/tower-rs/tower-http/blob/master/tower-http/src/auth/async_require_authorization.rs#L234-L269

After

```rust
pub trait AsyncAuthorizeRequest<B> {
    type RequestBody;
    type ResponseBody: Body;
    type Future: Future<Output = Result<Request<Self::RequestBody>, Response<Self::ResponseBody>>>;

    fn authorize(&mut self, request: Request<B>) -> Self::Future;
}
```

- `authorize` now receives an owned request. This allows you to move the request into the future, do some async stuff which yields some data (such as user id from a database), and then save that in a request extension.
- This wouldn't be possible if the future received a `&mut Request` because it would require GATs.
- Therefore the future must resolve to `Result<Request, Response>` so the request can be passed on the inner service.
- Authorization is allowed to change the request body type. Might be useful for someone to buffer and parse the request body to consider it for auth. Then one could change the request body from a generic `B` to [`http_body::Full`](https://docs.rs/http-body/0.4.4/http_body/struct.Full.html).
- This is essentially the same as [`AsyncPredicate`](https://docs.rs/tower/0.4.11/tower/filter/trait.AsyncPredicate.html) from tower.