### PR TITLE
Release 0.2.0

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Box<dyn std::error::Error + Send + Sync>`. This makes them usable if
   the body they're wrapping uses `Box<dyn std::error::Error + Send + Sync>` as
   its error type which they previously weren't ([#166]) (BREAKING)
-- **fs**: Changed response body type of `ServeDir` and `ServeFile` to
+- **fs**: Change response body type of `ServeDir` and `ServeFile` to
   `ServeFileSystemResponseBody` and `ServeFileSystemResponseFuture` ([#187]) (BREAKING)
 - **auth**: Change `AuthorizeRequest` and `AsyncAuthorizeRequest` traits to be simpler ([#192]) (BREAKING)
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   std::error::Error + Send + Sync>` ([#166]) (BREAKING)
 - **compression, decompression**: Remove the `compression` and `decompression` feature. They were unnecessary
   and `compression-full`/`decompression-full` can be used to get full
-  compression/decompression support. For more granular control `[compression|decompression]-gzip`,
+  compression/decompression support. For more granular control, `[compression|decompression]-gzip`,
   `[compression|decompression]-br` and `[compression|decompression]-deflate` may
   be used instead ([#170]) (BREAKING)
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -9,16 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
+- None.
+
+## Changed
+
+- None.
+
+## Removed
+
+- None.
+
+## Fixed
+
+- None.
+
+# 0.2.0 (December 1, 2021)
+
+## Added
+
 - **builder**: Add `ServiceBuilderExt` which adds methods to `tower::ServiceBuilder` for
-  adding middleware from tower-http.
+  adding middleware from tower-http ([#106])
 - **request_id**: Add `SetRequestId` and `PropagateRequestId` middleware ([#150])
 - **trace**: Add `DefaultMakeSpan::level` to make log level of tracing spans easily configurable ([#124])
-- **trace**: Add `LatencyUnit::Seconds` for formatting latencies as seconds.
+- **trace**: Add `LatencyUnit::Seconds` for formatting latencies as seconds ([#179])
 - **trace**: Support customizing which status codes are considered failures by `GrpcErrorsAsFailures` ([#189])
 - **compression**: Support specifying predicates to choose when responses should
   be compressed. This can be used to disable compression of small responses,
   responses with a certain `content-type`, or something user defined ([#172])
 - **fs**: Ability to serve precompressed files ([#156])
+- **fs**: Support `Range` requests ([#173])
+- **fs**: Properly support HEAD requests which return no body and have the `Content-Length` header set ([#169])
 
 ## Changed
 
@@ -33,24 +53,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Box<dyn std::error::Error + Send + Sync>`. This makes them usable if
   the body they're wrapping uses `Box<dyn std::error::Error + Send + Sync>` as
   its error type which they previously weren't ([#166]) (BREAKING)
-- **compression, decompression**: Remove the `compression` and `decompression` feature. They were unnecessary
-  and `compression-full`/`decompression-full` can be used to get full
-  compression/decompression support. For more granular control `[compression|decompression]-gzip`,
-  `[compression|decompression]-br` and `[compression|decompression]-deflate` may
-  be used instead ([#170]) (BREAKING)
 - **fs**: Changed response body type of `ServeDir` and `ServeFile` to
   `ServeFileSystemResponseBody` and `ServeFileSystemResponseFuture` ([#187]) (BREAKING)
-- **auth**: Change `AuthorizeRequest` and `AsyncAuthorizeRequest` traits to be simpler ([#???]) (BREAKING)
+- **auth**: Change `AuthorizeRequest` and `AsyncAuthorizeRequest` traits to be simpler ([#192]) (BREAKING)
 
 ## Removed
 
 - **compression, decompression**: Remove `BodyOrIoError`. Its been replaced with `Box<dyn
   std::error::Error + Send + Sync>` ([#166]) (BREAKING)
+- **compression, decompression**: Remove the `compression` and `decompression` feature. They were unnecessary
+  and `compression-full`/`decompression-full` can be used to get full
+  compression/decompression support. For more granular control `[compression|decompression]-gzip`,
+  `[compression|decompression]-br` and `[compression|decompression]-deflate` may
+  be used instead ([#170]) (BREAKING)
 
-## Fixed
-
-- **fs**: Properly support HEAD requests which return no body and have the `Content-Length` header set ([#169])
-
+[#106]: https://github.com/tower-rs/tower-http/pull/106
 [#124]: https://github.com/tower-rs/tower-http/pull/124
 [#148]: https://github.com/tower-rs/tower-http/pull/148
 [#150]: https://github.com/tower-rs/tower-http/pull/150
@@ -59,9 +76,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#169]: https://github.com/tower-rs/tower-http/pull/169
 [#170]: https://github.com/tower-rs/tower-http/pull/170
 [#172]: https://github.com/tower-rs/tower-http/pull/172
+[#173]: https://github.com/tower-rs/tower-http/pull/173
+[#179]: https://github.com/tower-rs/tower-http/pull/179
 [#182]: https://github.com/tower-rs/tower-http/pull/182
 [#187]: https://github.com/tower-rs/tower-http/pull/187
 [#189]: https://github.com/tower-rs/tower-http/pull/189
+[#192]: https://github.com/tower-rs/tower-http/pull/192
 
 # 0.1.2 (November 13, 2021)
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tower-http"
 description = "Tower middleware and utilities for HTTP clients and servers"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
So much good stuff in this release 🥳 

---

## Added

- **builder**: Add `ServiceBuilderExt` which adds methods to `tower::ServiceBuilder` for
  adding middleware from tower-http ([#106])
- **request_id**: Add `SetRequestId` and `PropagateRequestId` middleware ([#150])
- **trace**: Add `DefaultMakeSpan::level` to make log level of tracing spans easily configurable ([#124])
- **trace**: Add `LatencyUnit::Seconds` for formatting latencies as seconds ([#179])
- **trace**: Support customizing which status codes are considered failures by `GrpcErrorsAsFailures` ([#189])
- **compression**: Support specifying predicates to choose when responses should
  be compressed. This can be used to disable compression of small responses,
  responses with a certain `content-type`, or something user defined ([#172])
- **fs**: Ability to serve precompressed files ([#156])
- **fs**: Support `Range` requests ([#173])
- **fs**: Properly support HEAD requests which return no body and have the `Content-Length` header set ([#169])

## Changed

- `AddAuthorization`, `InFlightRequests`, `SetRequestHeader`,
  `SetResponseHeader`, `AddExtension`, `MapRequestBody` and `MapResponseBody`
   now requires underlying service to use `http::Request<ReqBody>` and
   `http::Response<ResBody>` as request and responses ([#182]) (BREAKING)
- **set_header**: Remove unnecessary generic parameter from `SetRequestHeaderLayer`
  and `SetResponseHeaderLayer`. This removes the need (and possibility) to specify a
  body type for these layers ([#148]) (BREAKING)
- **compression, decompression**: Change the response body error type to
  `Box<dyn std::error::Error + Send + Sync>`. This makes them usable if
  the body they're wrapping uses `Box<dyn std::error::Error + Send + Sync>` as
  its error type which they previously weren't ([#166]) (BREAKING)
- **fs**: Changed response body type of `ServeDir` and `ServeFile` to
  `ServeFileSystemResponseBody` and `ServeFileSystemResponseFuture` ([#187]) (BREAKING)
- **auth**: Change `AuthorizeRequest` and `AsyncAuthorizeRequest` traits to be simpler ([#192]) (BREAKING)

## Removed

- **compression, decompression**: Remove `BodyOrIoError`. Its been replaced with `Box<dyn
  std::error::Error + Send + Sync>` ([#166]) (BREAKING)
- **compression, decompression**: Remove the `compression` and `decompression` feature. They were unnecessary
  and `compression-full`/`decompression-full` can be used to get full
  compression/decompression support. For more granular control `[compression|decompression]-gzip`,
  `[compression|decompression]-br` and `[compression|decompression]-deflate` may
  be used instead ([#170]) (BREAKING)

[#106]: https://github.com/tower-rs/tower-http/pull/106
[#124]: https://github.com/tower-rs/tower-http/pull/124
[#148]: https://github.com/tower-rs/tower-http/pull/148
[#150]: https://github.com/tower-rs/tower-http/pull/150
[#156]: https://github.com/tower-rs/tower-http/pull/156
[#166]: https://github.com/tower-rs/tower-http/pull/166
[#169]: https://github.com/tower-rs/tower-http/pull/169
[#170]: https://github.com/tower-rs/tower-http/pull/170
[#172]: https://github.com/tower-rs/tower-http/pull/172
[#173]: https://github.com/tower-rs/tower-http/pull/173
[#179]: https://github.com/tower-rs/tower-http/pull/179
[#182]: https://github.com/tower-rs/tower-http/pull/182
[#187]: https://github.com/tower-rs/tower-http/pull/187
[#189]: https://github.com/tower-rs/tower-http/pull/189
[#192]: https://github.com/tower-rs/tower-http/pull/192