### PR TITLE
Update minimum dependency versions

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["io", "async", "futures", "service", "http"]
 rust-version = "1.51"
 
 [dependencies]
-bitflags = "1.0"
+bitflags = "1.3.1"
 bytes = "1"
 futures-core = "0.3"
-futures-util = { version = "0.3", default_features = false, features = [] }
-http = "0.2"
+futures-util = { version = "0.3.14", default_features = false, features = [] }
+http = "0.2.2"
 http-body = "0.4.1"
 pin-project-lite = "0.2.7"
 tower-layer = "0.3"
@@ -32,7 +32,7 @@ mime = { version = "0.3", optional = true, default_features = false }
 mime_guess = { version = "2", optional = true, default_features = false }
 percent-encoding = { version = "2.1.0", optional = true }
 tokio = { version = "1", optional = true, default_features = false }
-tokio-util = { version = "0.6", optional = true, default_features = false, features = ["io"] }
+tokio-util = { version = "0.6.8", optional = true, default_features = false, features = ["io"] }
 tower = { version = "0.4.1", optional = true }
 tracing = { version = "0.1", default_features = false, optional = true }
 


### PR DESCRIPTION
This PR updates the minimum dependency versions in `Cargo.toml` to prevent compilation failures.

## Motivation

Originally, after trying to update our project to tower-http 0.2.0, we got a compilation error from tower-http itself after updating.

I did some sleuthing and found that the version of `futures-util` in our lockfile was too old for tower-http. Doing `cargo update -p futures-util` was good enough to solve the immediate problem, but it seems like the kind of thing that should be upstreamed!

## Solution

I updated all dependencies listed in `Cargo.toml` to the minimum versions needed to still compile. I basically used the following to verify that I didn't miss any dependencies:

```
$ git clone 'https://github.com/kylewlacy/tower-http.git'
$ cd tower-http
$ git checkout origin/update-minimum-dependency-versions
$ cargo +nightly check -Z minimal-versions --all-features --lib
(Initial compilation will fail due to an upstream error in crc32)
$ cargo update -p crc32
$ cargo +nightly check -Z minimal-versions --all-features --lib
(This succeeds with the changes from this PR, but would fail on master)
```
