### PR TITLE
fix link from readme to license

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tower middleware and utilities for HTTP clients and servers.
 [![Build status](https://github.com/tower-rs/tower-http/workflows/CI/badge.svg)](https://github.com/tower-rs/tower-http/actions)
 [![Crates.io](https://img.shields.io/crates/v/tower-http)](https://crates.io/crates/tower-http)
 [![Documentation](https://docs.rs/tower-http/badge.svg)](https://docs.rs/tower-http)
-[![Crates.io](https://img.shields.io/crates/l/tower-http)](LICENSE)
+[![Crates.io](https://img.shields.io/crates/l/tower-http)](tower-http/LICENSE)
 
 More information about this crate can be found in the [crate documentation][docs].
 
@@ -56,7 +56,7 @@ HTTP project.
 
 ## License
 
-This project is licensed under the [MIT license](LICENSE).
+This project is licensed under the [MIT license](tower-http/LICENSE).
 
 ### Contribution
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

The LICENSE file for this project was lost in the great reset of 9ca9e7cc56a43.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

The README still says MIT license and links to the missing file, so I am taking the liberty of sending you an MR that reinstates that file.

It's exactly as it previously was, except that I've added 2022 to the copyright range.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
