### PR TITLE
Set acess-control-allow-origin to request origin when using Any (#194)

### DIFF
--- a/tower-http/src/cors.rs
+++ b/tower-http/src/cors.rs
@@ -769,7 +769,7 @@ where
         match self.project().inner.project() {
             KindProj::CorsCall {
                 future,
-                allow_origin,
+                allow_origin: _,
                 origin,
                 allow_credentials,
                 expose_headers,
@@ -779,7 +779,7 @@ where
 
                 headers.insert(
                     header::ACCESS_CONTROL_ALLOW_ORIGIN,
-                    response_origin(allow_origin.take().unwrap(), origin),
+                    origin.clone()
                 );
 
                 if let Some(allow_credentials) = allow_credentials {
@@ -805,14 +805,6 @@ where
             KindProj::NonCorsCall { future } => future.poll(cx),
             KindProj::Error { response } => Poll::Ready(Ok(response.take().unwrap())),
         }
-    }
-}
-
-fn response_origin(allow_origin: AnyOr<Origin>, origin: &HeaderValue) -> HeaderValue {
-    if let AnyOrInner::Any = allow_origin.0 {
-        WILDCARD.parse().unwrap()
-    } else {
-        origin.clone()
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

Cross-site requests with credentials are currently prevented by browsers when CorsLayer is set to allow any origin, because it replies with a literal '*' instead of the requests origin.

Example error:
> The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

This *fixes* #194, by replying with the request's Origin when the CorsLayer is set to allow Any origin.
It does that by removing existing special-casing of the Any origin.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

cc @jplatte, who was arguing against this solution
