### PR TITLE
Clean up some #[cfg]s in compression/body.rs

### DIFF
--- a/tower-http/src/compression/mod.rs
+++ b/tower-http/src/compression/mod.rs
@@ -69,6 +69,7 @@ pub mod predicate;
 mod body;
 mod future;
 mod layer;
+mod pin_project_cfg;
 mod service;
 
 #[doc(inline)]

--- a/tower-http/src/compression/pin_project_cfg.rs
+++ b/tower-http/src/compression/pin_project_cfg.rs
@@ -1,0 +1,144 @@
+// Full credit to @tesaguri who posted this gist under CC0 1.0 Universal licence
+// https://gist.github.com/tesaguri/2a1c0790a48bbda3dd7f71c26d02a793
+
+macro_rules! pin_project_cfg {
+    ($(#[$($attr:tt)*])* $vis:vis enum $($rest:tt)+) => {
+        pin_project_cfg! {
+            @outer [$(#[$($attr)*])* $vis enum] $($rest)+
+        }
+    };
+    // Accumulate type parameters and `where` clause.
+    (@outer [$($accum:tt)*] $tt:tt $($rest:tt)+) => {
+        pin_project_cfg! {
+            @outer [$($accum)* $tt] $($rest)+
+        }
+    };
+    (@outer [$($accum:tt)*] { $($body:tt)* }) => {
+        pin_project_cfg! {
+            @body #[cfg(all())] [$($accum)*] {} $($body)*
+        }
+    };
+    // Process a variant with `cfg`.
+    (
+        @body
+        #[cfg(all($($pred_accum:tt)*))]
+        $outer:tt
+        { $($accum:tt)* }
+
+        #[cfg($($pred:tt)*)]
+        $(#[$($attr:tt)*])* $variant:ident { $($body:tt)* },
+        $($rest:tt)*
+    ) => {
+        // Create two versions of the enum with `cfg($pred)` and `cfg(not($pred))`.
+        pin_project_cfg! {
+            @variant_body
+            { $($body)* }
+            {}
+            #[cfg(all($($pred_accum)* $($pred)*,))]
+            $outer
+            { $($accum)* $(#[$($attr)*])* $variant }
+            $($rest)*
+        }
+        pin_project_cfg! {
+            @body
+            #[cfg(all($($pred_accum)* not($($pred)*),))]
+            $outer
+            { $($accum)* }
+            $($rest)*
+        }
+    };
+    // Process a variant without `cfg`.
+    (
+        @body
+        #[cfg(all($($pred_accum:tt)*))]
+        $outer:tt
+        { $($accum:tt)* }
+
+        $(#[$($attr:tt)*])* $variant:ident { $($body:tt)* },
+        $($rest:tt)*
+    ) => {
+        pin_project_cfg! {
+            @variant_body
+            { $($body)* }
+            {}
+            #[cfg(all($($pred_accum)*))]
+            $outer
+            { $($accum)* $(#[$($attr)*])* $variant }
+            $($rest)*
+        }
+    };
+    // Process a variant field with `cfg`.
+    (
+        @variant_body
+        {
+            #[cfg($($pred:tt)*)]
+            $(#[$($attr:tt)*])* $field:ident: $ty:ty,
+            $($rest:tt)*
+        }
+        { $($accum:tt)* }
+        #[cfg(all($($pred_accum:tt)*))]
+        $($outer:tt)*
+    ) => {
+        pin_project_cfg! {
+            @variant_body
+            {$($rest)*}
+            { $($accum)* $(#[$($attr)*])* $field: $ty, }
+            #[cfg(all($($pred_accum)* $($pred)*,))]
+            $($outer)*
+        }
+        pin_project_cfg! {
+            @variant_body
+            { $($rest)* }
+            { $($accum)* }
+            #[cfg(all($($pred_accum)* not($($pred)*),))]
+            $($outer)*
+        }
+    };
+    // Process a variant field without `cfg`.
+    (
+        @variant_body
+        {
+            $(#[$($attr:tt)*])* $field:ident: $ty:ty,
+            $($rest:tt)*
+        }
+        { $($accum:tt)* }
+        $($outer:tt)*
+    ) => {
+        pin_project_cfg! {
+            @variant_body
+            {$($rest)*}
+            { $($accum)* $(#[$($attr)*])* $field: $ty, }
+            $($outer)*
+        }
+    };
+    (
+        @variant_body
+        {}
+        $body:tt
+        #[cfg(all($($pred_accum:tt)*))]
+        $outer:tt
+        { $($accum:tt)* }
+        $($rest:tt)*
+    ) => {
+        pin_project_cfg! {
+            @body
+            #[cfg(all($($pred_accum)*))]
+            $outer
+            { $($accum)* $body, }
+            $($rest)*
+        }
+    };
+    (
+        @body
+        #[$cfg:meta]
+        [$($outer:tt)*]
+        $body:tt
+    ) => {
+        #[$cfg]
+        pin_project_lite::pin_project! {
+            $($outer)* $body
+        }
+    };
+}
+
+pub(crate) use pin_project_cfg;

--- a/tower-http/src/services/fs/mod.rs
+++ b/tower-http/src/services/fs/mod.rs
@@ -35,21 +35,11 @@ pub use self::{
     serve_file::ServeFile,
 };
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 struct PrecompressedVariants {
     gzip: bool,
     deflate: bool,
     br: bool,
-}
-
-impl Default for PrecompressedVariants {
-    fn default() -> Self {
-        Self {
-            gzip: false,
-            deflate: false,
-            br: false,
-        }
-    }
 }
 
 impl SupportedEncodings for PrecompressedVariants {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation
Was originally looking into https://github.com/tower-rs/tower-http/issues/201 but kind of rabbit holed and felt a strong urge to clean up some of the `#[cfg]` we use in compression body.

## Solution
The `pin_project_lite` macro (looks like it's the same for the regular `#[pin_project]` macro) doesn't play well with `#[cfg]` attributes which led to some messy workarounds that I wanted to get rid of. I found this comment https://github.com/taiki-e/pin-project-lite/issues/3#issuecomment-774461161 by @tesaguri which provides a macro workaround which solves the problem and makes things a bit cleaner. It's licensed under CC0 1.0 which means it should be fine to use afaik.  It's still a bit messy but more contained to the macro itself at least.