### PR TITLE
Fix cargo deny on CI

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -38,6 +38,7 @@ multiple-versions = "deny"
 highlight = "all"
 skip-tree = [{ name = "tower", version = ">=0.3, <=0.4" }]
 skip = [
+    { name = "itoa", version = "=0.4.8" },
 ]
 
 [sources]


### PR DESCRIPTION
Waiting on a new hyper release to remove the duplicate itoa dependency.