### PR TITLE
predicate: Fix comment for images and SizeAbove

### DIFF
--- a/tower-http/src/compression/predicate.rs
+++ b/tower-http/src/compression/predicate.rs
@@ -89,8 +89,8 @@ where
 /// This will compress responses unless:
 ///
 /// - They're gRPC, which has its own protocol specific compression scheme.
-/// - Its not an image as determined by the `content-type` starting with `image/`.
-/// - The response is larger than 32 bytes.
+/// - It's an image as determined by the `content-type` starting with `image/`.
+/// - The response is less than 32 bytes.
 ///
 /// # Configuring the defaults
 ///


### PR DESCRIPTION
The original comment referred to when compression *would* happen, not when it would not.

## Motivation

A comment documented the behavior incorrectly.

## Solution

Fixed the comment.
