### PR TITLE
Release 0.2.2

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+- None.
+
+# 0.2.2 (February 8, 2022)
+
+## Fixed
+
+- Add `Vary` headers for CORS preflight responses ([#216])
+
+[#216]: https://github.com/tower-rs/tower-http/pull/216
+
 # 0.2.1 (January 21, 2022)
 
 ## Added

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tower-http"
 description = "Tower middleware and utilities for HTTP clients and servers"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
## Fixed

- Add `Vary` headers for CORS preflight responses ([#216])

[#216]: https://github.com/tower-rs/tower-http/pull/216