### PR TITLE
Release 0.2.3

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -21,9 +21,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+- None.
+
+# 0.2.3 (February 8, 2022)
+
+## Changed
+
+- Update to tokio-util 0.7 ([#221])
+
+## Fixed
+
 - The CORS layer / service methods `allow_headers`, `allow_methods`, `allow_origin`
   and `expose_headers` now do nothing if given an empty `Vec`, instead of sending
-  the respective header with an empty value
+  the respective header with an empty value ([#218])
+
+[#218]: https://github.com/tower-rs/tower-http/pull/218
+[#221]: https://github.com/tower-rs/tower-http/pull/221
 
 # 0.2.2 (February 8, 2022)
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tower-http"
 description = "Tower middleware and utilities for HTTP clients and servers"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
## Changed

- Update to tokio-util 0.7 ([#221])

## Fixed

- The CORS layer / service methods `allow_headers`, `allow_methods`, `allow_origin`
  and `expose_headers` now do nothing if given an empty `Vec`, instead of sending
  the respective header with an empty value ([#218])

[#218]: https://github.com/tower-rs/tower-http/pull/218
[#221]: https://github.com/tower-rs/tower-http/pull/221
