### PR TITLE
Bump iri-string to 0.5.0 and use shorter type names

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -27,7 +27,7 @@ tower-service = "0.3"
 async-compression = { version = "0.3", optional = true, features = ["tokio"] }
 base64 = { version = "0.13", optional = true }
 http-range-header = "0.3.0"
-iri-string = { version = "0.4", optional = true }
+iri-string = { version = "0.5.0", optional = true }
 mime = { version = "0.3", optional = true, default_features = false }
 mime_guess = { version = "2", optional = true, default_features = false }
 percent-encoding = { version = "2.1.0", optional = true }

--- a/tower-http/src/follow_redirect/mod.rs
+++ b/tower-http/src/follow_redirect/mod.rs
@@ -99,10 +99,7 @@ use http::{
     header::LOCATION, HeaderMap, HeaderValue, Method, Request, Response, StatusCode, Uri, Version,
 };
 use http_body::Body;
-use iri_string::{
-    spec::UriSpec,
-    types::{RiAbsoluteString, RiReferenceStr},
-};
+use iri_string::types::{UriAbsoluteString, UriReferenceStr};
 use pin_project_lite::pin_project;
 use std::{
     convert::TryFrom,
@@ -380,9 +377,9 @@ where
 
 /// Try to resolve a URI reference `relative` against a base URI `base`.
 fn resolve_uri(relative: &str, base: &Uri) -> Option<Uri> {
-    let relative = RiReferenceStr::<UriSpec>::new(relative).ok()?;
-    let base = RiAbsoluteString::try_from(base.to_string()).ok()?;
-    let uri = relative.resolve_against(&base);
+    let relative = UriReferenceStr::new(relative).ok()?;
+    let base = UriAbsoluteString::try_from(base.to_string()).ok()?;
+    let uri = relative.resolve_against(&base).ok()?;
     Uri::try_from(uri.as_str()).ok()
 }
 


### PR DESCRIPTION
This PR bumps the internal dependency to `iri-string` crate to the latest stable version.

(Disclaimer: I am the author of `iri-string` crate.)

## Motivation

* The new version performs a little better.
    + URI resolution is made roughly 3x faster (by quite simple and naive benchmark).
* The new version has no mandatory dependencies.
    + Dependencies to `nom` and its indirect deps are removed since v0.5.0.
    + `axum` still depends on `nom`, but `tokio-http` no longer does.
* Updating the dependency is happy :-).
    + The crate and its items are completely internal, so updating won't cause compatibility issues.

## Solution

Just bump the `iri-string` dependency.