### PR TITLE
fix content-length calculation on range requests

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -21,7 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
-- None.
+- Fix content-length calculation on range requests ([#228])
+
+[#228]: https://github.com/tower-rs/tower-http/pull/228
 
 # 0.2.4 (March 5, 2022)
 


### PR DESCRIPTION
hello,

content-length response header on range requests should represent the length of the returned range, not the length of the whole file.

more explanations here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests

Best regards.
