### PR TITLE
feat(fs): make AsyncReadBody::with_capacity() pub

### DIFF
--- a/tower-http/src/services/fs/mod.rs
+++ b/tower-http/src/services/fs/mod.rs
@@ -150,7 +150,7 @@ where
 {
     /// Create a new [`AsyncReadBody`] wrapping the given reader,
     /// with a specific read buffer capacity
-    fn with_capacity(read: T, capacity: usize) -> Self {
+    pub fn with_capacity(read: T, capacity: usize) -> Self {
         Self {
             reader: ReaderStream::with_capacity(read, capacity),
         }


### PR DESCRIPTION
The `AsyncReadBody` type is a generally useful type. It is already public, but it has no public constructor. This commit makes the main constructor public so that the type can be used by other projects. If the type is ever upstreamed to `http-body`, it can be reexported here to maintain compatibility.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
