### PR TITLE
Rewrite the CORS middleware

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -9,11 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- None.
+- **cors**: Added `CorsLayer::very_permissive` which is like
+  `CorsLayer::permissive` except it (truly) allows credentials. This is made
+  possible by mirroring the request's origin as well as method and headers
+  back as CORS-whitelisted ones
+* **cors**: Allow customizing the value(s) for the `Vary` header
 
 ## Changed
 
-- None.
+- **cors**: Removed `allow-credentials: true` from `CorsLayer::permissive`.
+  It never actually took effect in compliant browsers because it is mutually
+  exclusive with the `*` wildcard (`Any`) on origins, methods and headers
+- **cors**: Rewrote the CORS middleware. Almost all existing usage patterns
+  will continue to work. (BREAKING)
+- **cors**: The CORS middleware will now panic if you try to use `Any` in
+  combination with `.allow_credentials(true)`. This configuration worked
+  before, but resulted in browsers ignoring the `allow-credentials` header,
+  which defeats the purpose of setting it and can be very annoying to debug.
 
 ## Removed
 

--- a/tower-http/src/cors.rs
+++ b/tower-http/src/cors.rs
@@ -46,6 +46,8 @@
 //!
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
 
+#![allow(clippy::enum_variant_names)]
+
 use bytes::{BufMut, BytesMut};
 use futures_core::ready;
 use http::{
@@ -747,7 +749,6 @@ pin_project! {
             headers: HeaderMap,
         },
         InvalidCorsCall,
-        InvalidOrigin,
     }
 }
 
@@ -778,14 +779,6 @@ where
             KindProj::InvalidCorsCall => {
                 let response = Response::builder()
                     .status(StatusCode::OK)
-                    .body(B::default())
-                    .unwrap();
-
-                Poll::Ready(Ok(response))
-            }
-            KindProj::InvalidOrigin => {
-                let response = Response::builder()
-                    .status(StatusCode::UNAUTHORIZED)
                     .body(B::default())
                     .unwrap();
 

--- a/tower-http/src/cors.rs
+++ b/tower-http/src/cors.rs
@@ -538,6 +538,8 @@ impl<S> Cors<S> {
             headers.insert(header::ACCESS_CONTROL_EXPOSE_HEADERS, expose_headers);
         }
 
+        apply_vary_headers(&mut headers);
+
         headers
     }
 
@@ -688,8 +690,6 @@ where
             response_origin(self.layer.allow_origin.as_ref().unwrap(), &origin),
         );
 
-        apply_vary_headers(&mut headers);
-
         ResponseFuture {
             inner: Kind::CorsCall {
                 future: self.inner.call(req),
@@ -742,8 +742,6 @@ where
             }
             KindProj::NonCorsCall { future } => future.poll(cx),
             KindProj::PreflightCall { headers } => {
-                apply_vary_headers(headers);
-
                 let mut response = Response::new(B::default());
                 mem::swap(response.headers_mut(), headers);
 

--- a/tower-http/src/cors.rs
+++ b/tower-http/src/cors.rs
@@ -538,7 +538,9 @@ impl<S> Cors<S> {
             headers.insert(header::ACCESS_CONTROL_EXPOSE_HEADERS, expose_headers);
         }
 
-        apply_vary_headers(&mut headers);
+        headers.append(header::VARY, header::ORIGIN.into());
+        headers.append(header::VARY, header::ACCESS_CONTROL_REQUEST_METHOD.into());
+        headers.append(header::VARY, header::ACCESS_CONTROL_REQUEST_HEADERS.into());
 
         headers
     }
@@ -748,18 +750,6 @@ where
                 Poll::Ready(Ok(response))
             }
         }
-    }
-}
-
-fn apply_vary_headers(headers: &mut http::HeaderMap) {
-    const VARY_HEADERS: [HeaderName; 3] = [
-        header::ORIGIN,
-        header::ACCESS_CONTROL_REQUEST_METHOD,
-        header::ACCESS_CONTROL_REQUEST_HEADERS,
-    ];
-
-    for h in &VARY_HEADERS {
-        headers.append(header::VARY, HeaderValue::from_static(h.as_str()));
     }
 }
 

--- a/tower-http/src/cors/allow_credentials.rs
+++ b/tower-http/src/cors/allow_credentials.rs
@@ -1,0 +1,86 @@
+use std::{fmt, sync::Arc};
+
+use http::{request::Parts as RequestParts, HeaderValue};
+
+/// Holds configuration for how to set the [`Access-Control-Allow-Credentials`][mdn] header.
+///
+/// See [`CorsLayer::allow_credentials`] for more details.
+///
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials
+/// [`CorsLayer::allow_credentials`]: super::CorsLayer::allow_credentials
+#[derive(Clone, Default)]
+pub struct AllowCredentials(AllowCredentialsInner);
+
+impl AllowCredentials {
+    /// Allow credentials for all requests
+    ///
+    /// See [`CorsLayer::allow_credentials`] for more details.
+    ///
+    /// [`CorsLayer::allow_credentials`]: super::CorsLayer::allow_credentials
+    pub fn yes() -> Self {
+        Self(AllowCredentialsInner::Yes)
+    }
+
+    /// Allow credentials for some requests, based on a given predicate
+    ///
+    /// See [`CorsLayer::allow_credentials`] for more details.
+    ///
+    /// [`CorsLayer::allow_credentials`]: super::CorsLayer::allow_credentials
+    pub fn predicate<F>(f: F) -> Self
+    where
+        F: Fn(&HeaderValue, &RequestParts) -> bool + Send + Sync + 'static,
+    {
+        Self(AllowCredentialsInner::Predicate(Arc::new(f)))
+    }
+
+    pub(super) fn to_header_val(
+        &self,
+        origin: &HeaderValue,
+        parts: &RequestParts,
+    ) -> Option<HeaderValue> {
+        #[allow(clippy::declare_interior_mutable_const)]
+        const TRUE: HeaderValue = HeaderValue::from_static("true");
+
+        let allow_creds = match &self.0 {
+            AllowCredentialsInner::Yes => true,
+            AllowCredentialsInner::No => false,
+            AllowCredentialsInner::Predicate(c) => c(origin, parts),
+        };
+
+        allow_creds.then(|| TRUE)
+    }
+}
+
+impl From<bool> for AllowCredentials {
+    fn from(v: bool) -> Self {
+        match v {
+            true => Self(AllowCredentialsInner::Yes),
+            false => Self(AllowCredentialsInner::No),
+        }
+    }
+}
+
+impl fmt::Debug for AllowCredentials {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            AllowCredentialsInner::Yes => f.debug_tuple("Yes").finish(),
+            AllowCredentialsInner::No => f.debug_tuple("No").finish(),
+            AllowCredentialsInner::Predicate(_) => f.debug_tuple("Predicate").finish(),
+        }
+    }
+}
+
+#[derive(Clone)]
+enum AllowCredentialsInner {
+    Yes,
+    No,
+    Predicate(
+        Arc<dyn for<'a> Fn(&'a HeaderValue, &'a RequestParts) -> bool + Send + Sync + 'static>,
+    ),
+}
+
+impl Default for AllowCredentialsInner {
+    fn default() -> Self {
+        Self::No
+    }
+}

--- a/tower-http/src/cors/allow_credentials.rs
+++ b/tower-http/src/cors/allow_credentials.rs
@@ -1,6 +1,9 @@
 use std::{fmt, sync::Arc};
 
-use http::{request::Parts as RequestParts, HeaderValue};
+use http::{
+    header::{self, HeaderName, HeaderValue},
+    request::Parts as RequestParts,
+};
 
 /// Holds configuration for how to set the [`Access-Control-Allow-Credentials`][mdn] header.
 ///
@@ -38,11 +41,11 @@ impl AllowCredentials {
         matches!(&self.0, AllowCredentialsInner::Yes)
     }
 
-    pub(super) fn to_header_val(
+    pub(super) fn to_header(
         &self,
         origin: &HeaderValue,
         parts: &RequestParts,
-    ) -> Option<HeaderValue> {
+    ) -> Option<(HeaderName, HeaderValue)> {
         #[allow(clippy::declare_interior_mutable_const)]
         const TRUE: HeaderValue = HeaderValue::from_static("true");
 
@@ -52,7 +55,7 @@ impl AllowCredentials {
             AllowCredentialsInner::Predicate(c) => c(origin, parts),
         };
 
-        allow_creds.then(|| TRUE)
+        allow_creds.then(|| (header::ACCESS_CONTROL_ALLOW_CREDENTIALS, TRUE))
     }
 }
 

--- a/tower-http/src/cors/allow_credentials.rs
+++ b/tower-http/src/cors/allow_credentials.rs
@@ -34,6 +34,10 @@ impl AllowCredentials {
         Self(AllowCredentialsInner::Predicate(Arc::new(f)))
     }
 
+    pub(super) fn is_true(&self) -> bool {
+        matches!(&self.0, AllowCredentialsInner::Yes)
+    }
+
     pub(super) fn to_header_val(
         &self,
         origin: &HeaderValue,

--- a/tower-http/src/cors/allow_credentials.rs
+++ b/tower-http/src/cors/allow_credentials.rs
@@ -43,7 +43,7 @@ impl AllowCredentials {
 
     pub(super) fn to_header(
         &self,
-        origin: &HeaderValue,
+        origin: Option<&HeaderValue>,
         parts: &RequestParts,
     ) -> Option<(HeaderName, HeaderValue)> {
         #[allow(clippy::declare_interior_mutable_const)]
@@ -52,7 +52,7 @@ impl AllowCredentials {
         let allow_creds = match &self.0 {
             AllowCredentialsInner::Yes => true,
             AllowCredentialsInner::No => false,
-            AllowCredentialsInner::Predicate(c) => c(origin, parts),
+            AllowCredentialsInner::Predicate(c) => c(origin?, parts),
         };
 
         allow_creds.then(|| (header::ACCESS_CONTROL_ALLOW_CREDENTIALS, TRUE))

--- a/tower-http/src/cors/allow_credentials.rs
+++ b/tower-http/src/cors/allow_credentials.rs
@@ -9,6 +9,7 @@ use http::{request::Parts as RequestParts, HeaderValue};
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials
 /// [`CorsLayer::allow_credentials`]: super::CorsLayer::allow_credentials
 #[derive(Clone, Default)]
+#[must_use]
 pub struct AllowCredentials(AllowCredentialsInner);
 
 impl AllowCredentials {

--- a/tower-http/src/cors/allow_headers.rs
+++ b/tower-http/src/cors/allow_headers.rs
@@ -54,6 +54,11 @@ impl AllowHeaders {
         Self(AllowHeadersInner::MirrorRequest)
     }
 
+    #[allow(clippy::borrow_interior_mutable_const)]
+    pub(super) fn is_wildcard(&self) -> bool {
+        matches!(&self.0, AllowHeadersInner::Const(Some(v)) if v == WILDCARD)
+    }
+
     pub(super) fn to_header_val(&self, parts: &RequestParts) -> Option<HeaderValue> {
         match &self.0 {
             AllowHeadersInner::Const(v) => v.clone(),

--- a/tower-http/src/cors/allow_headers.rs
+++ b/tower-http/src/cors/allow_headers.rs
@@ -15,6 +15,7 @@ use super::{separated_by_commas, Any, WILDCARD};
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
 /// [`CorsLayer::allow_headers`]: super::CorsLayer::allow_headers
 #[derive(Clone, Default)]
+#[must_use]
 pub struct AllowHeaders(AllowHeadersInner);
 
 impl AllowHeaders {

--- a/tower-http/src/cors/allow_headers.rs
+++ b/tower-http/src/cors/allow_headers.rs
@@ -1,0 +1,105 @@
+use std::{array, fmt};
+
+use http::{
+    header::{self, HeaderName},
+    request::Parts as RequestParts,
+    HeaderValue,
+};
+
+use super::{separated_by_commas, Any, WILDCARD};
+
+/// Holds configuration for how to set the [`Access-Control-Allow-Headers`][mdn] header.
+///
+/// See [`CorsLayer::allow_headers`] for more details.
+///
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
+/// [`CorsLayer::allow_headers`]: super::CorsLayer::allow_headers
+#[derive(Clone, Default)]
+pub struct AllowHeaders(AllowHeadersInner);
+
+impl AllowHeaders {
+    /// Allow any headers by sending a wildcard (`*`)
+    ///
+    /// See [`CorsLayer::allow_headers`] for more details.
+    ///
+    /// [`CorsLayer::allow_headers`]: super::CorsLayer::allow_headers
+    pub fn any() -> Self {
+        Self(AllowHeadersInner::Const(Some(WILDCARD)))
+    }
+
+    /// Set multiple allowed headers
+    ///
+    /// See [`CorsLayer::allow_headers`] for more details.
+    ///
+    /// [`CorsLayer::allow_headers`]: super::CorsLayer::allow_headers
+    pub fn list<I>(headers: I) -> Self
+    where
+        I: IntoIterator<Item = HeaderName>,
+    {
+        Self(AllowHeadersInner::Const(separated_by_commas(
+            headers.into_iter().map(Into::into),
+        )))
+    }
+
+    /// Allow any headers, by mirroring the preflight [`Access-Control-Request-Headers`][mdn]
+    /// header.
+    ///
+    /// See [`CorsLayer::allow_headers`] for more details.
+    ///
+    /// [`CorsLayer::allow_headers`]: super::CorsLayer::allow_headers
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Headers
+    pub fn mirror_request() -> Self {
+        Self(AllowHeadersInner::MirrorRequest)
+    }
+
+    pub(super) fn to_header_val(&self, parts: &RequestParts) -> Option<HeaderValue> {
+        match &self.0 {
+            AllowHeadersInner::Const(v) => v.clone(),
+            AllowHeadersInner::MirrorRequest => parts
+                .headers
+                .get(header::ACCESS_CONTROL_REQUEST_HEADERS)
+                .cloned(),
+        }
+    }
+}
+
+impl fmt::Debug for AllowHeaders {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            AllowHeadersInner::Const(inner) => f.debug_tuple("Const").field(inner).finish(),
+            AllowHeadersInner::MirrorRequest => f.debug_tuple("MirrorRequest").finish(),
+        }
+    }
+}
+
+impl From<Any> for AllowHeaders {
+    fn from(_: Any) -> Self {
+        Self::any()
+    }
+}
+
+impl<const N: usize> From<[HeaderName; N]> for AllowHeaders {
+    fn from(arr: [HeaderName; N]) -> Self {
+        #[allow(deprecated)] // Can be changed when MSRV >= 1.53
+        Self::list(array::IntoIter::new(arr))
+    }
+}
+
+impl From<Vec<HeaderName>> for AllowHeaders {
+    fn from(vec: Vec<HeaderName>) -> Self {
+        Self::list(vec)
+    }
+}
+
+#[derive(Clone)]
+enum AllowHeadersInner {
+    Const(Option<HeaderValue>),
+    MirrorRequest,
+}
+
+impl Default for AllowHeadersInner {
+    fn default() -> Self {
+        Self::Const(None)
+    }
+}

--- a/tower-http/src/cors/allow_headers.rs
+++ b/tower-http/src/cors/allow_headers.rs
@@ -1,9 +1,8 @@
 use std::{array, fmt};
 
 use http::{
-    header::{self, HeaderName},
+    header::{self, HeaderName, HeaderValue},
     request::Parts as RequestParts,
-    HeaderValue,
 };
 
 use super::{separated_by_commas, Any, WILDCARD};
@@ -59,14 +58,16 @@ impl AllowHeaders {
         matches!(&self.0, AllowHeadersInner::Const(Some(v)) if v == WILDCARD)
     }
 
-    pub(super) fn to_header_val(&self, parts: &RequestParts) -> Option<HeaderValue> {
-        match &self.0 {
-            AllowHeadersInner::Const(v) => v.clone(),
+    pub(super) fn to_header(&self, parts: &RequestParts) -> Option<(HeaderName, HeaderValue)> {
+        let allow_headers = match &self.0 {
+            AllowHeadersInner::Const(v) => v.clone()?,
             AllowHeadersInner::MirrorRequest => parts
                 .headers
-                .get(header::ACCESS_CONTROL_REQUEST_HEADERS)
-                .cloned(),
-        }
+                .get(header::ACCESS_CONTROL_REQUEST_HEADERS)?
+                .clone(),
+        };
+
+        Some((header::ACCESS_CONTROL_ALLOW_HEADERS, allow_headers))
     }
 }
 

--- a/tower-http/src/cors/allow_methods.rs
+++ b/tower-http/src/cors/allow_methods.rs
@@ -1,6 +1,10 @@
 use std::{array, fmt};
 
-use http::{header, request::Parts as RequestParts, HeaderValue, Method};
+use http::{
+    header::{self, HeaderName, HeaderValue},
+    request::Parts as RequestParts,
+    Method,
+};
 
 use super::{separated_by_commas, Any, WILDCARD};
 
@@ -68,14 +72,16 @@ impl AllowMethods {
         matches!(&self.0, AllowMethodsInner::Const(Some(v)) if v == WILDCARD)
     }
 
-    pub(super) fn to_header_val(&self, parts: &RequestParts) -> Option<HeaderValue> {
-        match &self.0 {
-            AllowMethodsInner::Const(v) => v.clone(),
+    pub(super) fn to_header(&self, parts: &RequestParts) -> Option<(HeaderName, HeaderValue)> {
+        let allow_methods = match &self.0 {
+            AllowMethodsInner::Const(v) => v.clone()?,
             AllowMethodsInner::MirrorRequest => parts
                 .headers
-                .get(header::ACCESS_CONTROL_REQUEST_METHOD)
-                .cloned(),
-        }
+                .get(header::ACCESS_CONTROL_REQUEST_METHOD)?
+                .clone(),
+        };
+
+        Some((header::ACCESS_CONTROL_ALLOW_METHODS, allow_methods))
     }
 }
 

--- a/tower-http/src/cors/allow_methods.rs
+++ b/tower-http/src/cors/allow_methods.rs
@@ -1,0 +1,120 @@
+use std::{array, fmt};
+
+use http::{header, request::Parts as RequestParts, HeaderValue, Method};
+
+use super::{separated_by_commas, Any, WILDCARD};
+
+/// Holds configuration for how to set the [`Access-Control-Allow-Methods`][mdn] header.
+///
+/// See [`CorsLayer::allow_methods`] for more details.
+///
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
+/// [`CorsLayer::allow_methods`]: super::CorsLayer::allow_methods
+#[derive(Clone, Default)]
+pub struct AllowMethods(AllowMethodsInner);
+
+impl AllowMethods {
+    /// Allow any method by sending a wildcard (`*`)
+    ///
+    /// See [`CorsLayer::allow_methods`] for more details.
+    ///
+    /// [`CorsLayer::allow_methods`]: super::CorsLayer::allow_methods
+    pub fn any() -> Self {
+        Self(AllowMethodsInner::Const(Some(WILDCARD)))
+    }
+
+    /// Set a single allowed method
+    ///
+    /// See [`CorsLayer::allow_methods`] for more details.
+    ///
+    /// [`CorsLayer::allow_methods`]: super::CorsLayer::allow_methods
+    pub fn exact(method: Method) -> Self {
+        Self(AllowMethodsInner::Const(Some(
+            HeaderValue::from_str(method.as_str()).unwrap(),
+        )))
+    }
+
+    /// Set multiple allowed methods
+    ///
+    /// See [`CorsLayer::allow_methods`] for more details.
+    ///
+    /// [`CorsLayer::allow_methods`]: super::CorsLayer::allow_methods
+    pub fn list<I>(methods: I) -> Self
+    where
+        I: IntoIterator<Item = Method>,
+    {
+        Self(AllowMethodsInner::Const(separated_by_commas(
+            methods
+                .into_iter()
+                .map(|m| HeaderValue::from_str(m.as_str()).unwrap()),
+        )))
+    }
+
+    /// Allow any method, by mirroring the preflight [`Access-Control-Request-Method`][mdn]
+    /// header.
+    ///
+    /// See [`CorsLayer::allow_methods`] for more details.
+    ///
+    /// [`CorsLayer::allow_methods`]: super::CorsLayer::allow_methods
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Method
+    pub fn mirror_request() -> Self {
+        Self(AllowMethodsInner::MirrorRequest)
+    }
+
+    pub(super) fn to_header_val(&self, parts: &RequestParts) -> Option<HeaderValue> {
+        match &self.0 {
+            AllowMethodsInner::Const(v) => v.clone(),
+            AllowMethodsInner::MirrorRequest => parts
+                .headers
+                .get(header::ACCESS_CONTROL_REQUEST_METHOD)
+                .cloned(),
+        }
+    }
+}
+
+impl fmt::Debug for AllowMethods {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            AllowMethodsInner::Const(inner) => f.debug_tuple("Const").field(inner).finish(),
+            AllowMethodsInner::MirrorRequest => f.debug_tuple("MirrorRequest").finish(),
+        }
+    }
+}
+
+impl From<Any> for AllowMethods {
+    fn from(_: Any) -> Self {
+        Self::any()
+    }
+}
+
+impl From<Method> for AllowMethods {
+    fn from(method: Method) -> Self {
+        Self::exact(method)
+    }
+}
+
+impl<const N: usize> From<[Method; N]> for AllowMethods {
+    fn from(arr: [Method; N]) -> Self {
+        #[allow(deprecated)] // Can be changed when MSRV >= 1.53
+        Self::list(array::IntoIter::new(arr))
+    }
+}
+
+impl From<Vec<Method>> for AllowMethods {
+    fn from(vec: Vec<Method>) -> Self {
+        Self::list(vec)
+    }
+}
+
+#[derive(Clone)]
+enum AllowMethodsInner {
+    Const(Option<HeaderValue>),
+    MirrorRequest,
+}
+
+impl Default for AllowMethodsInner {
+    fn default() -> Self {
+        Self::Const(None)
+    }
+}

--- a/tower-http/src/cors/allow_methods.rs
+++ b/tower-http/src/cors/allow_methods.rs
@@ -63,6 +63,11 @@ impl AllowMethods {
         Self(AllowMethodsInner::MirrorRequest)
     }
 
+    #[allow(clippy::borrow_interior_mutable_const)]
+    pub(super) fn is_wildcard(&self) -> bool {
+        matches!(&self.0, AllowMethodsInner::Const(Some(v)) if v == WILDCARD)
+    }
+
     pub(super) fn to_header_val(&self, parts: &RequestParts) -> Option<HeaderValue> {
         match &self.0 {
             AllowMethodsInner::Const(v) => v.clone(),

--- a/tower-http/src/cors/allow_methods.rs
+++ b/tower-http/src/cors/allow_methods.rs
@@ -11,6 +11,7 @@ use super::{separated_by_commas, Any, WILDCARD};
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
 /// [`CorsLayer::allow_methods`]: super::CorsLayer::allow_methods
 #[derive(Clone, Default)]
+#[must_use]
 pub struct AllowMethods(AllowMethodsInner);
 
 impl AllowMethods {

--- a/tower-http/src/cors/allow_origin.rs
+++ b/tower-http/src/cors/allow_origin.rs
@@ -1,0 +1,131 @@
+use std::{array, fmt, sync::Arc};
+
+use http::{request::Parts as RequestParts, HeaderValue};
+
+use super::{separated_by_commas, Any, WILDCARD};
+
+/// Holds configuration for how to set the [`Access-Control-Allow-Origin`][mdn] header.
+///
+/// See [`CorsLayer::allow_origin`] for more details.
+///
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+/// [`CorsLayer::allow_origin`]: super::CorsLayer::allow_origin
+#[derive(Clone, Default)]
+pub struct AllowOrigin(OriginInner);
+
+impl AllowOrigin {
+    /// Allow any origin by sending a wildcard (`*`)
+    ///
+    /// See [`CorsLayer::allow_origin`] for more details.
+    ///
+    /// [`CorsLayer::allow_origin`]: super::CorsLayer::allow_origin
+    pub fn any() -> Self {
+        Self(OriginInner::Const(Some(WILDCARD)))
+    }
+
+    /// Set a single allowed origin
+    ///
+    /// See [`CorsLayer::allow_origin`] for more details.
+    ///
+    /// [`CorsLayer::allow_origin`]: super::CorsLayer::allow_origin
+    pub fn exact(origin: HeaderValue) -> Self {
+        Self(OriginInner::Const(Some(origin)))
+    }
+
+    /// Set multiple allowed origins
+    ///
+    /// See [`CorsLayer::allow_origin`] for more details.
+    ///
+    /// [`CorsLayer::allow_origin`]: super::CorsLayer::allow_origin
+    pub fn list<I>(origins: I) -> Self
+    where
+        I: IntoIterator<Item = HeaderValue>,
+    {
+        Self(OriginInner::Const(separated_by_commas(
+            origins.into_iter().map(Into::into),
+        )))
+    }
+
+    /// Set the allowed origins from a predicate
+    ///
+    /// See [`CorsLayer::allow_origin`] for more details.
+    ///
+    /// [`CorsLayer::allow_origin`]: super::CorsLayer::allow_origin
+    pub fn predicate<F>(f: F) -> Self
+    where
+        F: Fn(&HeaderValue, &RequestParts) -> bool + Send + Sync + 'static,
+    {
+        Self(OriginInner::Predicate(Arc::new(f)))
+    }
+
+    /// Allow any origin, by mirroring the request origin
+    ///
+    /// This is equivalent to
+    /// [`AllowOrigin::predicate(|_, _| true)`][Self::predicate].
+    ///
+    /// See [`CorsLayer::allow_origin`] for more details.
+    ///
+    /// [`CorsLayer::allow_origin`]: super::CorsLayer::allow_origin
+    pub fn mirror_request() -> Self {
+        Self::predicate(|_, _| true)
+    }
+
+    pub(super) fn to_header_val(
+        &self,
+        origin: &HeaderValue,
+        parts: &RequestParts,
+    ) -> Option<HeaderValue> {
+        match &self.0 {
+            OriginInner::Const(v) => v.clone(),
+            OriginInner::Predicate(c) => c(origin, parts).then(|| origin.to_owned()),
+        }
+    }
+}
+
+impl fmt::Debug for AllowOrigin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            OriginInner::Const(inner) => f.debug_tuple("Const").field(inner).finish(),
+            OriginInner::Predicate(_) => f.debug_tuple("Predicate").finish(),
+        }
+    }
+}
+
+impl From<Any> for AllowOrigin {
+    fn from(_: Any) -> Self {
+        Self::any()
+    }
+}
+
+impl From<HeaderValue> for AllowOrigin {
+    fn from(val: HeaderValue) -> Self {
+        Self::exact(val)
+    }
+}
+
+impl<const N: usize> From<[HeaderValue; N]> for AllowOrigin {
+    fn from(arr: [HeaderValue; N]) -> Self {
+        #[allow(deprecated)] // Can be changed when MSRV >= 1.53
+        Self::list(array::IntoIter::new(arr))
+    }
+}
+
+impl From<Vec<HeaderValue>> for AllowOrigin {
+    fn from(vec: Vec<HeaderValue>) -> Self {
+        Self::list(vec)
+    }
+}
+
+#[derive(Clone)]
+enum OriginInner {
+    Const(Option<HeaderValue>),
+    Predicate(
+        Arc<dyn for<'a> Fn(&'a HeaderValue, &'a RequestParts) -> bool + Send + Sync + 'static>,
+    ),
+}
+
+impl Default for OriginInner {
+    fn default() -> Self {
+        Self::Const(None)
+    }
+}

--- a/tower-http/src/cors/allow_origin.rs
+++ b/tower-http/src/cors/allow_origin.rs
@@ -11,6 +11,7 @@ use super::{separated_by_commas, Any, WILDCARD};
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
 /// [`CorsLayer::allow_origin`]: super::CorsLayer::allow_origin
 #[derive(Clone, Default)]
+#[must_use]
 pub struct AllowOrigin(OriginInner);
 
 impl AllowOrigin {

--- a/tower-http/src/cors/allow_origin.rs
+++ b/tower-http/src/cors/allow_origin.rs
@@ -71,6 +71,11 @@ impl AllowOrigin {
         Self::predicate(|_, _| true)
     }
 
+    #[allow(clippy::borrow_interior_mutable_const)]
+    pub(super) fn is_wildcard(&self) -> bool {
+        matches!(&self.0, OriginInner::Const(Some(v)) if v == WILDCARD)
+    }
+
     pub(super) fn to_header_val(
         &self,
         origin: &HeaderValue,

--- a/tower-http/src/cors/allow_origin.rs
+++ b/tower-http/src/cors/allow_origin.rs
@@ -81,12 +81,12 @@ impl AllowOrigin {
 
     pub(super) fn to_header(
         &self,
-        origin: &HeaderValue,
+        origin: Option<&HeaderValue>,
         parts: &RequestParts,
     ) -> Option<(HeaderName, HeaderValue)> {
         let allow_origin = match &self.0 {
             OriginInner::Const(v) => v.clone()?,
-            OriginInner::Predicate(c) => c(origin, parts).then(|| origin.to_owned())?,
+            OriginInner::Predicate(c) => origin.filter(|origin| c(origin, parts))?.clone(),
         };
 
         Some((header::ACCESS_CONTROL_ALLOW_ORIGIN, allow_origin))

--- a/tower-http/src/cors/expose_headers.rs
+++ b/tower-http/src/cors/expose_headers.rs
@@ -1,7 +1,7 @@
 use std::{array, fmt};
 
 use http::{
-    header::{HeaderName, HeaderValue},
+    header::{self, HeaderName, HeaderValue},
     request::Parts as RequestParts,
 };
 
@@ -46,10 +46,12 @@ impl ExposeHeaders {
         matches!(&self.0, ExposeHeadersInner::Const(Some(v)) if v == WILDCARD)
     }
 
-    pub(super) fn to_header_val(&self, _parts: &RequestParts) -> Option<HeaderValue> {
-        match &self.0 {
-            ExposeHeadersInner::Const(v) => v.clone(),
-        }
+    pub(super) fn to_header(&self, _parts: &RequestParts) -> Option<(HeaderName, HeaderValue)> {
+        let expose_headers = match &self.0 {
+            ExposeHeadersInner::Const(v) => v.clone()?,
+        };
+
+        Some((header::ACCESS_CONTROL_EXPOSE_HEADERS, expose_headers))
     }
 }
 

--- a/tower-http/src/cors/expose_headers.rs
+++ b/tower-http/src/cors/expose_headers.rs
@@ -41,6 +41,11 @@ impl ExposeHeaders {
         )))
     }
 
+    #[allow(clippy::borrow_interior_mutable_const)]
+    pub(super) fn is_wildcard(&self) -> bool {
+        matches!(&self.0, ExposeHeadersInner::Const(Some(v)) if v == WILDCARD)
+    }
+
     pub(super) fn to_header_val(&self, _parts: &RequestParts) -> Option<HeaderValue> {
         match &self.0 {
             ExposeHeadersInner::Const(v) => v.clone(),

--- a/tower-http/src/cors/expose_headers.rs
+++ b/tower-http/src/cors/expose_headers.rs
@@ -1,0 +1,86 @@
+use std::{array, fmt};
+
+use http::{
+    header::{HeaderName, HeaderValue},
+    request::Parts as RequestParts,
+};
+
+use super::{separated_by_commas, Any, WILDCARD};
+
+/// Holds configuration for how to set the [`Access-Control-Expose-Headers`][mdn] header.
+///
+/// See [`CorsLayer::expose_headers`] for more details.
+///
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
+/// [`CorsLayer::expose_headers`]: super::CorsLayer::expose_headers
+#[derive(Clone, Default)]
+pub struct ExposeHeaders(ExposeHeadersInner);
+
+impl ExposeHeaders {
+    /// Expose any / all headers by sending a wildcard (`*`)
+    ///
+    /// See [`CorsLayer::expose_headers`] for more details.
+    ///
+    /// [`CorsLayer::expose_headers`]: super::CorsLayer::expose_headers
+    pub fn any() -> Self {
+        Self(ExposeHeadersInner::Const(Some(WILDCARD)))
+    }
+
+    /// Set multiple exposed header names
+    ///
+    /// See [`CorsLayer::expose_headers`] for more details.
+    ///
+    /// [`CorsLayer::expose_headers`]: super::CorsLayer::expose_headers
+    pub fn list<I>(headers: I) -> Self
+    where
+        I: IntoIterator<Item = HeaderName>,
+    {
+        Self(ExposeHeadersInner::Const(separated_by_commas(
+            headers.into_iter().map(Into::into),
+        )))
+    }
+
+    pub(super) fn to_header_val(&self, _parts: &RequestParts) -> Option<HeaderValue> {
+        match &self.0 {
+            ExposeHeadersInner::Const(v) => v.clone(),
+        }
+    }
+}
+
+impl fmt::Debug for ExposeHeaders {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            ExposeHeadersInner::Const(inner) => f.debug_tuple("Const").field(inner).finish(),
+        }
+    }
+}
+
+impl From<Any> for ExposeHeaders {
+    fn from(_: Any) -> Self {
+        Self::any()
+    }
+}
+
+impl<const N: usize> From<[HeaderName; N]> for ExposeHeaders {
+    fn from(arr: [HeaderName; N]) -> Self {
+        #[allow(deprecated)] // Can be changed when MSRV >= 1.53
+        Self::list(array::IntoIter::new(arr))
+    }
+}
+
+impl From<Vec<HeaderName>> for ExposeHeaders {
+    fn from(vec: Vec<HeaderName>) -> Self {
+        Self::list(vec)
+    }
+}
+
+#[derive(Clone)]
+enum ExposeHeadersInner {
+    Const(Option<HeaderValue>),
+}
+
+impl Default for ExposeHeadersInner {
+    fn default() -> Self {
+        ExposeHeadersInner::Const(None)
+    }
+}

--- a/tower-http/src/cors/expose_headers.rs
+++ b/tower-http/src/cors/expose_headers.rs
@@ -14,6 +14,7 @@ use super::{separated_by_commas, Any, WILDCARD};
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
 /// [`CorsLayer::expose_headers`]: super::CorsLayer::expose_headers
 #[derive(Clone, Default)]
+#[must_use]
 pub struct ExposeHeaders(ExposeHeadersInner);
 
 impl ExposeHeaders {

--- a/tower-http/src/cors/max_age.rs
+++ b/tower-http/src/cors/max_age.rs
@@ -34,12 +34,12 @@ impl MaxAge {
 
     pub(super) fn to_header(
         &self,
-        origin: &HeaderValue,
+        origin: Option<&HeaderValue>,
         parts: &RequestParts,
     ) -> Option<(HeaderName, HeaderValue)> {
         let max_age = match &self.0 {
             MaxAgeInner::Exact(v) => v.clone()?,
-            MaxAgeInner::Fn(c) => c(origin, parts).as_secs().into(),
+            MaxAgeInner::Fn(c) => c(origin?, parts).as_secs().into(),
         };
 
         Some((header::ACCESS_CONTROL_MAX_AGE, max_age))

--- a/tower-http/src/cors/max_age.rs
+++ b/tower-http/src/cors/max_age.rs
@@ -1,0 +1,68 @@
+use std::{fmt, sync::Arc, time::Duration};
+
+use http::{request::Parts as RequestParts, HeaderValue};
+
+/// Holds configuration for how to set the [`Access-Control-Max-Age`][mdn] header.
+///
+/// See [`CorsLayer::max_age`][super::CorsLayer::max_age] for more details.
+///
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
+#[derive(Clone, Default)]
+pub struct MaxAge(MaxAgeInner);
+
+impl MaxAge {
+    /// Set a static max-age value
+    ///
+    /// See [`CorsLayer::max_age`][super::CorsLayer::max_age] for more details.
+    pub fn exact(max_age: Duration) -> Self {
+        Self(MaxAgeInner::Exact(Some(max_age.as_secs().into())))
+    }
+
+    /// Set the max-age based on the preflight request parts
+    ///
+    /// See [`CorsLayer::max_age`][super::CorsLayer::max_age] for more details.
+    pub fn dynamic<F>(f: F) -> Self
+    where
+        F: Fn(&HeaderValue, &RequestParts) -> Duration + Send + Sync + 'static,
+    {
+        Self(MaxAgeInner::Fn(Arc::new(f)))
+    }
+
+    pub(super) fn to_header_val(
+        &self,
+        origin: &HeaderValue,
+        parts: &RequestParts,
+    ) -> Option<HeaderValue> {
+        match &self.0 {
+            MaxAgeInner::Exact(v) => v.clone(),
+            MaxAgeInner::Fn(c) => Some(c(origin, parts).as_secs().into()),
+        }
+    }
+}
+
+impl fmt::Debug for MaxAge {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            MaxAgeInner::Exact(inner) => f.debug_tuple("Exact").field(inner).finish(),
+            MaxAgeInner::Fn(_) => f.debug_tuple("Fn").finish(),
+        }
+    }
+}
+
+impl From<Duration> for MaxAge {
+    fn from(max_age: Duration) -> Self {
+        Self::exact(max_age)
+    }
+}
+
+#[derive(Clone)]
+enum MaxAgeInner {
+    Exact(Option<HeaderValue>),
+    Fn(Arc<dyn for<'a> Fn(&'a HeaderValue, &'a RequestParts) -> Duration + Send + Sync + 'static>),
+}
+
+impl Default for MaxAgeInner {
+    fn default() -> Self {
+        Self::Exact(None)
+    }
+}

--- a/tower-http/src/cors/max_age.rs
+++ b/tower-http/src/cors/max_age.rs
@@ -8,6 +8,7 @@ use http::{request::Parts as RequestParts, HeaderValue};
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
 #[derive(Clone, Default)]
+#[must_use]
 pub struct MaxAge(MaxAgeInner);
 
 impl MaxAge {

--- a/tower-http/src/cors/mod.rs
+++ b/tower-http/src/cors/mod.rs
@@ -80,6 +80,7 @@ pub use self::{
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
 #[derive(Debug, Clone)]
+#[must_use]
 pub struct CorsLayer {
     allow_credentials: AllowCredentials,
     allow_headers: AllowHeaders,
@@ -343,6 +344,7 @@ impl CorsLayer {
 /// Represents a wildcard value (`*`) used with some CORS headers such as
 /// [`CorsLayer::allow_methods`].
 #[derive(Debug, Clone, Copy)]
+#[must_use]
 pub struct Any;
 
 /// Represents a wildcard value (`*`) used with some CORS headers such as
@@ -394,6 +396,7 @@ impl<S> Layer<S> for CorsLayer {
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
 #[derive(Debug, Clone)]
+#[must_use]
 pub struct Cors<S> {
     inner: S,
     layer: CorsLayer,

--- a/tower-http/src/cors/vary.rs
+++ b/tower-http/src/cors/vary.rs
@@ -1,0 +1,51 @@
+use std::array;
+
+use http::{header::HeaderName, HeaderValue};
+
+use super::preflight_request_headers;
+
+/// Holds configuration for how to set the [`Vary`][mdn] header.
+///
+/// See [`CorsLayer::vary`] for more details.
+///
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary
+/// [`CorsLayer::vary`]: super::CorsLayer::vary
+#[derive(Clone, Debug)]
+pub struct Vary(Vec<HeaderValue>);
+
+impl Vary {
+    /// Set the list of header names to return as vary header values
+    ///
+    /// See [`CorsLayer::vary`] for more details.
+    ///
+    /// [`CorsLayer::vary`]: super::CorsLayer::vary
+    pub fn list<I>(headers: I) -> Self
+    where
+        I: IntoIterator<Item = HeaderName>,
+    {
+        Self(headers.into_iter().map(Into::into).collect())
+    }
+
+    pub(super) fn values(&self) -> impl Iterator<Item = HeaderValue> + '_ {
+        self.0.iter().cloned()
+    }
+}
+
+impl Default for Vary {
+    fn default() -> Self {
+        Self::list(preflight_request_headers())
+    }
+}
+
+impl<const N: usize> From<[HeaderName; N]> for Vary {
+    fn from(arr: [HeaderName; N]) -> Self {
+        #[allow(deprecated)] // Can be changed when MSRV >= 1.53
+        Self::list(array::IntoIter::new(arr))
+    }
+}
+
+impl From<Vec<HeaderName>> for Vary {
+    fn from(vec: Vec<HeaderName>) -> Self {
+        Self::list(vec)
+    }
+}


### PR DESCRIPTION
Closes #194

## Motivation

The CORS middleware could use some streamlining internally and also doesn't offer all of the functionality that people want from it.

## Solution

This PR basically rewrites how the `cors::ResponseFuture` is built (but changes very little about how its structure and `Future` impl). It builds on my previous refactorings, but still amounts to a very large diff (mostly due to reorganizing how header values are obtained). It might be easier to read the new module entirely than to look at the diff

## Notes

~~This is a work in progress, I still need to~~

* [x] Add missing documentation for the new types
* [x] Add more examples to the method documentation
* [x] Add more constructors for the various new types (`AllowOrigin`, `ExposeHeaders` and such)
* [x] Fix `Vary` header application (currently there's just a hardcoded list of headers there, which seems wrong)
* [x] Add a new constructor that's more permissive than `Cors::permissive()` (potential names would be `permissive_with_credentials`, `very_permissive`, `extremely_permissive`, `anything_goes`)
* [x] Create internal sub-modules?
* [x] Panic if `AllowCredentials::yes()` is combined with `Any` headers / origin / ...
* [x] Remove allow-credentials from `permissive()`
* [x] Add `#[must_use]` to most / all of the types in the `cors` module
* [x] Fix broken intra-doc links