### PR TITLE
fix: add default to trace response body

### DIFF
--- a/tower-http/src/trace/body.rs
+++ b/tower-http/src/trace/body.rs
@@ -28,6 +28,25 @@ pin_project! {
     }
 }
 
+impl<B, C, OnBodyChunk, OnEos, OnFailure> Default
+    for ResponseBody<B, C, OnBodyChunk, OnEos, OnFailure>
+where
+    B: Default,
+    OnBodyChunk: Default,
+{
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+            classify_eos: None,
+            on_eos: None,
+            on_body_chunk: Default::default(),
+            on_failure: None,
+            start: Instant::now(),
+            span: Span::current(),
+        }
+    }
+}
+
 impl<B, C, OnBodyChunkT, OnEosT, OnFailureT> Body
     for ResponseBody<B, C, OnBodyChunkT, OnEosT, OnFailureT>
 where

--- a/tower-http/src/trace/service.rs
+++ b/tower-http/src/trace/service.rs
@@ -280,7 +280,6 @@ where
     ResBody::Error: fmt::Display + 'static,
     S::Error: fmt::Display + 'static,
     M: MakeClassifier,
-    M::Classifier: Clone,
     MakeSpanT: MakeSpan<ReqBody>,
     OnRequestT: OnRequest<ReqBody>,
     OnResponseT: OnResponse<ResBody> + Clone,


### PR DESCRIPTION
## Motivation

This is an attempt to fix https://github.com/hyperium/tonic/issues/973

## Solution

Adds `Default` to `trace::ResponseBody`.

I'm not sure on the implications this may have however
