### PR TITLE
Check method in `ServeDir`

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `ServeDir::{fallback, not_found_service}` for calling another service if
   the file cannot be found.
 - Add `SetStatus` to override status codes.
+- `ServeDir` and `ServeFile` now responds with `405 Method Not Allowed` to requests where the
+  method isn't `GET` or `HEAD`.
 - **cors**: Added `CorsLayer::very_permissive` which is like
   `CorsLayer::permissive` except it (truly) allows credentials. This is made
   possible by mirroring the request's origin as well as method and headers

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `ServeDir::{fallback, not_found_service}` for calling another service if
   the file cannot be found.
 - Add `SetStatus` to override status codes.
-- `ServeDir` and `ServeFile` now responds with `405 Method Not Allowed` to requests where the
+- `ServeDir` and `ServeFile` now respond with `405 Method Not Allowed` to requests where the
   method isn't `GET` or `HEAD`.
 - **cors**: Added `CorsLayer::very_permissive` which is like
   `CorsLayer::permissive` except it (truly) allows credentials. This is made


### PR DESCRIPTION
## Motivation

Methods outside of `GET` and `HEAD` don't make much sense for serving static files but `ServeDir` (and therefore also `ServeFile`) would just accept all methods.

## Solution

Check the method in `ServeDir` and respond with `405 Method Not Allowed` if its not `GET` or `HEAD`. A response is immediately returned without calling the fallback.