### PR TITLE
Use doc_auto_cfg instead of doc_cfg feature for docsrs

### DIFF
--- a/tower-http/src/builder.rs
+++ b/tower-http/src/builder.rs
@@ -40,6 +40,8 @@ use tower_layer::Stack;
 /// # service.ready().await.unwrap().call(Request::new(Body::empty())).await.unwrap();
 /// # }
 /// ```
+#[cfg(feature = "util")]
+// ^ work around rustdoc not inferring doc(cfg)s for cfg's from surrounding scopes
 pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     /// Propagate a header from the request to the response.
     ///
@@ -47,7 +49,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     ///
     /// [`tower_http::propagate_header`]: crate::propagate_header
     #[cfg(feature = "propagate-header")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "propagate-header")))]
     fn propagate_header(
         self,
         header: HeaderName,
@@ -60,7 +61,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     /// [`tower_http::add_extension`]: crate::add_extension
     /// [request extensions]: https://docs.rs/http/latest/http/struct.Extensions.html
     #[cfg(feature = "add-extension")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "add-extension")))]
     fn add_extension<T>(
         self,
         value: T,
@@ -72,7 +72,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     ///
     /// [`tower_http::map_request_body`]: crate::map_request_body
     #[cfg(feature = "map-request-body")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "map-request-body")))]
     fn map_request_body<F>(
         self,
         f: F,
@@ -84,7 +83,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     ///
     /// [`tower_http::map_response_body`]: crate::map_response_body
     #[cfg(feature = "map-response-body")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "map-response-body")))]
     fn map_response_body<F>(
         self,
         f: F,
@@ -100,14 +98,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
         feature = "compression-deflate",
         feature = "compression-gzip"
     ))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(any(
-            feature = "compression-br",
-            feature = "compression-deflate",
-            feature = "compression-gzip"
-        )))
-    )]
     fn compression(self) -> ServiceBuilder<Stack<crate::compression::CompressionLayer, L>>;
 
     /// Decompress response bodies.
@@ -120,14 +110,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
         feature = "decompression-deflate",
         feature = "decompression-gzip"
     ))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(any(
-            feature = "decompression-br",
-            feature = "decompression-deflate",
-            feature = "decompression-gzip"
-        )))
-    )]
     fn decompression(self) -> ServiceBuilder<Stack<crate::decompression::DecompressionLayer, L>>;
 
     /// High level tracing that classifies responses using HTTP status codes.
@@ -140,7 +122,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     /// [`tower_http::trace`]: crate::trace
     /// [`TraceLayer`]: crate::trace::TraceLayer
     #[cfg(feature = "trace")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
     fn trace_for_http(
         self,
     ) -> ServiceBuilder<Stack<crate::trace::TraceLayer<SharedClassifier<ServerErrorsAsFailures>>, L>>;
@@ -155,7 +136,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     /// [`tower_http::trace`]: crate::trace
     /// [`TraceLayer`]: crate::trace::TraceLayer
     #[cfg(feature = "trace")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
     fn trace_for_grpc(
         self,
     ) -> ServiceBuilder<Stack<crate::trace::TraceLayer<SharedClassifier<GrpcErrorsAsFailures>>, L>>;
@@ -167,7 +147,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     /// [`tower_http::follow_redirect`]: crate::follow_redirect
     /// [`Standard`]: crate::follow_redirect::policy::Standard
     #[cfg(feature = "follow-redirect")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "follow-redirect")))]
     fn follow_redirects(
         self,
     ) -> ServiceBuilder<
@@ -184,7 +163,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     /// [sensitive]: https://docs.rs/http/latest/http/header/struct.HeaderValue.html#method.set_sensitive
     /// [`tower_http::sensitive_headers`]: crate::sensitive_headers
     #[cfg(feature = "sensitive-headers")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "sensitive-headers")))]
     fn sensitive_headers<I>(
         self,
         headers: I,
@@ -199,7 +177,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     /// [sensitive]: https://docs.rs/http/latest/http/header/struct.HeaderValue.html#method.set_sensitive
     /// [`tower_http::sensitive_headers`]: crate::sensitive_headers
     #[cfg(feature = "sensitive-headers")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "sensitive-headers")))]
     fn sensitive_request_headers(
         self,
         headers: std::sync::Arc<[HeaderName]>,
@@ -212,7 +189,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     /// [sensitive]: https://docs.rs/http/latest/http/header/struct.HeaderValue.html#method.set_sensitive
     /// [`tower_http::sensitive_headers`]: crate::sensitive_headers
     #[cfg(feature = "sensitive-headers")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "sensitive-headers")))]
     fn sensitive_response_headers(
         self,
         headers: std::sync::Arc<[HeaderName]>,
@@ -227,7 +203,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     ///
     /// [`tower_http::set_header`]: crate::set_header
     #[cfg(feature = "set-header")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "set-header")))]
     fn override_request_header<M>(
         self,
         header_name: HeaderName,
@@ -242,7 +217,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     ///
     /// [`tower_http::set_header`]: crate::set_header
     #[cfg(feature = "set-header")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "set-header")))]
     fn append_request_header<M>(
         self,
         header_name: HeaderName,
@@ -255,7 +229,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     ///
     /// [`tower_http::set_header`]: crate::set_header
     #[cfg(feature = "set-header")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "set-header")))]
     fn insert_request_header_if_not_present<M>(
         self,
         header_name: HeaderName,
@@ -271,7 +244,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     ///
     /// [`tower_http::set_header`]: crate::set_header
     #[cfg(feature = "set-header")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "set-header")))]
     fn override_response_header<M>(
         self,
         header_name: HeaderName,
@@ -286,7 +258,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     ///
     /// [`tower_http::set_header`]: crate::set_header
     #[cfg(feature = "set-header")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "set-header")))]
     fn append_response_header<M>(
         self,
         header_name: HeaderName,
@@ -299,7 +270,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     ///
     /// [`tower_http::set_header`]: crate::set_header
     #[cfg(feature = "set-header")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "set-header")))]
     fn insert_response_header_if_not_present<M>(
         self,
         header_name: HeaderName,
@@ -312,7 +282,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     ///
     /// [`tower_http::request_id`]: crate::request_id
     #[cfg(feature = "request-id")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "request-id")))]
     fn set_request_id<M>(
         self,
         header_name: HeaderName,
@@ -327,7 +296,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     ///
     /// [`tower_http::request_id`]: crate::request_id
     #[cfg(feature = "request-id")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "request-id")))]
     fn set_x_request_id<M>(
         self,
         make_request_id: M,
@@ -347,7 +315,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     ///
     /// [`tower_http::request_id`]: crate::request_id
     #[cfg(feature = "request-id")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "request-id")))]
     fn propagate_request_id(
         self,
         header_name: HeaderName,
@@ -359,7 +326,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     ///
     /// [`tower_http::request_id`]: crate::request_id
     #[cfg(feature = "request-id")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "request-id")))]
     fn propagate_x_request_id(
         self,
     ) -> ServiceBuilder<Stack<crate::request_id::PropagateRequestIdLayer, L>> {
@@ -372,7 +338,6 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     ///
     /// [`tower_http::catch_panic`]: crate::catch_panic
     #[cfg(feature = "catch-panic")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "catch-panic")))]
     fn catch_panic(
         self,
     ) -> ServiceBuilder<
@@ -420,14 +385,6 @@ impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
         feature = "compression-deflate",
         feature = "compression-gzip"
     ))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(any(
-            feature = "compression-br",
-            feature = "compression-deflate",
-            feature = "compression-gzip"
-        )))
-    )]
     fn compression(self) -> ServiceBuilder<Stack<crate::compression::CompressionLayer, L>> {
         self.layer(crate::compression::CompressionLayer::new())
     }
@@ -437,14 +394,6 @@ impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
         feature = "decompression-deflate",
         feature = "decompression-gzip"
     ))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(any(
-            feature = "decompression-br",
-            feature = "decompression-deflate",
-            feature = "decompression-gzip"
-        )))
-    )]
     fn decompression(self) -> ServiceBuilder<Stack<crate::decompression::DecompressionLayer, L>> {
         self.layer(crate::decompression::DecompressionLayer::new())
     }
@@ -466,7 +415,6 @@ impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
     }
 
     #[cfg(feature = "follow-redirect")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "follow-redirect")))]
     fn follow_redirects(
         self,
     ) -> ServiceBuilder<
@@ -603,7 +551,6 @@ impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
     }
 
     #[cfg(feature = "catch-panic")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "catch-panic")))]
     fn catch_panic(
         self,
     ) -> ServiceBuilder<

--- a/tower-http/src/compression/layer.rs
+++ b/tower-http/src/compression/layer.rs
@@ -38,7 +38,6 @@ impl CompressionLayer {
 
     /// Sets whether to enable the gzip encoding.
     #[cfg(feature = "compression-gzip")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compression-gzip")))]
     pub fn gzip(mut self, enable: bool) -> Self {
         self.accept.set_gzip(enable);
         self
@@ -46,7 +45,6 @@ impl CompressionLayer {
 
     /// Sets whether to enable the Deflate encoding.
     #[cfg(feature = "compression-deflate")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compression-deflate")))]
     pub fn deflate(mut self, enable: bool) -> Self {
         self.accept.set_deflate(enable);
         self
@@ -54,7 +52,6 @@ impl CompressionLayer {
 
     /// Sets whether to enable the Brotli encoding.
     #[cfg(feature = "compression-br")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compression-br")))]
     pub fn br(mut self, enable: bool) -> Self {
         self.accept.set_br(enable);
         self

--- a/tower-http/src/compression/service.rs
+++ b/tower-http/src/compression/service.rs
@@ -42,7 +42,6 @@ impl<S, P> Compression<S, P> {
 
     /// Sets whether to enable the gzip encoding.
     #[cfg(feature = "compression-gzip")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compression-gzip")))]
     pub fn gzip(mut self, enable: bool) -> Self {
         self.accept.set_gzip(enable);
         self
@@ -50,7 +49,6 @@ impl<S, P> Compression<S, P> {
 
     /// Sets whether to enable the Deflate encoding.
     #[cfg(feature = "compression-deflate")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compression-deflate")))]
     pub fn deflate(mut self, enable: bool) -> Self {
         self.accept.set_deflate(enable);
         self
@@ -58,7 +56,6 @@ impl<S, P> Compression<S, P> {
 
     /// Sets whether to enable the Brotli encoding.
     #[cfg(feature = "compression-br")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compression-br")))]
     pub fn br(mut self, enable: bool) -> Self {
         self.accept.set_br(enable);
         self

--- a/tower-http/src/decompression/layer.rs
+++ b/tower-http/src/decompression/layer.rs
@@ -32,7 +32,6 @@ impl DecompressionLayer {
 
     /// Sets whether to request the gzip encoding.
     #[cfg(feature = "decompression-gzip")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "decompression-gzip")))]
     pub fn gzip(mut self, enable: bool) -> Self {
         self.accept.set_gzip(enable);
         self
@@ -40,7 +39,6 @@ impl DecompressionLayer {
 
     /// Sets whether to request the Deflate encoding.
     #[cfg(feature = "decompression-deflate")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "decompression-deflate")))]
     pub fn deflate(mut self, enable: bool) -> Self {
         self.accept.set_deflate(enable);
         self
@@ -48,7 +46,6 @@ impl DecompressionLayer {
 
     /// Sets whether to request the Brotli encoding.
     #[cfg(feature = "decompression-br")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "decompression-br")))]
     pub fn br(mut self, enable: bool) -> Self {
         self.accept.set_br(enable);
         self

--- a/tower-http/src/decompression/service.rs
+++ b/tower-http/src/decompression/service.rs
@@ -40,7 +40,6 @@ impl<S> Decompression<S> {
 
     /// Sets whether to request the gzip encoding.
     #[cfg(feature = "decompression-gzip")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "decompression-gzip")))]
     pub fn gzip(mut self, enable: bool) -> Self {
         self.accept.set_gzip(enable);
         self
@@ -48,7 +47,6 @@ impl<S> Decompression<S> {
 
     /// Sets whether to request the Deflate encoding.
     #[cfg(feature = "decompression-deflate")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "decompression-deflate")))]
     pub fn deflate(mut self, enable: bool) -> Self {
         self.accept.set_deflate(enable);
         self
@@ -56,7 +54,6 @@ impl<S> Decompression<S> {
 
     /// Sets whether to request the Brotli encoding.
     #[cfg(feature = "decompression-br")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "decompression-br")))]
     pub fn br(mut self, enable: bool) -> Self {
         self.accept.set_br(enable);
         self

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -217,22 +217,19 @@
     clippy::type_complexity
 )]
 #![forbid(unsafe_code)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 
 #[macro_use]
 pub(crate) mod macros;
 
 #[cfg(feature = "auth")]
-#[cfg_attr(docsrs, doc(cfg(feature = "auth")))]
 pub mod auth;
 
 #[cfg(feature = "set-header")]
-#[cfg_attr(docsrs, doc(cfg(feature = "set-header")))]
 pub mod set_header;
 
 #[cfg(feature = "propagate-header")]
-#[cfg_attr(docsrs, doc(cfg(feature = "propagate-header")))]
 pub mod propagate_header;
 
 #[cfg(any(
@@ -240,22 +237,12 @@ pub mod propagate_header;
     feature = "compression-deflate",
     feature = "compression-gzip"
 ))]
-#[cfg_attr(
-    docsrs,
-    doc(cfg(any(
-        feature = "compression-br",
-        feature = "compression-deflate",
-        feature = "compression-gzip"
-    )))
-)]
 pub mod compression;
 
 #[cfg(feature = "add-extension")]
-#[cfg_attr(docsrs, doc(cfg(feature = "add-extension")))]
 pub mod add_extension;
 
 #[cfg(feature = "sensitive-headers")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sensitive-headers")))]
 pub mod sensitive_headers;
 
 #[cfg(any(
@@ -263,14 +250,6 @@ pub mod sensitive_headers;
     feature = "decompression-deflate",
     feature = "decompression-gzip"
 ))]
-#[cfg_attr(
-    docsrs,
-    doc(cfg(any(
-        feature = "decompression-br",
-        feature = "decompression-deflate",
-        feature = "decompression-gzip"
-    )))
-)]
 pub mod decompression;
 
 #[cfg(any(
@@ -295,39 +274,30 @@ mod content_encoding;
 mod compression_utils;
 
 #[cfg(feature = "map-response-body")]
-#[cfg_attr(docsrs, doc(cfg(feature = "map-response-body")))]
 pub mod map_response_body;
 
 #[cfg(feature = "map-request-body")]
-#[cfg_attr(docsrs, doc(cfg(feature = "map-request-body")))]
 pub mod map_request_body;
 
 #[cfg(feature = "trace")]
-#[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
 pub mod trace;
 
 #[cfg(feature = "follow-redirect")]
-#[cfg_attr(docsrs, doc(cfg(feature = "follow-redirect")))]
 pub mod follow_redirect;
 
 #[cfg(feature = "metrics")]
-#[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
 pub mod metrics;
 
 #[cfg(feature = "cors")]
-#[cfg_attr(docsrs, doc(cfg(feature = "cors")))]
 pub mod cors;
 
 #[cfg(feature = "request-id")]
-#[cfg_attr(docsrs, doc(cfg(feature = "request-id")))]
 pub mod request_id;
 
 #[cfg(feature = "catch-panic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "catch-panic")))]
 pub mod catch_panic;
 
 #[cfg(feature = "set-status")]
-#[cfg_attr(docsrs, doc(cfg(feature = "set-status")))]
 pub mod set_status;
 
 pub mod classify;
@@ -337,7 +307,6 @@ pub mod services;
 mod builder;
 
 #[cfg(feature = "util")]
-#[cfg_attr(docsrs, doc(cfg(feature = "util")))]
 #[doc(inline)]
 pub use self::builder::ServiceBuilderExt;
 

--- a/tower-http/src/services/mod.rs
+++ b/tower-http/src/services/mod.rs
@@ -7,19 +7,15 @@
 //! [tree]: https://en.wikipedia.org/wiki/Tree_(data_structure)
 
 #[cfg(feature = "redirect")]
-#[cfg_attr(docsrs, doc(cfg(feature = "redirect")))]
 pub mod redirect;
 
 #[cfg(feature = "redirect")]
-#[cfg_attr(docsrs, doc(cfg(feature = "redirect")))]
 #[doc(inline)]
 pub use self::redirect::Redirect;
 
 #[cfg(feature = "fs")]
-#[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
 pub mod fs;
 
 #[cfg(feature = "fs")]
-#[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
 #[doc(inline)]
 pub use self::fs::{ServeDir, ServeFile};


### PR DESCRIPTION
## Motivation

Fixes #253.

## Solution

Make it clear in docs that `ServiceBuilderExt` requires the `util` feature.