### PR TITLE
Properly clone the request for ServeDir's fallback

### DIFF
--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -290,17 +290,17 @@ where
         };
 
         let fallback_and_request = self.fallback.as_mut().map(|fallback| {
-            let mut req = Request::new(body);
-            *req.method_mut() = req.method().clone();
-            *req.uri_mut() = req.uri().clone();
-            *req.headers_mut() = req.headers().clone();
-            *req.extensions_mut() = extensions;
+            let mut fallback_req = Request::new(body);
+            *fallback_req.method_mut() = req.method().clone();
+            *fallback_req.uri_mut() = req.uri().clone();
+            *fallback_req.headers_mut() = req.headers().clone();
+            *fallback_req.extensions_mut() = extensions;
 
             // get the ready fallback and leave a non-ready clone in its place
             let clone = fallback.clone();
             let fallback = std::mem::replace(fallback, clone);
 
-            (fallback, req)
+            (fallback, fallback_req)
         });
 
         let buf_chunk_size = self.buf_chunk_size;

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -585,8 +585,11 @@ async fn last_modified() {
 
 #[tokio::test]
 async fn with_fallback_svc() {
-    async fn fallback<B>(_: Request<B>) -> io::Result<Response<Body>> {
-        Ok(Response::new(Body::from("from fallback")))
+    async fn fallback<B>(req: Request<B>) -> io::Result<Response<Body>> {
+        Ok(Response::new(Body::from(format!(
+            "from fallback {}",
+            req.uri().path()
+        ))))
     }
 
     let svc = ServeDir::new("..").fallback(tower::service_fn(fallback));
@@ -600,7 +603,7 @@ async fn with_fallback_svc() {
     assert_eq!(res.status(), StatusCode::OK);
 
     let body = body_into_text(res.into_body()).await;
-    assert_eq!(body, "from fallback");
+    assert_eq!(body, "from fallback /doesnt-exist");
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

I tried to chain two ServeDir (one being the fallback for the other) and got confused why it could not find files from the second one.
It turns out, the request passed to the fallback service was not cloned properly from the original request.

## Solution

Renamed the fallback request variable name to properly clone the method/uri/headers/extensions from the original request, and not from itself.
I modified the fallback test to include the URI path in the response and check if it matches.
