### PR TITLE
Use clap 3.x instead of structop for example project CLIs

### DIFF
--- a/examples/axum-key-value-store/Cargo.toml
+++ b/examples/axum-key-value-store/Cargo.toml
@@ -8,10 +8,10 @@ license = "MIT"
 
 [dependencies]
 hyper = { version = "0.14.15", features = ["full"] }
-structopt = "0.3.21"
 tokio = { version = "1.2.0", features = ["full"] }
 tower = { version = "0.4.5", features = ["full"] }
 tower-http = { path = "../../tower-http", features = ["full"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 axum = "0.4"
+clap = { version = "3.1.13", features = ["derive"] }

--- a/examples/axum-key-value-store/src/main.rs
+++ b/examples/axum-key-value-store/src/main.rs
@@ -7,13 +7,13 @@ use axum::{
     routing::get,
     BoxError, Router,
 };
+use clap::Parser;
 use std::{
     collections::HashMap,
     net::SocketAddr,
     sync::{Arc, RwLock},
     time::Duration,
 };
-use structopt::StructOpt;
 use tower::ServiceBuilder;
 use tower_http::{
     trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer},
@@ -21,10 +21,10 @@ use tower_http::{
 };
 
 /// Simple key/value store with an HTTP API
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Config {
     /// The port to listen on
-    #[structopt(long, short = "p", default_value = "3000")]
+    #[clap(short = 'p', long, default_value = "3000")]
     port: u16,
 }
 
@@ -39,7 +39,7 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     // Parse command line arguments
-    let config = Config::from_args();
+    let config = Config::parse();
 
     // Run our service
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));

--- a/examples/tonic-key-value-store/Cargo.toml
+++ b/examples/tonic-key-value-store/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 bytes = "1"
 hyper = { version = "0.14.4", features = ["full"] }
 prost = "0.8"
-structopt = "0.3.21"
 tokio = { version = "1.2.0", features = ["full"] }
 futures = "0.3"
 tokio-stream = { version = "0.1", features = ["sync", "net"] }
@@ -19,6 +18,7 @@ tower = { version = "0.4.5", features = ["full"] }
 tower-http = { path = "../../tower-http", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+clap = { version = "3.1.13", features = ["derive"] }
 
 [build-dependencies]
 tonic-build = "0.5"

--- a/examples/tonic-key-value-store/src/main.rs
+++ b/examples/tonic-key-value-store/src/main.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use clap::Parser;
 use futures::StreamExt;
 use hyper::{
     body::HttpBody,
@@ -16,7 +17,6 @@ use std::{
     sync::{Arc, RwLock},
     time::Duration,
 };
-use structopt::StructOpt;
 use tokio::{
     io::AsyncReadExt,
     net::TcpListener,
@@ -42,30 +42,30 @@ mod proto {
 }
 
 /// Simple key/value store with an HTTP API
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Config {
     /// The port to listen on
-    #[structopt(long, short = "p", default_value = "3000")]
+    #[clap(short = 'p', long, default_value = "3000")]
     port: u16,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     command: Command,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 enum Command {
     /// Run the gRPC server
     Server,
     /// Get the value at some key
     Get {
-        #[structopt(long, short = "k")]
+        #[clap(short = 'k', long)]
         key: String,
     },
     /// Set a value at some key.
     ///
     /// The value will be read from stdin.
     Set {
-        #[structopt(long, short = "k")]
+        #[structopt(short = 'k', long)]
         key: String,
     },
     /// Subscribe to a stream of inserted keys
@@ -78,7 +78,7 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     // Parse command line arguments
-    let config = Config::from_args();
+    let config = Config::parse();
 
     // The server address
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));

--- a/examples/warp-key-value-store/Cargo.toml
+++ b/examples/warp-key-value-store/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 
 [dependencies]
 bytes = "1"
+clap = { version = "3.1.13", features = ["derive"] }
 hyper = { version = "0.14.4", features = ["full"] }
-structopt = "0.3.21"
 tokio = { version = "1.2.0", features = ["full"] }
 tower = { version = "0.4.5", features = ["full"] }
 tower-http = { path = "../../tower-http", features = ["full"] }

--- a/examples/warp-key-value-store/src/main.rs
+++ b/examples/warp-key-value-store/src/main.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use clap::Parser;
 use hyper::{
     body::HttpBody,
     header::{self, HeaderValue},
@@ -9,7 +10,6 @@ use std::net::SocketAddr;
 use std::net::TcpListener;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use structopt::StructOpt;
 use tower::{make::Shared, ServiceBuilder};
 use tower_http::{
     add_extension::AddExtensionLayer,
@@ -23,10 +23,10 @@ use warp::{filters, path};
 use warp::{Filter, Rejection, Reply};
 
 /// Simple key/value store with an HTTP API
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Config {
     /// The port to listen on
-    #[structopt(long, short = "p", default_value = "3000")]
+    #[clap(short = 'p', long, default_value = "3000")]
     port: u16,
 }
 
@@ -41,7 +41,7 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     // Parse command line arguments
-    let config = Config::from_args();
+    let config = Config::parse();
 
     // Create a `TcpListener`
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));


### PR DESCRIPTION
This pull request updates the three example projects for axum, tonic, and warp to use clap with the 3.x `derive` feature instead of structop.

Where available, the tests of the example projects were executed. Additionally, I tested the CLI and the example functionality manually and did not notice any unexpected behavior.

## Motivation
Since structop is now integrated into clap it will not receive further development. In the future, developers will likely be more familiar with clap's derive feature.