### PR TITLE
Include `Allow` header for `405 Method Not Allowed` responses

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
-- None.
+- **serve_dir:** Include `Allow` header for `405 Method Not Allowed` responses.
 
 # 0.3.2 (April 29, 2022)
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -21,7 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
-- **serve_dir:** Include `Allow` header for `405 Method Not Allowed` responses.
+- **serve_dir:** Include `Allow` header for `405 Method Not Allowed` responses ([#263])
+
+[#263]: https://github.com/tower-rs/tower-http/pull/263
 
 # 0.3.2 (April 29, 2022)
 

--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -8,7 +8,10 @@ use futures_util::{
     future::{BoxFuture, FutureExt, TryFutureExt},
     ready,
 };
-use http::{header, Request, Response, StatusCode};
+use http::{
+    header::{self, ALLOW},
+    HeaderValue, Request, Response, StatusCode,
+};
 use http_body::{Body, Empty, Full};
 use pin_project_lite::pin_project;
 use std::{
@@ -136,7 +139,10 @@ where
                 }
 
                 ResponseFutureInnerProj::MethodNotAllowed => {
-                    break Poll::Ready(Ok(response_with_status(StatusCode::METHOD_NOT_ALLOWED)));
+                    let mut res = response_with_status(StatusCode::METHOD_NOT_ALLOWED);
+                    res.headers_mut()
+                        .insert(ALLOW, HeaderValue::from_static("GET,HEAD"));
+                    break Poll::Ready(Ok(res));
                 }
             };
 

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -2,6 +2,7 @@ use crate::services::{ServeDir, ServeFile};
 use brotli::BrotliDecompress;
 use bytes::Bytes;
 use flate2::bufread::{DeflateDecoder, GzDecoder};
+use http::header::ALLOW;
 use http::{header, Method, Response};
 use http::{Request, StatusCode};
 use http_body::Body as HttpBody;
@@ -637,4 +638,5 @@ async fn method_not_allowed() {
     let res = svc.oneshot(req).await.unwrap();
 
     assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
+    assert_eq!(res.headers()[ALLOW], "GET,HEAD");
 }


### PR DESCRIPTION
When a server responds with `405 Method Not Allowed` it _must_ include the `Allow` header telling UA which methods are allowed (source [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405)). `ServeDir` didn't do this.