### PR TITLE
Support calling fallback on `405 Method Not Allowed`

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- None.
+- **serve_dir:** Add `ServeDir::call_fallback_on_method_not_allowed` to allow calling the fallback
+  for requests that aren't `GET` or `HEAD`
 
 ## Changed
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 - **serve_dir:** Add `ServeDir::call_fallback_on_method_not_allowed` to allow calling the fallback
-  for requests that aren't `GET` or `HEAD`
+  for requests that aren't `GET` or `HEAD` ([#264])
+
+[#264]: https://github.com/tower-rs/tower-http/pull/264
 
 ## Changed
 

--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -51,12 +51,6 @@ impl<ReqBody, F> ResponseFuture<ReqBody, F> {
             inner: ResponseFutureInner::MethodNotAllowed,
         }
     }
-
-    pub(super) fn fallback(future: BoxFuture<'static, io::Result<Response<ResponseBody>>>) -> Self {
-        Self {
-            inner: ResponseFutureInner::FallbackFuture { future },
-        }
-    }
 }
 
 pin_project! {

--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -249,7 +249,7 @@ impl<F> ServeDir<F> {
 
     /// Customize whether or not to call the fallback for requests that aren't `GET` or `HEAD`.
     ///
-    /// Defaults not calling the fallback and instead returning `405 Method Not Allowed`.
+    /// Defaults to not calling the fallback and instead returning `405 Method Not Allowed`.
     pub fn call_fallback_on_method_not_allowed(mut self, call_fallback: bool) -> Self {
         self.call_fallback_on_method_not_allowed = call_fallback;
         self

--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -63,6 +63,7 @@ pub struct ServeDir<F = DefaultServeDirFallback> {
     // single files
     variant: ServeVariant,
     fallback: Option<F>,
+    call_fallback_on_method_not_allowed: bool,
 }
 
 impl ServeDir<DefaultServeDirFallback> {
@@ -82,6 +83,7 @@ impl ServeDir<DefaultServeDirFallback> {
                 append_index_html_on_directories: true,
             },
             fallback: None,
+            call_fallback_on_method_not_allowed: false,
         }
     }
 
@@ -95,6 +97,7 @@ impl ServeDir<DefaultServeDirFallback> {
             precompressed_variants: None,
             variant: ServeVariant::SingleFile { mime },
             fallback: None,
+            call_fallback_on_method_not_allowed: false,
         }
     }
 }
@@ -210,6 +213,7 @@ impl<F> ServeDir<F> {
             precompressed_variants: self.precompressed_variants,
             variant: self.variant,
             fallback: Some(new_fallback),
+            call_fallback_on_method_not_allowed: self.call_fallback_on_method_not_allowed,
         }
     }
 
@@ -242,6 +246,14 @@ impl<F> ServeDir<F> {
     pub fn not_found_service<F2>(self, new_fallback: F2) -> ServeDir<SetStatus<F2>> {
         self.fallback(SetStatus::new(new_fallback, StatusCode::NOT_FOUND))
     }
+
+    /// Customize whether or not to call the fallback for requests that aren't `GET` or `HEAD`.
+    ///
+    /// Defaults not calling the fallback and instead returning `405 Method Not Allowed`.
+    pub fn call_fallback_on_method_not_allowed(mut self, call_fallback: bool) -> Self {
+        self.call_fallback_on_method_not_allowed = call_fallback;
+        self
+    }
 }
 
 impl<ReqBody, F, FResBody> Service<Request<ReqBody>> for ServeDir<F>
@@ -267,7 +279,15 @@ where
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
         if req.method() != Method::GET && req.method() != Method::HEAD {
-            return ResponseFuture::method_not_allowed();
+            if self.call_fallback_on_method_not_allowed {
+                if let Some(fallback) = &mut self.fallback {
+                    return ResponseFuture {
+                        inner: future::call_fallback(fallback, req),
+                    };
+                }
+            } else {
+                return ResponseFuture::method_not_allowed();
+            }
         }
 
         // `ServeDir` doesn't care about the request body but the fallback might. So move out the

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -638,3 +638,29 @@ async fn method_not_allowed() {
 
     assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
 }
+
+#[tokio::test]
+async fn calling_fallback_on_not_allowed() {
+    async fn fallback<B>(req: Request<B>) -> io::Result<Response<Body>> {
+        Ok(Response::new(Body::from(format!(
+            "from fallback {}",
+            req.uri().path()
+        ))))
+    }
+
+    let svc = ServeDir::new("..")
+        .call_fallback_on_method_not_allowed(true)
+        .fallback(tower::service_fn(fallback));
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/doesnt-exist")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = body_into_text(res.into_body()).await;
+    assert_eq!(body, "from fallback /doesnt-exist");
+}


### PR DESCRIPTION
Previously `ServeDir` fallbacks would only be called if the request file wasn't found, not if it received a non `GET` or `HEAD` request.

However for serving assets at the root in a router it might be useful to delegate all requests to the fallback, regardless of the method. Something like:

```rust
ServeDir::new(".")
    .call_fallback_on_method_not_allowed(true)
    .fallback(Router::new().route("/", ...));
```