### PR TITLE
Also call fallback if `.append_index_html_on_directories(false)`

### DIFF
--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -98,8 +98,12 @@ where
                         break Poll::Ready(Ok(res));
                     }
 
-                    Ok(OpenFileOutput::NotFound) => {
-                        break Poll::Ready(Ok(not_found()));
+                    Ok(OpenFileOutput::FileNotFound) => {
+                        if let Some((mut fallback, request)) = fallback_and_request.take() {
+                            call_fallback(&mut fallback, request)
+                        } else {
+                            break Poll::Ready(Ok(not_found()));
+                        }
                     }
 
                     Ok(OpenFileOutput::PreconditionFailed) => {

--- a/tower-http/src/services/fs/serve_dir/open_file.rs
+++ b/tower-http/src/services/fs/serve_dir/open_file.rs
@@ -19,7 +19,7 @@ use tokio::{fs::File, io::AsyncSeekExt};
 pub(super) enum OpenFileOutput {
     FileOpened(Box<FileOpened>),
     Redirect { location: HeaderValue },
-    NotFound,
+    FileNotFound,
     PreconditionFailed,
     NotModified,
 }
@@ -268,7 +268,7 @@ async fn maybe_redirect_or_append_path(
             path_to_file.push("index.html");
             None
         } else {
-            Some(OpenFileOutput::NotFound)
+            Some(OpenFileOutput::FileNotFound)
         }
     } else {
         None

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -638,3 +638,25 @@ async fn method_not_allowed() {
 
     assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
 }
+
+#[tokio::test]
+async fn with_fallback_svc_and_not_append_index_html_on_directories() {
+    async fn fallback<B>(req: Request<B>) -> io::Result<Response<Body>> {
+        Ok(Response::new(Body::from(format!(
+            "from fallback {}",
+            req.uri().path()
+        ))))
+    }
+
+    let svc = ServeDir::new("..")
+        .append_index_html_on_directories(false)
+        .fallback(tower::service_fn(fallback));
+
+    let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = body_into_text(res.into_body()).await;
+    assert_eq!(body, "from fallback /");
+}


### PR DESCRIPTION
When using `ServeDir::new(...).append_index_html_on_directories(false)` if a directory was requested it would return 404 instead of calling the fallback.

Fixes https://github.com/tower-rs/tower-http/issues/262