### PR TITLE
Add `MakeRequestUuid`

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- **request_id:** Add `MakeRequestUuid` for generating request ids using UUIDs
+- **request_id:** Add `MakeRequestUuid` for generating request ids using UUIDs ([#266])
+
+[#266]: https://github.com/tower-rs/tower-http/pull/266
 
 ## Changed
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- None.
+- **request_id:** Add `MakeRequestUuid` for generating request ids using UUIDs
 
 ## Changed
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -36,6 +36,7 @@ tokio-util = { version = "0.7", optional = true, default_features = false, featu
 tower = { version = "0.4.1", optional = true }
 tracing = { version = "0.1", default_features = false, optional = true }
 httpdate = { version = "1.0", optional = true }
+uuid = { version = "1.0", features = ["v4"], optional = true }
 
 [dev-dependencies]
 bytes = "1"
@@ -47,7 +48,7 @@ once_cell = "1"
 tokio = { version = "1", features = ["full"] }
 tower = { version = "0.4.10", features = ["buffer", "util", "retry", "make", "timeout"] }
 tracing-subscriber = "0.3"
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4"] }
 serde_json = "1.0"
 
 [features]
@@ -85,7 +86,7 @@ map-response-body = []
 metrics = ["tokio/time"]
 propagate-header = []
 redirect = []
-request-id = []
+request-id = ["uuid"]
 sensitive-headers = []
 set-header = []
 set-status = []


### PR DESCRIPTION
Now that [uuid](https://crates.io/crates/uuid) is 1.0 I think its appropriate to have a `MakeRequestId` implementation that uses it.

uuid doesn't have any dependencies by default so imo its fine not to feature gate it.