### PR TITLE
Add `Timeout` middleware

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- Add `Timeout` middleware.
+- Add `Timeout` middleware ([#270])
+
+[#270]: https://github.com/tower-rs/tower-http/pull/270
 
 ## Changed
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- None.
+- Add `Timeout` middleware.
 
 ## Changed
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -71,6 +71,7 @@ full = [
     "sensitive-headers",
     "set-header",
     "set-status",
+    "timeout",
     "trace",
     "util",
 ]
@@ -90,6 +91,7 @@ request-id = ["uuid"]
 sensitive-headers = []
 set-header = []
 set-status = []
+timeout = ["tokio/time"]
 trace = ["tracing"]
 util = ["tower"]
 

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -300,6 +300,9 @@ pub mod catch_panic;
 #[cfg(feature = "set-status")]
 pub mod set_status;
 
+#[cfg(feature = "timeout")]
+pub mod timeout;
+
 pub mod classify;
 pub mod services;
 

--- a/tower-http/src/timeout.rs
+++ b/tower-http/src/timeout.rs
@@ -9,7 +9,7 @@
 //! it changes the error type to [`BoxError`](tower::BoxError). For HTTP services that is rarely
 //! what you want as returning errors will terminate the connection without sending a response.
 //!
-//! Instead this middleware wont change the error type and instead return a `408 Request Timeout`
+//! This middleware won't change the error type and instead return a `408 Request Timeout`
 //! response. That means if your service's error type is [`Infallible`] it will still be
 //! [`Infallible`] after applying this middleware.
 //!

--- a/tower-http/src/timeout.rs
+++ b/tower-http/src/timeout.rs
@@ -1,0 +1,156 @@
+//! Middleware that applies a timeout to requests.
+//!
+//! If the request does not complete within the specified timeout it will be aborted and a `408
+//! Request Timeout` response will be sent.
+//!
+//! # Differences from `tower::timeout`
+//!
+//! tower's [`Timeout`](tower::timeout::Timeout) middleware uses an error to signal timeout, i.e.
+//! it changes the error type to [`BoxError`](tower::BoxError). For HTTP services that is rarely
+//! what you want as returning errors will terminate the connection without sending a response.
+//!
+//! Instead this middleware wont change the error type and instead return a `408 Request Timeout`
+//! response. That means if your service's error type is [`Infallible`] it will still be
+//! [`Infallible`] after applying this middleware.
+//!
+//! # Example
+//!
+//! ```
+//! use http::{Request, Response};
+//! use hyper::Body;
+//! use std::{convert::Infallible, time::Duration};
+//! use tower::ServiceBuilder;
+//! use tower_http::timeout::TimeoutLayer;
+//!
+//! async fn handle(_: Request<Body>) -> Result<Response<Body>, Infallible> {
+//!     // ...
+//!     # Ok(Response::new(Body::empty()))
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let svc = ServiceBuilder::new()
+//!     // Timeout requests after 30 seconds
+//!     .layer(TimeoutLayer::new(Duration::from_secs(30)))
+//!     .service_fn(handle);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [`Infallible`]: std::convert::Infallible
+
+use http::{Request, Response, StatusCode};
+use pin_project_lite::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+use tokio::time::Sleep;
+use tower_layer::Layer;
+use tower_service::Service;
+
+/// Layer that applies the [`Timeout`] middleware which apply a timeout to requests.
+///
+/// See the [module docs](self) for an example.
+#[derive(Debug, Clone, Copy)]
+pub struct TimeoutLayer {
+    timeout: Duration,
+}
+
+impl TimeoutLayer {
+    /// Create a new [`TimeoutLayer`].
+    pub fn new(timeout: Duration) -> Self {
+        TimeoutLayer { timeout }
+    }
+}
+
+impl<S> Layer<S> for TimeoutLayer {
+    type Service = Timeout<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Timeout::new(inner, self.timeout)
+    }
+}
+
+/// Middleware which apply a timeout to requests.
+///
+/// If the request does not complete within the specified timeout it will be aborted and a `408
+/// Request Timeout` response will be sent.
+///
+/// See the [module docs](self) for an example.
+#[derive(Debug, Clone, Copy)]
+pub struct Timeout<S> {
+    inner: S,
+    timeout: Duration,
+}
+
+impl<S> Timeout<S> {
+    /// Create a new [`Timeout`].
+    pub fn new(inner: S, timeout: Duration) -> Self {
+        Self { inner, timeout }
+    }
+
+    define_inner_service_accessors!();
+
+    /// Returns a new [`Layer`] that wraps services with a `Timeout` middleware.
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(timeout: Duration) -> TimeoutLayer {
+        TimeoutLayer::new(timeout)
+    }
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for Timeout<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    ResBody: Default,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let sleep = tokio::time::sleep(self.timeout);
+        ResponseFuture {
+            inner: self.inner.call(req),
+            sleep,
+        }
+    }
+}
+
+pin_project! {
+    /// Response future for [`Timeout`].
+    pub struct ResponseFuture<F> {
+        #[pin]
+        inner: F,
+        #[pin]
+        sleep: Sleep,
+    }
+}
+
+impl<F, B, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<Response<B>, E>>,
+    B: Default,
+{
+    type Output = Result<Response<B>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        if this.sleep.poll(cx).is_ready() {
+            let mut res = Response::new(B::default());
+            *res.status_mut() = StatusCode::REQUEST_TIMEOUT;
+            return Poll::Ready(Ok(res));
+        }
+
+        this.inner.poll(cx)
+    }
+}


### PR DESCRIPTION
`tower::timeout::Timeout` doesn't work well with axum since it changes the error type to `BoxError`. That requires doing this:

```rust
let app = Router::new()
    .route("/", get(|| async {}))
    .layer(
        ServiceBuilder::new()
            .layer(HandleErrorLayer::new(handle_timeout_error))
            .timeout(Duration::from_secs(30))
    );

async fn handle_timeout_error(err: BoxError) -> (StatusCode, String) {
    if err.is::<tower::timeout::error::Elapsed>() {
        (
            StatusCode::REQUEST_TIMEOUT,
            "Request took too long".to_string(),
        )
    } else {
        (
            StatusCode::INTERNAL_SERVER_ERROR,
            format!("Unhandled internal error: {}", err),
        )
    }
}
```

Thats quite a mouthful. With this middleware that becomes:

```rust
let app = Router::new()
    .route("/", get(|| async {}))
    .layer(TimeoutLayer::new(Duration::from_secs(30));
```

This works because it doesn't change the service's error type and thus keeps `Infallible` which axum requires.