### PR TITLE
Add `Gateway` middleware

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,21 +74,20 @@ jobs:
         args: --workspace --all-features
 
   test-msrv:
-    # some examples don't compile on 1.46, so just test tower-http itself
     needs: check
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.51
+        toolchain: 1.54
         profile: minimal
         override: true
     - name: Run tests
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: -p tower-http --all-features
+        args: --workspace --all-features
 
   style:
     needs: check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,6 @@ members = [
   "tower-http",
   "examples/*",
 ]
+
+[patch.crates-io]
+tower-http = { version = "0.3", path = "tower-http" }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The [examples] folder contains various examples of how to use Tower HTTP:
 
 ## Minimum supported Rust version
 
-tower-http's MSRV is 1.51.
+tower-http's MSRV is 1.54.
 
 ## Getting Help
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+avoid-breaking-exported-api = false

--- a/examples/axum-key-value-store/Cargo.toml
+++ b/examples/axum-key-value-store/Cargo.toml
@@ -13,5 +13,5 @@ tower = { version = "0.4.5", features = ["full"] }
 tower-http = { path = "../../tower-http", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
-axum = "0.4"
+axum = "0.5"
 clap = { version = "3.1.13", features = ["derive"] }

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- None.
+- **gateway:** Add `Gateway` middleware ([#274])
+
+[#274]: https://github.com/tower-rs/tower-http/pull/274
 
 ## Changed
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/tower-rs/tower-http"
 homepage = "https://github.com/tower-rs/tower-http"
 categories = ["asynchronous", "network-programming", "web-programming"]
 keywords = ["io", "async", "futures", "service", "http"]
-rust-version = "1.51"
+rust-version = "1.54"
 
 [dependencies]
 bitflags = "1.3.1"

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -17,7 +17,7 @@ bitflags = "1.3.1"
 bytes = "1"
 futures-core = "0.3"
 futures-util = { version = "0.3.14", default_features = false, features = [] }
-http = "0.2.2"
+http = "0.2.7"
 http-body = "0.4.5"
 pin-project-lite = "0.2.7"
 tower-layer = "0.3"
@@ -39,6 +39,7 @@ httpdate = { version = "1.0", optional = true }
 uuid = { version = "1.0", features = ["v4"], optional = true }
 
 [dev-dependencies]
+axum = { version = "0.5", default-features = false }
 bytes = "1"
 flate2 = "1.0"
 brotli = "3"
@@ -62,6 +63,7 @@ full = [
     "decompression-full",
     "follow-redirect",
     "fs",
+    "gateway",
     "limit",
     "map-request-body",
     "map-response-body",
@@ -83,6 +85,7 @@ catch-panic = ["tracing", "futures-util/std"]
 cors = []
 follow-redirect = ["iri-string", "tower/util"]
 fs = ["tokio/fs", "tokio-util/io", "tokio/io-util", "mime_guess", "mime", "percent-encoding", "httpdate", "set-status", "futures-util/alloc"]
+gateway = []
 limit = []
 map-request-body = []
 map-response-body = []

--- a/tower-http/src/compression/future.rs
+++ b/tower-http/src/compression/future.rs
@@ -61,6 +61,9 @@ where
             #[cfg(feature = "compression-br")]
             (_, Encoding::Brotli) => CompressionBody::new(BodyInner::brotli(WrapBody::new(body))),
             #[cfg(feature = "fs")]
+            #[cfg(not(feature = "compression-gzip"))]
+            #[cfg(not(feature = "compression-deflate"))]
+            #[cfg(not(feature = "compression-br"))]
             (true, _) => {
                 // This should never happen because the `AcceptEncoding` struct which is used to determine
                 // `self.encoding` will only enable the different compression algorithms if the

--- a/tower-http/src/compression/future.rs
+++ b/tower-http/src/compression/future.rs
@@ -63,7 +63,7 @@ where
             #[cfg(feature = "fs")]
             (true, _) => {
                 // This should never happen because the `AcceptEncoding` struct which is used to determine
-                // `self.encoding` will only enable the different compression algorightms if the
+                // `self.encoding` will only enable the different compression algorithms if the
                 // corresponding crate feature has been enabled. This means
                 // Encoding::[Gzip|Brotli|Deflate] should be impossible at this point without the
                 // features enabled.

--- a/tower-http/src/content_encoding.rs
+++ b/tower-http/src/content_encoding.rs
@@ -136,7 +136,7 @@ impl QValue {
         let mut c = s.chars();
         // Parse "q=" (case-insensitively).
         match c.next() {
-            Some('q') | Some('Q') => (),
+            Some('q' | 'Q') => (),
             _ => return None,
         };
         match c.next() {
@@ -215,11 +215,7 @@ pub(crate) fn encodings(
             };
 
             let qval = if let Some(qval) = v.next() {
-                if let Some(qval) = QValue::parse(qval.trim()) {
-                    qval
-                } else {
-                    return None;
-                }
+                QValue::parse(qval.trim())?
             } else {
                 QValue::one()
             };

--- a/tower-http/src/gateway/connection_info.rs
+++ b/tower-http/src/gateway/connection_info.rs
@@ -1,0 +1,799 @@
+//! Types and implementations for [`ConnectionInfo`].
+
+use std::{
+    borrow::{Borrow, Cow},
+    convert::TryFrom,
+    fmt,
+    net::{IpAddr, SocketAddr},
+};
+
+use http::{uri::Scheme, HeaderValue};
+
+/// Information about the source of an incoming request.
+///
+/// If gateway is not configured to read a `ConnectionInfo` from the request, or the
+/// [`peer_ip`](Self::peer_ip) field is [`None`], the [`Forwarded`][] header will specify
+/// `for=unknown`.
+///
+/// This type can store both borrowed and owned data. Typically the data will be borrowed from
+/// request extensions, but it may also return owned data in the case where the data is being
+/// generated from within a [`Gateway::with_connection_info_fn`] handler.
+///
+/// # Implementation notes
+///
+/// The common way to produce this type is through an [`Into<ConnectionInfo>`] impl (or the dual
+/// [`From`] impl) on a value that is stored in the request extensions. A few basic implementations
+/// are already provided.
+///
+/// When implementing this on a new type, you will typically want to implement it for `&T`. This is
+/// because it will typically be called on borrowed data. However if your type is [`Copy`] then it
+/// can implement [`Into<ConnectionInfo>`] directly and an [existing blanket impl][blanket] will
+/// provide the expected `&T` impl.
+///
+/// ## Examples
+///
+/// Non-[`Copy`] type:
+///
+/// ```rust
+/// use tower_http::gateway::ConnectionInfo;
+///
+/// struct SocketInfo {
+///     ip: std::net::IpAddr,
+///     scheme: http::uri::Scheme,
+/// }
+///
+/// impl<'a> From<&'a SocketInfo> for ConnectionInfo<'a> {
+///     fn from(info: &'a SocketInfo) -> Self {
+///         ConnectionInfo::new()
+///             .peer_ip(Some(info.ip))
+///             .scheme(Some(&info.scheme))
+///     }
+/// }
+/// ```
+///
+/// [`Copy`] type:
+///
+/// ```rust
+/// use tower_http::gateway::ConnectionInfo;
+///
+/// #[derive(Copy, Clone)]
+/// struct SocketInfo {
+///     ip: std::net::IpAddr,
+/// }
+///
+/// impl From<SocketInfo> for ConnectionInfo<'_> {
+///     fn from(info: SocketInfo) -> Self {
+///         info.ip.into()
+///     }
+/// }
+///
+/// let _ = ConnectionInfo::from(&SocketInfo { ip: std::net::Ipv4Addr::LOCALHOST.into() });
+/// ```
+///
+/// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+/// [`Gateway::with_connection_info_fn`]: fn@super::Gateway::with_connection_info_fn
+/// [blanket]: #impl-From%3C%26%27_%20C%3E
+#[derive(Clone, Debug, Default)]
+pub struct ConnectionInfo<'a> {
+    /// The peer IP address for the connection, a generated token obfuscating the peer IP address,
+    /// or `None` if the IP address is unknown.
+    ///
+    /// This is used by the `for` directive of the [`Forwarded`][] header along with
+    /// [`self.peer_port`](#structfield.peer_port), and by the [`X-Forwarded-For`][] header if it
+    /// is [`NodeIdentifier::Value`].
+    ///
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    /// [`X-Forwarded-For`]:
+    ///     https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+    pub peer_ip: Option<NodeIdentifier<'a, IpAddr>>,
+    /// The port number associated with the peer IP address for the connection, a generated token
+    /// obfuscating the peer port, or `None` if the port number is unknown or irrelevant.
+    ///
+    /// This is used by the `for` directive of the [`Forwarded`][] header along with
+    /// [`self.peer_ip`](#structfield.peer_ip).
+    ///
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    pub peer_port: Option<NodeIdentifier<'a, u16>>,
+
+    /// The local IP address for the connection, a generated token obfuscating the local IP
+    /// address, or `None` if the IP address is unknown or irrelevant.
+    ///
+    /// This is used by the `by` directive of the [`Forwarded`][] header along with
+    /// [`self.local_port`](#structfield.local_port).
+    ///
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    pub local_ip: Option<NodeIdentifier<'a, IpAddr>>,
+    /// The port number associated with the local IP address for the connection, a generated token
+    /// obfuscating the local port, or `None` if the port number is unknown or irrelevant.
+    ///
+    /// This is used by the `by` directive of the [`Forwarded`][] header along with
+    /// [`self.local_ip`](#structfield.local_ip).
+    ///
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    pub local_port: Option<NodeIdentifier<'a, u16>>,
+
+    /// The scheme for the connection, typically `http` or `https`.
+    pub scheme: Option<Cow<'a, Scheme>>,
+
+    /// The [`received-by`][received-by] portion of the [`Via`][] header.
+    ///
+    /// If [`Some`], this value will be used to construct the [`Via`][] header. If [`None`],
+    /// [`self.local_ip`][] and [`self.local_port`][] will be used instead. If [`self.local_ip`][]
+    /// is also [`None`] then the [`Via`][] header will be left unmodified.
+    ///
+    /// This field, if set, must match the ABNF syntax
+    /// <code>[received-by][] [ [RWS][] [comment][] ]</code> as specified by the [`Via`][] header.
+    /// This syntax is not validated by this module, but a failure to match this syntax this may
+    /// cause downstream issues with the forwarded request.
+    ///
+    /// [`Via`]: https://httpwg.org/specs/rfc7230.html#header.via "RFC 7230, Section 5.7.1. Via"
+    /// [`self.local_ip`]: #structfield.local_ip
+    /// [`self.local_port`]: #structfield.local_port
+    /// [received-by]: https://httpwg.org/specs/rfc7230.html#header.via
+    /// [RWS]: https://httpwg.org/specs/rfc7230.html#rule.RWS
+    /// [comment]: https://httpwg.org/specs/rfc7230.html#rule.comment
+    pub via_received_by: Option<Cow<'a, HeaderValue>>,
+
+    /// The [`received-protocol`][] portion of the [`Via`][] header.
+    ///
+    /// If [`Some`], this value will be used to construct the [`Via`][] header. If [`None`], the
+    /// protocol portion of the constructed [`Via`][] header (if any) will be derived from the
+    /// request's [`http::Version`].
+    ///
+    /// This field, if set, must match the ABNF syntax
+    /// <code>[ [protocol-name][] &quot;/&quot; ] [protocol-version][]</code> as specified by the
+    /// [`Via`][] header. This syntax is not validated by this module, but a failure to match this
+    /// syntax this may cause downstream issues with the forwarded request.
+    ///
+    /// [`received-protocol`]: https://httpwg.org/specs/rfc7230.html#header.via
+    /// [`Via`]: https://httpwg.org/specs/rfc7230.html#header.via "RFC 7230, Section 5.7.1. Via"
+    /// [protocol-name]: https://httpwg.org/specs/rfc7230.html#header.upgrade
+    /// [protocol-version]: https://httpwg.org/specs/rfc7230.html#header.upgrade
+    pub via_protocol: Option<Cow<'a, HeaderValue>>,
+}
+
+impl<'a> ConnectionInfo<'a> {
+    /// Returns a new `ConnectionInfo`.
+    ///
+    /// All fields are [`None`].
+    pub const fn new() -> Self {
+        Self {
+            peer_ip: None,
+            peer_port: None,
+            local_ip: None,
+            local_port: None,
+            scheme: None,
+            via_received_by: None,
+            via_protocol: None,
+        }
+    }
+
+    /// Sets the peer node identifier (IP address or generated token).
+    ///
+    /// This corresponds to the `for` directive in the [`Forwarded`][] header along with
+    /// [`self.peer_port`](Self::peer_port), or the value of the [`X-Forwarded-For`][] header.
+    ///
+    /// `ip` may be an IP address or an obfuscated identifier. See [`ObfuscatedIdentifier`] for
+    /// details on the identifier format. If an [`ObfuscatedIdentifier`] is used then the
+    /// [`X-Forwarded-For`][] header will not be set or modified.
+    ///
+    /// If [`None`] (the default) the [`Forwarded`][] header will specify `for=unknown`.
+    ///
+    /// Also see [`obfuscated_peer_ip`](Self::obfuscated_peer_ip) to work around generic inference
+    /// issues caused when trying to call e.g. `peer_ip(Some(token.try_into()?))`.
+    ///
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    /// [`X-Forwarded-For`]:
+    ///     https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+    pub fn peer_ip(self, ip: Option<impl Into<NodeIdentifier<'a, IpAddr>>>) -> Self {
+        Self {
+            peer_ip: ip.map(Into::into),
+            ..self
+        }
+    }
+
+    /// Ssets the peer node identifier to a generated token.
+    ///
+    /// This corresponds to the `for` directive in the [`Forwarded`][] header along with
+    /// [`self.peer_port`](Self::peer_port), or the value of the [`X-Forwarded-For`][] header.
+    ///
+    /// This is equivalent to calling [`peer_ip`](Self::peer_ip) with the results of
+    /// `ip.try_into()` but works around generic inference issues. Note that calling
+    /// `obfuscated_peer_ip` with [`None`] will clear any previously-set
+    /// [`peer_ip`](Self::peer_ip).
+    ///
+    /// See [`peer_ip`](Self::peer_ip) for more details.
+    ///
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    /// [`X-Forwarded-For`]:
+    ///     https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+    pub fn obfuscated_peer_ip(self, ip: Option<ObfuscatedIdentifier<'a>>) -> Self {
+        self.peer_ip(ip)
+    }
+
+    /// Sets the peer port identifier (port number or generated token).
+    ///
+    /// This corresponds to the `for` directive in the [`Forwarded`][] header along with
+    /// [`self.peer_ip`](Self::peer_ip).
+    ///
+    /// `port` may be a port number or an obfuscated identifier. See [`ObfuscatedIdentifier`] for
+    /// details on the identifier format.
+    ///
+    /// Also see [`obfuscated_peer_port`](Self::obfuscated_peer_port) to work around generic
+    /// inference issues caused when trying to call e.g. `peer_port(Some(token.try_into()?))`.
+    ///
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    pub fn peer_port(self, port: Option<impl Into<NodeIdentifier<'a, u16>>>) -> Self {
+        Self {
+            peer_port: port.map(Into::into),
+            ..self
+        }
+    }
+
+    /// Sets the peer port identifier to a generated token.
+    ///
+    /// This corresponds to the `for` directive in the [`Forwarded`][] header along with
+    /// [`self.peer_ip`](Self::peer_ip).
+    ///
+    /// This is equivalent to calling [`peer_port`](Self::peer_port) with the results of
+    /// `port.try_into()` but works around generic inference issues. Note that calling
+    /// `obfuscated_peer_port` with [`None`] will clear any previously-set
+    /// [`peer_port`](Self::peer_port).
+    ///
+    /// See [`peer_port`](Self::peer_port) for more details.
+    ///
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    pub fn obfuscated_peer_port(self, port: Option<ObfuscatedIdentifier<'a>>) -> Self {
+        self.peer_port(port)
+    }
+
+    /// Sets the peer node and port identifiers to an IP address and port.
+    ///
+    /// This correponds to the `for` directive in the [`Forwarded`][] header.
+    ///
+    /// This is equivalent to calling both [`peer_ip`](Self::peer_ip) and
+    /// [`peer_port`](Self::peer_port) using the IP and port from the [`SocketAddr`].
+    ///
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    pub fn peer_addr(self, addr: Option<SocketAddr>) -> Self {
+        self.peer_ip(addr.map(|a| a.ip()))
+            .peer_port(addr.map(|a| a.port()))
+    }
+
+    /// Sets the local interface (IP address or generated token).
+    ///
+    /// This corresponds to the `by` directive in the [`Forwarded`][] header along with
+    /// [`self.local_port`](Self::local_port).
+    ///
+    /// `ip` is the interface at which the request came into the proxy server. This may be an IP
+    /// address or a obfuscated identifier. See [`ObfuscatedIdentifier`] for details on the
+    /// identifier format.
+    ///
+    /// If `local_ip` is [`None`] but [`local_port`](Self::local_port) is [`Some`] the
+    /// [`Forwarded`][] header will specify `by="unknown:<port>"`. If both are [`None`] the `by`
+    /// directive will be omitted.
+    ///
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    pub fn local_ip(self, ip: Option<impl Into<NodeIdentifier<'a, IpAddr>>>) -> Self {
+        Self {
+            local_ip: ip.map(Into::into),
+            ..self
+        }
+    }
+
+    /// Ssets the local interface to a generated token.
+    ///
+    /// This corresponds to the `by` directive in the [`Forwarded`][] header along with
+    /// [`self.local_port`](Self::local_port).
+    ///
+    /// This is equivalent to calling [`local_ip`](Self::local_ip) with the results of
+    /// `ip.try_into()` but works around generic inference issues. Note that calling
+    /// `obfuscated_local_ip` with [`None`] will clear any previously-set
+    /// [`local_ip`](Self::local_ip).
+    ///
+    /// See [`local_ip`](Self::local_ip) for more details.
+    ///
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    pub fn obfuscated_local_ip(self, ip: Option<ObfuscatedIdentifier<'a>>) -> Self {
+        self.local_ip(ip)
+    }
+
+    /// Sets the local port identifier (port number or generated token).
+    ///
+    /// This corresponds to the `by` directive in the [`Forwarded`][] header along with
+    /// [`self.local_ip`](Self::local_ip).
+    ///
+    /// `port` is the port for the interface at which the request came into the proxy server. This
+    /// may be a port number or an obfuscated identifier. See [`ObfuscatedIdentifier`] for details
+    /// on the identifier format.
+    ///
+    /// If [`local_ip`](Self::local_ip) is [`None`] but `local_port` is [`Some`] the
+    /// [`Forwarded`][] header will specify `by="unknown:<port>"`. If both are [`None`] the `by`
+    /// directive will be omitted.
+    ///
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    pub fn local_port(self, port: Option<impl Into<NodeIdentifier<'a, u16>>>) -> Self {
+        Self {
+            local_port: port.map(Into::into),
+            ..self
+        }
+    }
+
+    /// Sets the local port identifier to a generated token.
+    ///
+    /// This corresponds to the `by` directive in the [`Forwarded`][] header along with
+    /// [`self.local_ip`](Self::local_ip).
+    ///
+    /// This is equivalent to calling [`local_port`](Self::local_port) with the results of
+    /// `port.try_into()` but works around generic inference issues. Note that calling
+    /// `obfuscated_local_port` with [`None`] will clear any previously-set
+    /// [`local_port`](Self::local_port).
+    ///
+    /// See [`local_port`](Self::local_port) for more details.
+    ///
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    pub fn obfuscated_local_port(self, port: Option<ObfuscatedIdentifier<'a>>) -> Self {
+        self.local_port(port)
+    }
+
+    /// Sets the local node and port identifiers to an IP address and port.
+    ///
+    /// This correponds to the `by` directive in the [`Forwarded`][] header.
+    ///
+    /// This is equivalent to calling both [`local_ip`](Self::local_ip) and
+    /// [`local_port`](Self::local_port) using the IP and port from the [`SocketAddr`].
+    ///
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    pub fn local_addr(self, addr: Option<SocketAddr>) -> Self {
+        self.local_ip(addr.map(|a| a.ip()))
+            .local_port(addr.map(|a| a.port()))
+    }
+
+    /// Sets the protocol scheme used by the client connection.
+    ///
+    /// This corresponds to the `proto` directive in the [`Forwarded`][] header, or the value of
+    /// the [`X-Forwarded-Proto`][] header.
+    ///
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    /// [`X-Forwarded-Proto`]:
+    ///     https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
+    pub fn scheme(self, scheme: Option<impl IntoCow<'a, Scheme>>) -> Self {
+        Self {
+            scheme: scheme.map(IntoCow::into_cow),
+            ..self
+        }
+    }
+
+    /// Sets the `received-by` portion of the [`Via`][] header.
+    ///
+    /// If [`Some`], this value will be used to construct the [`Via`][] header. If [`None`],
+    /// [`self.local_ip`][] and [`self.local_port`][] will be used instead. If [`self.local_ip`][]
+    /// is also [`None`] then the [`Via`][] header will be left unmodified.
+    ///
+    /// This value, if set, must match the ABNF syntax
+    /// <code>[received-by][] [ [RWS][] [comment][] ]</code> as specified by the [`Via`][] header.
+    /// This syntax is not validated by this module, but a failure to match this syntax this may
+    /// cause downstream issues with the forwarded request.
+    ///
+    /// [`Via`]: https://httpwg.org/specs/rfc7230.html#header.via "RFC 7230, Section 5.7.1. Via"
+    /// [`self.local_ip`]: fn@Self::local_ip
+    /// [`self.local_port`]: fn@Self::local_port
+    /// [received-by]: https://httpwg.org/specs/rfc7230.html#header.via
+    /// [RWS]: https://httpwg.org/specs/rfc7230.html#rule.RWS
+    /// [comment]: https://httpwg.org/specs/rfc7230.html#rule.comment
+    pub fn via_received_by(self, via_received_by: Option<impl IntoCow<'a, HeaderValue>>) -> Self {
+        Self {
+            via_received_by: via_received_by.map(IntoCow::into_cow),
+            ..self
+        }
+    }
+
+    /// Sets the [`received-protocol`][] portion of the [`Via`][] header.
+    ///
+    /// If [`Some`], this value will be used to construct the [`Via`][] header. If [`None`], the
+    /// protocol portion of the constructed [`Via`][] header (if any) will be derived from the
+    /// request's [`http::Version`].
+    ///
+    /// This value, if set, must match the ABNF syntax
+    /// <code>[ [protocol-name][] &quot;/&quot; ] [protocol-version][]</code> as specified by the
+    /// [`Via`][] header. This syntax is not validated by this module, but a failure to match this
+    /// syntax this may cause downstream issues with the forwarded request.
+    ///
+    /// [`received-protocol`]: https://httpwg.org/specs/rfc7230.html#header.via
+    /// [`Via`]: https://httpwg.org/specs/rfc7230.html#header.via "RFC 7230, Section 5.7.1. Via"
+    /// [protocol-name]: https://httpwg.org/specs/rfc7230.html#header.upgrade
+    /// [protocol-version]: https://httpwg.org/specs/rfc7230.html#header.upgrade
+    pub fn via_protocol(self, via_protocol: Option<impl IntoCow<'a, HeaderValue>>) -> Self {
+        Self {
+            via_protocol: via_protocol.map(IntoCow::into_cow),
+            ..self
+        }
+    }
+}
+
+impl From<SocketAddr> for ConnectionInfo<'_> {
+    /// Converts from [`SocketAddr`] to `ConnectionInfo`.
+    ///
+    /// The resulting `ConnectionInfo` sets its [`peer_ip`](ConnectionInfo::peer_ip) and
+    /// [`peer_port`](ConnectionInfo::peer_port) from the `SocketAddr`. Convert `addr.ip()` instead
+    /// if you don't want the peer port set.
+    ///
+    /// This is equivalent to
+    /// `ConnectionInfo::new().peer_ip(Some(addr.ip())).peer_port(Some(addr.port()))`.
+    fn from(addr: SocketAddr) -> Self {
+        Self::new()
+            .peer_ip(Some(addr.ip()))
+            .peer_port(Some(addr.port()))
+    }
+}
+
+impl From<IpAddr> for ConnectionInfo<'_> {
+    /// Converts from [`IpAddr`] to `ConnectionInfo`.
+    ///
+    /// The resulting `ConnctionInfo` sets its [`peer_ip`](ConnectionInfo::peer_ip) from the
+    /// `IpAddr`.
+    ///
+    /// This is equivalent to `ConnectionInfo::new().peer_ip(Some(addr))`.
+    fn from(addr: IpAddr) -> Self {
+        Self::new().peer_ip(Some(addr))
+    }
+}
+
+impl From<()> for ConnectionInfo<'_> {
+    fn from(_: ()) -> Self {
+        Self::new()
+    }
+}
+
+impl<'a, C: Copy> From<&C> for ConnectionInfo<'a>
+where
+    C: Into<ConnectionInfo<'a>>,
+{
+    fn from(c: &C) -> Self {
+        (*c).into()
+    }
+}
+
+impl<'a, C> From<Option<C>> for ConnectionInfo<'a>
+where
+    C: Into<ConnectionInfo<'a>>,
+{
+    fn from(c: Option<C>) -> Self {
+        c.map(Into::into).unwrap_or_default()
+    }
+}
+
+impl<'a, 'b: 'a> From<&'a ConnectionInfo<'b>> for ConnectionInfo<'a> {
+    fn from(info: &'a ConnectionInfo<'b>) -> Self {
+        Self {
+            peer_ip: info.peer_ip.as_ref().map(Into::into),
+            peer_port: info.peer_port.as_ref().map(Into::into),
+            local_ip: info.local_ip.as_ref().map(Into::into),
+            local_port: info.local_port.as_ref().map(Into::into),
+            scheme: info.scheme.as_ref().map(IntoCow::into_cow),
+            via_received_by: info.via_received_by.as_ref().map(IntoCow::into_cow),
+            via_protocol: info.via_protocol.as_ref().map(IntoCow::into_cow),
+        }
+    }
+}
+
+/// An obfuscated identifier for use with [`ConnectionInfo`].
+///
+/// This type represents an obfuscated node identifier (name/address or port) for use with the
+/// [`Forwarded`][] header. It guarantees that the contained string matches the ABNF syntax:
+///
+/// ```abnf
+/// obfnode = "_" 1*(ALPHA / DIGIT / "." / "_" / "-")
+/// ```
+///
+/// See [RFC 7239 §6 Node Identifiers][RFC7239§6] for more information.
+///
+/// [RFC7239§6]: https://www.rfc-editor.org/rfc/rfc7239#section-6 "RFC 7239, Section 6. Node
+///     Identifiers"
+/// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObfuscatedIdentifier<'a> {
+    inner: Cow<'a, str>,
+}
+
+impl<'a> ObfuscatedIdentifier<'a> {
+    /// Wraps a value in `ObfuscatedIdentifier`, or returns [`Err`] if the value doesn't match the
+    /// required ABNF syntax.
+    ///
+    /// The value must match the ABNF syntax:
+    ///
+    /// ```abnf
+    /// obfnode = "_" 1*(ALPHA / DIGIT / "." / "_" / "-")
+    /// ```
+    ///
+    /// See [RFC 7239 §6 Node Identifiers][RFC7239§6] for more information.
+    ///
+    /// [RFC7239§6]: https://www.rfc-editor.org/rfc/rfc7239#section-6
+    pub fn try_from<T: Into<Cow<'a, str>>>(inner: T) -> Result<Self, InvalidObfuscatedIdentifier> {
+        let inner = inner.into();
+        let mut iter = inner.as_ref().bytes();
+        (iter.next() == Some(b'_')
+            && iter.len() > 0 // is_empty is still experimental
+            && iter.all(|b| matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'-')))
+        .then(|| Self { inner })
+        .ok_or(InvalidObfuscatedIdentifier { _private: () })
+    }
+
+    /// Returns a string slice representing the identifier.
+    pub fn as_str(&self) -> &str {
+        self.inner.as_ref()
+    }
+}
+
+impl std::ops::Deref for ObfuscatedIdentifier<'_> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.inner
+    }
+}
+
+impl AsRef<str> for ObfuscatedIdentifier<'_> {
+    fn as_ref(&self) -> &str {
+        self.inner.as_ref()
+    }
+}
+
+impl TryFrom<String> for ObfuscatedIdentifier<'_> {
+    type Error = InvalidObfuscatedIdentifier;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::try_from(s)
+    }
+}
+
+impl<'a> TryFrom<&'a String> for ObfuscatedIdentifier<'a> {
+    type Error = InvalidObfuscatedIdentifier;
+
+    fn try_from(s: &'a String) -> Result<Self, Self::Error> {
+        Self::try_from(s)
+    }
+}
+
+impl<'a> TryFrom<&'a str> for ObfuscatedIdentifier<'a> {
+    type Error = InvalidObfuscatedIdentifier;
+
+    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
+        Self::try_from(s)
+    }
+}
+
+impl<'a> TryFrom<Cow<'a, str>> for ObfuscatedIdentifier<'a> {
+    type Error = InvalidObfuscatedIdentifier;
+
+    fn try_from(cow: Cow<'a, str>) -> Result<Self, Self::Error> {
+        Self::try_from(cow)
+    }
+}
+
+impl<'a> From<&'a ObfuscatedIdentifier<'_>> for ObfuscatedIdentifier<'a> {
+    fn from(ident: &'a ObfuscatedIdentifier<'_>) -> Self {
+        ObfuscatedIdentifier {
+            inner: ident.inner.as_ref().into(),
+        }
+    }
+}
+
+impl fmt::Debug for ObfuscatedIdentifier<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.inner, f)
+    }
+}
+
+impl fmt::Display for ObfuscatedIdentifier<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, f)
+    }
+}
+
+/// A possible error when converting an [`ObfuscatedIdentifier`] from an underlying type.
+///
+/// This error is returned when the value being converted into [`ObfuscatedIdentifier`] does not
+/// match the documented ABNF syntax. See [`ObfuscatedIdentifier`] for more details.
+pub struct InvalidObfuscatedIdentifier {
+    _private: (),
+}
+
+impl fmt::Debug for InvalidObfuscatedIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InvalidObfuscatedIdentifier").finish()
+    }
+}
+
+impl fmt::Display for InvalidObfuscatedIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("failed to parse obfuscated identifier")
+    }
+}
+
+impl std::error::Error for InvalidObfuscatedIdentifier {}
+
+/// Helper trait used by [`ConnectionInfo`] for types that can convert to [`Cow<'a, B>`](Cow).
+///
+/// This is a workaround for the fact that [`Cow<'a, B>`](Cow) does not implement [`From<B>`] or
+/// [`From<&'a B>`](From) for arbitrary <code>B: [Clone]</code> types.
+pub trait IntoCow<'a, B: ?Sized + 'a>
+where
+    B: ToOwned,
+{
+    /// Performs the conversion.
+    fn into_cow(self) -> Cow<'a, B>;
+}
+
+impl<'a, B: ?Sized + 'a> IntoCow<'a, B> for &'a B
+where
+    B: ToOwned,
+{
+    fn into_cow(self) -> Cow<'a, B> {
+        Cow::Borrowed(self)
+    }
+}
+
+// This impl must be expressed in terms of Clone instead of being implemented for <B as
+// ToOwned>::Owned, as the existence `&_: Clone` would make a `<B as ToOwned>::Owned` impl conflict
+// with the above `&'a B` impl.
+impl<'a, B: Clone + 'a> IntoCow<'a, B> for B {
+    fn into_cow(self) -> Cow<'a, B> {
+        Cow::Owned(self)
+    }
+}
+
+impl<'a, 'b: 'a, B: ToOwned> IntoCow<'a, B> for &'a Cow<'b, B> {
+    /// Reborrows the [`Cow<'b, B>`] into [`Cow::Borrowed`].
+    fn into_cow(self) -> Cow<'a, B> {
+        match *self {
+            Cow::Borrowed(b) => Cow::Borrowed(b),
+            Cow::Owned(ref o) => Cow::Borrowed(o.borrow()),
+        }
+    }
+}
+
+/// A possibly-obfuscated node identifier.
+///
+/// This represents an IP address or port, or a generated token that obfuscates the real address or
+/// port.
+///
+/// This is used by [`ConnectionInfo`] and the [`Forwarded`][] header.
+///
+/// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum NodeIdentifier<'a, T> {
+    /// An un-obfuscated IP address or port.
+    Value(T),
+    /// A generated token obfuscating the real address or port.
+    Obfuscated(ObfuscatedIdentifier<'a>),
+}
+
+impl<'a, T> NodeIdentifier<'a, T> {
+    /// Converts from `NodeIdentifier<T>` to [`Option<T>`].
+    ///
+    /// Converts `self` into an [`Option<T>`], consuming `self`, and discarding the obfuscated
+    /// identifier, if any.
+    pub fn exposed(self) -> Option<T> {
+        match self {
+            Self::Value(value) => Some(value),
+            Self::Obfuscated(_) => None,
+        }
+    }
+
+    /// Converts from `NodeIdentifier<_>` to [`Option<ObfuscatedIdentifier>`].
+    ///
+    /// Converts `self` into an [`Option<ObfuscatedIdentifier>`], consuming `self`, and discarding
+    /// the un-obfuscated IP address or port, if any.
+    pub fn obfuscated(self) -> Option<ObfuscatedIdentifier<'a>> {
+        match self {
+            Self::Value(_) => None,
+            Self::Obfuscated(obf) => Some(obf),
+        }
+    }
+
+    /// Converts from `&NodeIdentifier<T>` to `NodeIdentifier<&T>`.
+    ///
+    /// Produces a new `NodeIdentifier`, containing a reference into the original, leaving the
+    /// original in place.
+    pub fn as_ref(&self) -> NodeIdentifier<&T> {
+        match self {
+            Self::Value(val) => NodeIdentifier::Value(val),
+            Self::Obfuscated(obf) => NodeIdentifier::Obfuscated(obf.into()),
+        }
+    }
+
+    /// MAps a `NodeIdentifier<'a, T>` to `NodeIdentifier<'a, U>` by applying a function to a
+    /// contained value.
+    pub fn map_exposed<U, F>(self, f: F) -> NodeIdentifier<'a, U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        match self {
+            Self::Value(val) => NodeIdentifier::Value(f(val)),
+            Self::Obfuscated(obf) => NodeIdentifier::Obfuscated(obf),
+        }
+    }
+}
+
+impl<'a, T: Copy> NodeIdentifier<'a, &'_ T> {
+    /// Maps a `NodeIdentifier<'a, &T>` to a `NodeIdentifier<'a, T>` by copying the contained
+    /// value.
+    pub fn copied(self) -> NodeIdentifier<'a, T> {
+        self.map_exposed(|&x| x)
+    }
+}
+
+impl<T: Into<IpAddr>> From<T> for NodeIdentifier<'_, IpAddr> {
+    fn from(value: T) -> Self {
+        NodeIdentifier::Value(value.into())
+    }
+}
+
+impl From<u16> for NodeIdentifier<'_, u16> {
+    fn from(port: u16) -> Self {
+        NodeIdentifier::Value(port)
+    }
+}
+
+impl<'a, T> From<ObfuscatedIdentifier<'a>> for NodeIdentifier<'a, T> {
+    fn from(obf: ObfuscatedIdentifier<'a>) -> Self {
+        NodeIdentifier::Obfuscated(obf)
+    }
+}
+
+impl<'a, T> From<&'a ObfuscatedIdentifier<'_>> for NodeIdentifier<'a, T> {
+    fn from(obf: &'a ObfuscatedIdentifier<'_>) -> Self {
+        NodeIdentifier::Obfuscated(obf.into())
+    }
+}
+
+impl<'a, T: Copy> From<&'a NodeIdentifier<'_, T>> for NodeIdentifier<'a, T> {
+    fn from(maybe: &'a NodeIdentifier<'_, T>) -> Self {
+        match maybe {
+            NodeIdentifier::Value(val) => NodeIdentifier::Value(*val),
+            NodeIdentifier::Obfuscated(obf) => NodeIdentifier::Obfuscated(obf.into()),
+        }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for NodeIdentifier<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Value(x) => fmt::Debug::fmt(x, f),
+            Self::Obfuscated(x) => fmt::Debug::fmt(x, f),
+        }
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for NodeIdentifier<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Value(x) => fmt::Display::fmt(x, f),
+            Self::Obfuscated(x) => fmt::Display::fmt(x, f),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identifier_parsing() {
+        assert!(ObfuscatedIdentifier::try_from("").is_err());
+        assert!(ObfuscatedIdentifier::try_from("_").is_err());
+        assert!(ObfuscatedIdentifier::try_from("a").is_err());
+        assert!(ObfuscatedIdentifier::try_from("_a").is_ok());
+        assert!(ObfuscatedIdentifier::try_from("_Z").is_ok());
+        assert!(ObfuscatedIdentifier::try_from("_1").is_ok());
+        assert!(ObfuscatedIdentifier::try_from("__").is_ok());
+        assert!(ObfuscatedIdentifier::try_from("_-").is_ok());
+        assert!(ObfuscatedIdentifier::try_from("unknown").is_err());
+        assert!(ObfuscatedIdentifier::try_from("_hidden").is_ok());
+        assert!(ObfuscatedIdentifier::try_from("_1234").is_ok());
+        assert!(ObfuscatedIdentifier::try_from("_a.b-c_42").is_ok());
+        assert!(ObfuscatedIdentifier::try_from("_a b").is_err());
+        assert!(ObfuscatedIdentifier::try_from("_a b").is_err());
+    }
+}

--- a/tower-http/src/gateway/mod.rs
+++ b/tower-http/src/gateway/mod.rs
@@ -1,0 +1,1045 @@
+//! Middleware that implements an HTTP gateway / reverse proxy.
+//!
+//! [`Gateway`] implements the logic of an HTTP gateway / reverse proxy, modifying incoming request
+//! URLs and headers and outgoing response headers. It defers to an underlying service (such as
+//! [`hyper::Client`]) for the actual transport to the proxied server.
+//!
+//! # Example
+//!
+//! This can be mounted on [`axum::Router`] using [`hyper::Client`] as its transport:
+//!
+//! ```rust,no_run
+//! use axum::{error_handling::HandleError, http, Router};
+//! use tower_http::gateway::Gateway;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = hyper::Client::new();
+//! let gateway = Gateway::new(client, http::Uri::from_static("http://example.com:1234/api/v1"))?;
+//! let app = Router::new().nest(
+//!     "/api",
+//!     HandleError::new(gateway, |_| async { http::StatusCode::BAD_GATEWAY }),
+//! );
+//! # Ok(()) }
+//! ```
+//!
+//! # URL Handling
+//!
+//! Every request sent to this service will have its URI interpreted relative to the configured
+//! remote URI. Any scheme or authority on the request URI will be discarded, its path will be
+//! joined to the remote URI's path, and its query (if any) will be used. The remote URI's complete
+//! path will be a prefix of the resulting path (even if it doesn't end in `/`) and its query will
+//! be ignored.
+//!
+//! # Request Headers
+//!
+//! This service strips most hop-by-hop headers from the request before forwarding it along,
+//! including arbitrary headers listed in [`Connection`][]. The exceptions to this are [`TE`][],
+//! [`Transfer-Encoding`][], and [`Trailer`][]. This is because these headers do not affect any
+//! processing done by this service. In particular, if the request body is passed straight through
+//! to the backend server without processing then details on how its encoded (e.g.
+//! [`Transfer-Encoding`][]) must be sent to the backend server, if the response body similarly
+//! avoids processing then the [`TE`][] header also needs to be sent to the backend server, and
+//! lastly if the request or response body has any trailer headers then the [`Trailer`][] header
+//! needs to be preserved as well. Similarly the [`Connection`][] header will retain any of these
+//! headers even as it's processed to remove any other hop-by-hop headers. If the request or
+//! response body is modified by some other layer it is that layer's responsibility to update these
+//! headers accordingly.
+//!
+//! Besides [`Connection`][], other standard hop-by-hop headers (except those listed above) are
+//! removed even if they're not listed in [`Connection`][].
+//!
+//! This service will add a [`Forwarded`][] header to the request it forwards that identifies the
+//! source of the incoming request. If the connection info is unknown the request will specify
+//! `Forwarded: for=unknown`. See [`ConnectionInfo`], [`Gateway::with_connection_info`], and
+//! [`Gateway::with_connection_info_fn`] for details.
+//!
+//! This service may optionally add `X-Forwarded-*` headers that mirror the [`Forwarded`][] header.
+//! See [`Gateway::use_x_forwarded`] for details.
+//!
+//! ## `Via` header
+//!
+//! This service will add a [`Via`][] header if configured with a [`ConnectionInfo`] that has
+//! either [`local_ip`][] or [`via_received_by`][] set. The [`Via`][] header's documentation
+//! declares that an HTTP-to-HTTP gateway _MUST_ send an appropriate Via header field in each
+//! inbound request. For this reason you may want to ensure that either [`local_ip`][] or
+//! [`via_received_by`][] is set for each request.
+//!
+//! The constructed [`Via`][] header will use the incoming request's [`Request::version`] to derive
+//! the [`received-protocol`][] portion. For this reason the version should not be modified prior
+//! to handing the request to the gateway. The gateway will reset the version back to the default
+//! prior to forwarding it, and a layer can be used after the gateway to set the request version if
+//! something other than the default is desired.
+//!
+//! The [`Via`][] header can be used to detect infinite forwarding loops. Although this service
+//! does not implement such detection automatically, by ensuring that the either [`local_ip`][] or
+//! [`via_received_by`][] is set for each request, you may implement such detection in a wrapping
+//! layer.
+//!
+//! [`local_ip`]: ConnectionInfo::local_ip
+//! [`via_received_by`]: ConnectionInfo::via_received_by
+//!
+//! # Response Headers
+//!
+//! This service does not currently rewrite any response headers, besides filtering out hop-by-hop
+//! headers as needed. In particular, this does not rewrite URLs in `Location` or
+//! `Content-Location` headers. This may be added in the future. It also does not rewrite the
+//! domain or path in any `Set-Cookie` headers, and it does not set or modify the [`Via`][] header.
+//!
+//! [`hyper::Client`]: https://docs.rs/hyper/0.14/hyper/client/struct.Client.html
+//! [`axum::Router`]: https://docs.rs/axum/0.5/axum/struct.Router.html
+//! [`Connection`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection
+//! [`TE`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/TE
+//! [`Transfer-Encoding`]:
+//!     https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding
+//! [`Trailer`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer
+//! [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+//! [`Via`]: https://httpwg.org/specs/rfc7230.html#header.via "RFC 7230 §5.7.1 Via"
+//! [`Request::version`]: fn@http::Request::version
+//! [`received-protocol`]: https://httpwg.org/specs/rfc7230.html#header.via
+//! [features]: https://doc.rust-lang.org/cargo/reference/features.html#the-features-section
+
+use std::{
+    fmt::{self, Write},
+    future::Future,
+    net::IpAddr,
+    task::Poll,
+};
+
+use bytes::{BufMut, BytesMut};
+use http::{header::HeaderName, HeaderValue};
+use pin_project_lite::pin_project;
+use tower_layer::Layer;
+use tower_service::Service;
+
+mod connection_info;
+pub use connection_info::*;
+mod util;
+
+/// Layer that applies [`Gateway`] which implements an HTTP gateway / reverse proxy.
+///
+/// See the [module docs](self) for more details.
+#[derive(Clone)]
+pub struct GatewayLayer<F = for<'a> fn(&'a http::Extensions) -> ConnectionInfo<'a>> {
+    remote: http::Uri,
+    connection_info: F,
+    use_x_forwarded: bool,
+}
+
+impl GatewayLayer {
+    /// Forwards requests to a given remote URI after modifying headers appropriately.
+    ///
+    /// Returns [`Err`] if the remote URI cannot have a path joined onto it (e.g. because it has an
+    /// authority and no scheme).
+    pub fn new(remote: http::Uri) -> Result<Self, http::Error> {
+        Ok(Self {
+            remote: validate_remote_uri(remote)?,
+            connection_info: |_| ConnectionInfo::new(),
+            use_x_forwarded: false,
+        })
+    }
+
+    /// Sets the type to use to get info about the connection from the request.
+    ///
+    /// The type will be looked up in the request's extensions map.
+    ///
+    /// This is a convenience for `self.with_connection_info_fn(|ext| ext.get::<C>().into())`.
+    pub fn with_connection_info<C>(
+        self,
+    ) -> GatewayLayer<impl for<'a> FnMut(&'a http::Extensions) -> ConnectionInfo<'a>>
+    where
+        C: Send + Sync + 'static,
+        for<'a> &'a C: Into<ConnectionInfo<'a>>,
+    {
+        self.with_connection_info_fn(|ext| ext.get::<C>().into())
+    }
+
+    /// Sets a function to use to get info about the connection from the request.
+    ///
+    /// This can be used to adapt connection info from other crates without having to add a layer
+    /// that modifies the request extensions.
+    ///
+    /// # Example
+    ///
+    /// Adapting [`axum::extract::connect_info::ConnectInfo`][]:
+    ///
+    /// ```rust
+    /// use axum::extract::connect_info::ConnectInfo;
+    /// use std::net::SocketAddr;
+    /// use tower::ServiceBuilder;
+    /// use tower_http::gateway::Gateway;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let gateway = ServiceBuilder::new()
+    ///     .layer(
+    ///         Gateway::layer(http::Uri::from_static("http://example.com:1234/api"))?
+    ///             .with_connection_info_fn(|ext| ext.get::<ConnectInfo<SocketAddr>>().map(|x| &x.0).into()),
+    ///     )
+    ///     .service(hyper::Client::new());
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [`axum::extract::connect_info::ConnectInfo`]:
+    ///     https://docs.rs/axum/0.5/axum/extract/connect_info/struct.ConnectInfo.html
+    pub fn with_connection_info_fn<F>(self, f: F) -> GatewayLayer<F>
+    where
+        F: for<'a> FnMut(&'a http::Extensions) -> ConnectionInfo<'a>,
+    {
+        GatewayLayer {
+            remote: self.remote,
+            connection_info: f,
+            use_x_forwarded: self.use_x_forwarded,
+        }
+    }
+}
+
+impl<F> GatewayLayer<F> {
+    /// Enables or disables the `X-Forwarded-*` headers on forwarded requests.
+    ///
+    /// If set to `true`, the forwarded request will have [`X-Forwarded-For`][],
+    /// [`X-Forwarded-Host`][], and [`X-Forwarded-Proto`][] headers set accordingly, depending on
+    /// the associated [`ConnectionInfo`] (see [`with_connection_info`] and
+    /// [`with_connection_info_fn`]). If the corresponding fields on the [`ConnectionInfo`] are
+    /// [`None`] (or obfuscated) the `X-Forwarded-*` header will be left unmodified.
+    ///
+    /// If set to `false` (the default), those headers will be ignored and any such headers already
+    /// on the request will be retained as-is.
+    ///
+    /// Note: When the incoming request has any such headers and the [`ConnectionInfo`] does not
+    /// specify unobfuscated values for all 3 headers, this may result in the forwarded request
+    /// only updating some headers and not others, leading to the `X-Forwarded-*` headers having
+    /// differing numbers of components.
+    ///
+    /// This setting should only be enabled when required. Whenever possible, the [`Forwarded`][]
+    /// header should be preferred.
+    ///
+    /// [`X-Forwarded-For`]:
+    ///     https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+    /// [`X-Forwarded-Host`]:
+    ///     https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
+    /// [`X-Forwarded-Proto`]:
+    ///     https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
+    /// [`with_connection_info`]: fn@Self::with_connection_info
+    /// [`with_connection_info_fn`]: fn@Self::with_connection_info_fn
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    pub fn use_x_forwarded(self, use_x_forwarded: bool) -> Self {
+        Self {
+            use_x_forwarded,
+            ..self
+        }
+    }
+}
+
+impl<S, F: Clone> Layer<S> for GatewayLayer<F> {
+    type Service = Gateway<S, F>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Gateway {
+            inner,
+            remote: self.remote.clone(),
+            connection_info: self.connection_info.clone(),
+            use_x_forwarded: self.use_x_forwarded,
+        }
+    }
+}
+
+/// Middleware that implements an HTTP gateway / reverse proxy.
+///
+/// See the [module docs](self) for more details.
+#[derive(Clone)]
+pub struct Gateway<S, F = for<'a> fn(&'a http::Extensions) -> ConnectionInfo<'a>> {
+    inner: S,
+    /// The URI for the backend server.
+    ///
+    /// Invariant: This URI is guaranteed to have a path already and therefore is safe to join a
+    /// path to. It also has no query.
+    remote: http::Uri,
+    connection_info: F,
+    use_x_forwarded: bool,
+}
+
+impl<S> Gateway<S> {
+    /// Creates a new `Gateway` that forwards requests to a given remote URI.
+    ///
+    /// Returns [`Err`] if the remote URI cannot have a path joined onto it (e.g. because it has an
+    /// authority and no scheme).
+    pub fn new(inner: S, remote: http::Uri) -> Result<Self, http::Error> {
+        Ok(Self {
+            inner,
+            remote: validate_remote_uri(remote)?,
+            connection_info: |_| ConnectionInfo::new(),
+            use_x_forwarded: false,
+        })
+    }
+
+    /// Sets the type to use to get info about the connection from the request.
+    ///
+    /// The type will be looked up in the request's extensions map.
+    ///
+    /// This is a convenience for `self.with_connection_info_fn(|ext| ext.get::<C>().into())`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    ///use tower_http::gateway::Gateway;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = hyper::Client::new();
+    /// let gateway = Gateway::new(client, http::Uri::from_static("http://example.com:1234/api"))?
+    ///     .with_connection_info::<std::net::SocketAddr>();
+    /// # Ok(()) }
+    /// ```
+    pub fn with_connection_info<C>(
+        self,
+    ) -> Gateway<S, impl for<'a> FnMut(&'a http::Extensions) -> ConnectionInfo<'a>>
+    where
+        C: Send + Sync + 'static,
+        for<'a> &'a C: Into<ConnectionInfo<'a>>,
+    {
+        self.with_connection_info_fn(|ext| ext.get::<C>().into())
+    }
+
+    /// Sets a function to use to get info about the connection from the request.
+    ///
+    /// This can be used to adapt connection info from other crates without having to add a layer
+    /// that modifies the request extensions.
+    ///
+    /// # Example
+    ///
+    /// Adapting [`axum::extract::connect_info::ConnectInfo`][]:
+    ///
+    /// ```rust
+    /// use axum::extract::connect_info::ConnectInfo;
+    /// use std::net::SocketAddr;
+    /// use tower_http::gateway::Gateway;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = hyper::Client::new();
+    /// let gateway = Gateway::new(client, http::Uri::from_static("http://example.com:1234/api"))?
+    ///     .with_connection_info_fn(|ext| ext.get::<ConnectInfo<SocketAddr>>().map(|x| &x.0).into());
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [`axum::extract::connect_info::ConnectInfo`]:
+    ///     https://docs.rs/axum/0.5/axum/extract/connect_info/struct.ConnectInfo.html
+    pub fn with_connection_info_fn<F>(self, f: F) -> Gateway<S, F>
+    where
+        F: for<'a> FnMut(&'a http::Extensions) -> ConnectionInfo<'a>,
+    {
+        Gateway {
+            inner: self.inner,
+            remote: self.remote,
+            connection_info: f,
+            use_x_forwarded: self.use_x_forwarded,
+        }
+    }
+}
+
+impl Gateway<()> {
+    /// Returns a new [`Layer`] that wraps services with a [`GatewayLayer`] middleware.
+    pub fn layer(remote: http::Uri) -> Result<GatewayLayer, http::Error> {
+        GatewayLayer::new(remote)
+    }
+}
+
+impl<S, F> Gateway<S, F> {
+    /// Enables or disables the `X-Forwarded-*` headers on forwarded requests.
+    ///
+    /// If set to `true`, the forwarded request will have [`X-Forwarded-For`][],
+    /// [`X-Forwarded-Host`][], and [`X-Forwarded-Proto`][] headers set accordingly, depending on
+    /// the associated [`ConnectionInfo`] (see [`with_connection_info`] and
+    /// [`with_connection_info_fn`]). If the corresponding fields on the [`ConnectionInfo`] are
+    /// [`None`] (or obfuscated) the `X-Forwarded-*` header will be left unmodified.
+    ///
+    /// If set to `false` (the default), those headers will be ignored and any such headers already
+    /// on the request will be retained as-is.
+    ///
+    /// Note: When the incoming request has any such headers and the [`ConnectionInfo`] does not
+    /// specify unobfuscated values for all 3 headers, this may result in the forwarded request
+    /// only updating some headers and not others, leading to the `X-Forwarded-*` headers having
+    /// differing numbers of components.
+    ///
+    /// This setting should only be enabled when required. Whenever possible, the [`Forwarded`][]
+    /// header should be preferred.
+    ///
+    /// [`X-Forwarded-For`]:
+    ///     https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+    /// [`X-Forwarded-Host`]:
+    ///     https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
+    /// [`X-Forwarded-Proto`]:
+    ///     https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
+    /// [`with_connection_info`]: fn@Self::with_connection_info
+    /// [`with_connection_info_fn`]: fn@Self::with_connection_info_fn
+    /// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    pub fn use_x_forwarded(self, use_x_forwarded: bool) -> Self {
+        Self {
+            use_x_forwarded,
+            ..self
+        }
+    }
+
+    /// Gets a reference to the underlying service.
+    pub fn get_ref(&self) -> &S {
+        &self.inner
+    }
+
+    /// Gets a mutable reference to the underlying service.
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Consumes `self`, returning the underlying service.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+}
+
+impl<S, F, ReqBody, ResBody> Service<http::Request<ReqBody>> for Gateway<S, F>
+where
+    S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>>,
+    F: for<'a> FnMut(&'a http::Extensions) -> ConnectionInfo<'a>,
+    ResBody: Default,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future, ResBody>;
+
+    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: http::Request<ReqBody>) -> Self::Future {
+        // Disallow the CONNECT request type. It's the only one whose request-target is an absolute
+        // URI, and joining that on a remote makes no sense.
+        if req.method() == http::Method::CONNECT {
+            // 405 Method Not Allowed sounds nice but we can't populate the `Allow` header as
+            // required since we don't know what the backend allows. CONNECT isn't supposed to be
+            // sent to origin servers anyway, so we'll just do a 400 Bad Request.
+            let mut res = http::Response::default();
+            *res.status_mut() = http::StatusCode::BAD_REQUEST;
+            update_response_headers(&mut res); // just in case this is useful later
+            return ResponseFuture {
+                kind: Kind::Error {
+                    response: Some(res),
+                },
+            };
+        }
+
+        let uri = uri_join(&self.remote, req.uri());
+        self.update_request_headers(&mut req);
+        *req.uri_mut() = uri;
+        // Reset request version back to the default (HTTP/1.1), so the version used for the
+        // incoming request doesn't affect our forwarded request.
+        *req.version_mut() = Default::default();
+        ResponseFuture {
+            kind: Kind::Future {
+                future: self.inner.call(req),
+            },
+        }
+    }
+}
+
+impl<S, F> Gateway<S, F>
+where
+    F: for<'a> FnMut(&'a http::Extensions) -> ConnectionInfo<'a>,
+{
+    /// Updates the headers in the request as needed for forwarding.
+    fn update_request_headers<ReqBody>(&mut self, req: &mut http::Request<ReqBody>) {
+        // Calculate the Forwarded (and X-Forwarded-* if requested) headers
+        let host = req.headers_mut().remove(http::header::HOST);
+        let connection_info = (self.connection_info)(req.extensions());
+        let forwarded = make_forwarded_header(&connection_info, host.as_ref());
+        let x_forwarded = self
+            .use_x_forwarded
+            .then(|| make_x_forwarded_headers(&connection_info, host.as_ref()));
+
+        // Calculate the Via header, if requested
+        let via = make_via_header(req.version(), &connection_info);
+
+        // Remove hop-by-hop headers
+        let headers = req.headers_mut();
+        remove_hop_by_hop_headers(headers);
+
+        // Now append our new headers. Doing it in this order prevents the `Connection` header from
+        // removing these headers.
+        headers.append(http::header::FORWARDED, forwarded);
+        for (name, value) in x_forwarded.into_iter().flatten() {
+            headers.append(name, value);
+        }
+        if let Some(via) = via {
+            headers.append(http::header::VIA, via);
+        }
+    }
+}
+
+fn validate_remote_uri(uri: http::Uri) -> Result<http::Uri, http::Error> {
+    // Validate that the Uri has a path, or give it one if not. Ultimately this requires the
+    // Uri to either be path-only or to have scheme/authority/path. We don't actually want
+    // path-only but our wrapped service gets to deal with that.
+    //
+    // We're going to always split the Uri into parts first and then re-join it, even if it
+    // says it has a path. This tests the specific path we care about (converting to Parts,
+    // setting a path, and converting back), which we need to ensure the safety of our unwraps
+    // later on. It also lets us trim off the query here so we don't need to do it later.
+    let mut parts = uri.into_parts();
+    parts.path_and_query = Some(match parts.path_and_query.take() {
+        Some(path_and_query) if path_and_query.query().is_none() => path_and_query,
+        Some(path_and_query) => path_and_query.path().parse()?,
+        None => http::uri::PathAndQuery::from_static("/"),
+    });
+    Ok(http::Uri::from_parts(parts)?)
+}
+
+fn uri_join(base: &http::Uri, uri: &http::Uri) -> http::Uri {
+    match uri.path_and_query() {
+        Some(path_and_query) if path_and_query != "" && path_and_query != "/" => {
+            // We need to join the remote with the request.
+            let mut parts = base.clone().into_parts();
+            let base_path_and_query = parts.path_and_query.take();
+            let base_path = base_path_and_query.as_ref().map(|p| p.path().as_bytes());
+            parts.path_and_query = Some(match base_path {
+                None | Some(b"" | b"/") => {
+                    // Our remote has no meaningful path, we can use the request path as-is
+                    path_and_query.clone()
+                }
+                Some(base_path) => {
+                    // http doesn't have any built-in way of joining paths or URIs so we must. If
+                    // we do this with Bytes we can avoid the reallocation when converting to
+                    // PathAndQuery as the latter uses Bytes internally. This isn't exposed in the
+                    // API, but if it ever changes (or uses an incompatible version of bytes) then
+                    // the failure mode is just an extra allocation.
+                    let mut path_and_query = path_and_query.as_str().as_bytes();
+                    let mut buf =
+                        BytesMut::with_capacity(base_path.len() + 1 + path_and_query.len());
+                    // Start with the base path
+                    buf.extend_from_slice(base_path);
+                    // Join the path_and_query, adding `/` if needed
+                    match (buf.ends_with(b"/"), path_and_query.first().copied()) {
+                        (true, Some(b'/')) => path_and_query = &path_and_query[1..], // don't double the slash
+                        (true, _) | (false, Some(b'/' | b'?') | None) => {}
+                        (false, _) => buf.extend_from_slice(b"/"),
+                    }
+                    buf.extend_from_slice(path_and_query);
+                    http::uri::PathAndQuery::from_maybe_shared(buf.freeze())
+                        .expect("buffer should only have path-safe characters")
+                }
+            });
+            http::Uri::from_parts(parts).expect("base URI should be safe to join a path to")
+        }
+        _ => {
+            // We have no path or query, we can use the base as-is
+            base.clone()
+        }
+    }
+}
+
+/// Updates the headers in the response as needed for forwarding.
+fn update_response_headers<ResBody>(response: &mut http::Response<ResBody>) {
+    remove_hop_by_hop_headers(response.headers_mut());
+}
+
+fn remove_hop_by_hop_headers(headers: &mut http::HeaderMap) {
+    use http::header::{
+        Entry, CONNECTION, PROXY_AUTHENTICATE, PROXY_AUTHORIZATION, TE, TRAILER, TRANSFER_ENCODING,
+        UPGRADE,
+    };
+    #[allow(clippy::declare_interior_mutable_const)] // it's the atomic refcount
+    const KEEP_ALIVE: HeaderName = HeaderName::from_static("keep-alive"); // this one isn't in http::header
+
+    // There are a group of hop-by-hop headers that should be removed by proxies as they're
+    // intended to control this particular connection. RFC7230 mandates that every gateway
+    // processes Connection and removes it and the listed names, so we'll do that with a few
+    // exceptions. We're also going to strip some hop-by-hop headers even if they aren't listed
+    // in Connection as that seems to be recommended behavior, especially if we're sending the
+    // request over HTTP/2.
+
+    // Strip Connection and the headers it references
+    if let Entry::Occupied(mut entry) = headers.entry(CONNECTION) {
+        // I'd love to use `headers::Connection` here but that doesn't offer any way to iterate its
+        // values, and similarly `HeaderMap` doesn't offer a `retain()` method. We are optimizing
+        // here for a single value.
+
+        // http::header::ValueDrain currently (as of http v0.2.6) holds a hidden inner Vec
+        // instead of reading data out of the map on demand. We want to avoid an unnecessary
+        // vec allocation just to read this data, so we're going to instead move data out
+        // without draining and then just remove the entry. This way our own Vec that we
+        // allocate to let us drop the borrow on the map is the only allocation we need.
+
+        let mut iter = entry
+            .iter_mut()
+            .map(|slot| {
+                // We're going to swap each value with an empty one. This gives us owned values
+                // without extra allocation or atomic operations (a static HeaderValue is backed by
+                // a static Bytes which skips the reference counting).
+                std::mem::replace(slot, HeaderValue::from_static(""))
+            })
+            .fuse();
+        // Don't allocate a Vec if we only have one value
+        let value = iter.next();
+        let rest = iter.collect::<Vec<_>>();
+        // We've pulled out all the header values, now remove the Connection header
+        entry.remove();
+        // The borrow on HeaderMap has now been dropped and we can mutate it.
+
+        // Each header value is a comma-separated list of header names with optional whitespace
+        // (defined as a space or tab).
+        value
+            .iter()
+            .chain(&rest)
+            // split on commas
+            .flat_map(|value| value.as_bytes().split(|&b| b == b','))
+            // convert to &str, trim whitespace
+            .filter_map(|s| {
+                // we need to go to &str now because AsHeaderName isn't implemented for &[u8]
+                // even though HeaderName can be compared to &[u8]. This also makes it easier
+                // to trim whitespace.
+                Some(
+                    std::str::from_utf8(s)
+                        .ok()?
+                        .trim_matches(&[' ', '\t'] as &[_]),
+                )
+            })
+            .for_each(|s| {
+                // skip the headers affecting body processing, we want to allow those
+                if let Some(header) =
+                    IntoIterator::into_iter([TE, TRANSFER_ENCODING, TRAILER]).find(|x| x == s)
+                {
+                    // Put the header back into Connection, we still need it there
+                    headers.append(CONNECTION, header.into());
+                } else {
+                    // Remove all other headers
+                    headers.remove(s);
+                }
+            })
+    }
+
+    // Strip most hop-by-hop headers even if they aren't in Connection. These headers aren't
+    // supposed to do anything if they aren't in Connection but it's better to be safe,
+    // especially if HTTP/2 is being used.
+    for value in [KEEP_ALIVE, PROXY_AUTHENTICATE, PROXY_AUTHORIZATION, UPGRADE] {
+        headers.remove(value);
+    }
+}
+
+/// Constructs and returns a [`Forwarded`][] header.
+///
+/// This will always include a `for=` parameter, using `for=unknown` if the client IP is unknown.
+///
+/// [`Forwarded`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+fn make_forwarded_header(
+    connection_info: &ConnectionInfo,
+    host: Option<&HeaderValue>,
+) -> HeaderValue {
+    struct AddrPort<'a>(
+        &'a Option<NodeIdentifier<'a, IpAddr>>,
+        &'a Option<NodeIdentifier<'a, u16>>,
+    );
+    impl fmt::Display for AddrPort<'_> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            // IpAddr, u16, and ObfuscatedIdentifier don't need any escaping, but some combinations
+            // of these do need quoting.
+            let quote = matches!(
+                (self.0, self.1),
+                (Some(NodeIdentifier::Value(IpAddr::V6(_))), _) | (_, Some(_))
+            );
+            if quote {
+                f.write_char('"')?;
+            }
+            match (self.0, self.1) {
+                (Some(NodeIdentifier::Value(IpAddr::V6(ip))), _) => write!(f, "[{}]", ip)?,
+                (Some(ip), _) => write!(f, "{}", ip)?,
+                (None, Some(_)) => f.write_str("unknown")?,
+                (None, None) => {}
+            }
+            if let Some(port) = self.1 {
+                write!(f, ":{}", port)?;
+            }
+            if quote {
+                f.write_char('"')?;
+            }
+            Ok(())
+        }
+    }
+
+    let mut bytes = BytesMut::new();
+    match (&connection_info.local_ip, &connection_info.local_port) {
+        (None, None) => {}
+        (ip, port) => {
+            let _ = write!(&mut bytes, "by={};", AddrPort(ip, port));
+        }
+    }
+    bytes.extend_from_slice(b"for=");
+    match (&connection_info.peer_ip, &connection_info.peer_port) {
+        (None, None) => bytes.extend_from_slice(b"unknown"),
+        (ip, port) => {
+            let _ = write!(&mut bytes, "{}", AddrPort(ip, port));
+        }
+    }
+    if let Some(host) = host.filter(|x| !x.is_empty()) {
+        bytes.put_slice(b";host=");
+        util::put_token_or_quoted(&mut bytes, &host);
+    }
+    if let Some(scheme) = &connection_info.scheme {
+        bytes.put_slice(b";proto=");
+        // Note: All valid schemes match the `token` rule and therefore don't need quoting
+        bytes.put_slice(scheme.as_str().as_bytes());
+    }
+    // HeaderValue uses a Bytes internally, so if we pass that we will avoid a reallocation. It
+    // doesn't publicly expose this but that's the current implementation. If that ever changes,
+    // this code will still work, it may just start creating a new allocation.
+    HeaderValue::from_maybe_shared(bytes.freeze()).expect("buffer should not contain control chars")
+}
+
+/// Constructs and returns [`X-Forwarded-For`][], [`X-Forwarded-Host`][], and
+/// [`X-Forwarded-Proto`][] headers.
+///
+/// [`X-Forwarded-For`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+/// [`X-Forwarded-Host`]:
+///     https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
+/// [`X-Forwarded-Proto`]:
+///     https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
+fn make_x_forwarded_headers(
+    connection_info: &ConnectionInfo,
+    host: Option<&HeaderValue>,
+) -> impl Iterator<Item = (HeaderName, HeaderValue)> {
+    IntoIterator::into_iter([
+        // X-Forwarded-For
+        connection_info
+            .peer_ip
+            .as_ref()
+            .and_then(|ip| ip.as_ref().exposed())
+            .map(|ip| {
+                // HeaderValue uses Bytes internally, so we'll use that to avoid an allocation.
+                let mut bytes = BytesMut::new();
+                // Note: this header doesn't require square brackets around IPv6 addrs
+                let _ = write!(bytes, "{}", ip);
+                // Invariant: Our buffer does not contain any control chars
+                (
+                    HeaderName::from_static("x-forwarded-for"),
+                    HeaderValue::from_maybe_shared(bytes.freeze())
+                        .expect("buffer should not contain control chars"),
+                )
+            }),
+        // X-Forwarded-Host
+        host.cloned()
+            .map(|host| (HeaderName::from_static("x-forwarded-host"), host)),
+        // X-Forwarded-Proto
+        connection_info.scheme.as_deref().map(|scheme| {
+            (
+                HeaderName::from_static("x-forwarded-proto"),
+                HeaderValue::from_str(scheme.as_str())
+                    .expect("Scheme should be ascii with no control chars"),
+            )
+        }),
+    ])
+    .flatten()
+}
+
+/// Constructs and returns a `Via` header.
+fn make_via_header(
+    version: http::Version,
+    connection_info: &ConnectionInfo,
+) -> Option<HeaderValue> {
+    struct Addr(IpAddr);
+    impl fmt::Display for Addr {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match &self.0 {
+                IpAddr::V4(v4) => fmt::Display::fmt(v4, f),
+                IpAddr::V6(v6) => write!(f, "[{}]", v6),
+            }
+        }
+    }
+    enum ReceivedBy<'a> {
+        Host(NodeIdentifier<'a, Addr>, Option<u16>),
+        Value(&'a HeaderValue),
+    }
+    let received_by = match (&connection_info.via_received_by, &connection_info.local_ip) {
+        (Some(via_received_by), _) => ReceivedBy::Value(via_received_by.as_ref()),
+        (None, Some(local_ip @ NodeIdentifier::Value(_))) => ReceivedBy::Host(
+            local_ip.as_ref().map_exposed(|&ip| Addr(ip)),
+            connection_info
+                .local_port
+                .as_ref()
+                .and_then(|p| p.as_ref().exposed())
+                .copied(),
+        ),
+        (None, Some(NodeIdentifier::Obfuscated(token))) => ReceivedBy::Host(token.into(), None),
+        (None, None) => return None,
+    };
+
+    // HeaderValue uses a Bytes internally, so if we construct it that way we avoid a reallocation.
+    let mut bytes = BytesMut::new();
+    // The Via header states that for brevity, the protocol-name is omitted if it is "HTTP".
+    const PREFIX: &[u8] = b"HTTP/";
+    match connection_info.via_protocol.as_deref() {
+        Some(via_protocol) => {
+            let proto = via_protocol.as_bytes();
+            bytes.extend_from_slice(proto.strip_prefix(PREFIX).unwrap_or(proto));
+        }
+        None => {
+            // Version prints strings like "HTTP/1.1" from its Debug impl. I'm mildly nervous about
+            // relying on this format as it's Debug, but there's no other way to get the version
+            // string back out, and our only alternative is switching over all known versions and
+            // failing if a version we don't know about is introduced.
+            let _ = write!(&mut bytes, "{:?}", version);
+            if bytes.starts_with(PREFIX) {
+                bytes.copy_within(PREFIX.len().., 0);
+                bytes.truncate(bytes.len() - PREFIX.len());
+            }
+        }
+    }
+    bytes.extend_from_slice(b" ");
+    #[allow(clippy::unit_arg)]
+    let _ = match received_by {
+        ReceivedBy::Host(host, None) => write!(&mut bytes, "{}", host),
+        ReceivedBy::Host(host, Some(port)) => write!(&mut bytes, "{}:{}", host, port),
+        ReceivedBy::Value(value) => Ok(bytes.extend_from_slice(value.as_bytes())),
+    };
+    Some(
+        HeaderValue::from_maybe_shared(bytes.freeze())
+            .expect("buffer should not contain control chars"),
+    )
+}
+
+// Note: The response future here is modeled after tower_http::auth::RequireAuthorization
+pin_project! {
+    /// Response future for [`Gateway`].
+    pub struct ResponseFuture<F, B> {
+        #[pin]
+        kind: Kind<F, B>,
+    }
+}
+
+pin_project! {
+    #[project = KindProj]
+    enum Kind<F, B> {
+        Future {
+            #[pin]
+            future: F
+        },
+        Error {
+            response: Option<http::Response<B>>,
+        }
+    }
+}
+
+impl<F, B, E> Future for ResponseFuture<F, B>
+where
+    F: Future<Output = Result<http::Response<B>, E>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        match self.project().kind.project() {
+            KindProj::Future { future } => future.poll(cx).map_ok(|mut res| {
+                update_response_headers(&mut res);
+                res
+            }),
+            KindProj::Error { response } => {
+                let response = response
+                    .take()
+                    .expect("ResponseFuture should not be polled after returning Poll::Ready");
+                Poll::Ready(Ok(response))
+            }
+        }
+    }
+}
+
+impl<F> fmt::Debug for GatewayLayer<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GatewayLayer")
+            .field("remote", &self.remote)
+            .field("use_x_forwarded", &self.use_x_forwarded)
+            .field(
+                "connection_info",
+                &format_args!("{}", std::any::type_name::<F>()),
+            )
+            .finish()
+    }
+}
+
+impl<S: fmt::Debug, F> fmt::Debug for Gateway<S, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Gateway")
+            .field("remote", &self.remote)
+            .field("use_x_forwarded", &self.use_x_forwarded)
+            .field(
+                "connection_info",
+                &format_args!("{}", std::any::type_name::<F>()),
+            )
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        convert::TryInto,
+        net::{Ipv4Addr, Ipv6Addr, SocketAddr},
+    };
+
+    use http::uri::Scheme;
+
+    use super::*;
+
+    #[test]
+    fn forwarded_header() {
+        macro_rules! assert_forwarded {
+            ($conn:expr => $expected:expr) => { assert_forwarded!(@ $conn, None, $expected) };
+            ($conn:expr, host: $host:expr => $expected:expr) => { assert_forwarded!(@ $conn, Some(&$host), $expected) };
+            (@ $conn:expr, $host:expr, $expected:expr) => {
+                assert_eq!(make_forwarded_header(&$conn.into(), $host), $expected);
+            };
+        }
+        assert_forwarded!(() => "for=unknown");
+        assert_forwarded!(IpAddr::from(Ipv4Addr::LOCALHOST) => "for=127.0.0.1");
+        assert_forwarded!(IpAddr::from(Ipv6Addr::LOCALHOST) => "for=\"[::1]\"");
+        assert_forwarded!(SocketAddr::from((Ipv4Addr::LOCALHOST, 1234)) => "for=\"127.0.0.1:1234\"");
+        assert_forwarded!(ConnectionInfo::new().peer_port(Some(1234)) => "for=\"unknown:1234\"");
+        assert_forwarded!(ConnectionInfo::new().peer_addr(Some(SocketAddr::from((Ipv4Addr::LOCALHOST, 1234)))) => "for=\"127.0.0.1:1234\"");
+        assert_forwarded!(ConnectionInfo::new().local_addr(Some(SocketAddr::from((Ipv4Addr::LOCALHOST, 1234)))) => "by=\"127.0.0.1:1234\";for=unknown");
+
+        assert_forwarded!(ConnectionInfo::new().scheme(Some(Scheme::HTTPS)) => "for=unknown;proto=https");
+        assert_forwarded!((), host: HeaderValue::from_static("example.com") => "for=unknown;host=example.com");
+        assert_forwarded!((), host: HeaderValue::from_static("invalid\"host\\") => r#"for=unknown;host="invalid\"host\\""#);
+
+        assert_forwarded!(ConnectionInfo::new().obfuscated_peer_ip(Some("_hidden".try_into().unwrap())) => "for=_hidden");
+        assert_forwarded!(ConnectionInfo::new()
+            .obfuscated_peer_ip(Some("_hidden".try_into().unwrap()))
+            .obfuscated_peer_port(Some("_private".try_into().unwrap()))
+            => "for=\"_hidden:_private\"");
+        assert_forwarded!(ConnectionInfo::new()
+            .obfuscated_peer_ip(Some("_a.b_c-9".try_into().unwrap()))
+            .peer_port(Some(6789))
+            => "for=\"_a.b_c-9:6789\"");
+
+        assert_forwarded!(ConnectionInfo::new()
+            .local_ip(Some(Ipv4Addr::LOCALHOST))
+            .local_port(Some(1234))
+            => "by=\"127.0.0.1:1234\";for=unknown");
+        assert_forwarded!(ConnectionInfo::new()
+            .obfuscated_local_ip(Some("_hidden".try_into().unwrap()))
+            .obfuscated_local_port(Some("_private".try_into().unwrap()))
+            => "by=\"_hidden:_private\";for=unknown");
+
+        assert_forwarded!(ConnectionInfo::new()
+            .peer_ip(Some(Ipv6Addr::LOCALHOST))
+            .obfuscated_peer_port(Some("_yes".try_into().unwrap()))
+            .obfuscated_local_ip(Some("_borkbork".try_into().unwrap()))
+            .local_port(Some(4321))
+            .scheme(Some(Scheme::HTTPS)),
+            host: HeaderValue::from_static("example.com")
+            => "by=\"_borkbork:4321\";for=\"[::1]:_yes\";host=example.com;proto=https");
+    }
+
+    #[test]
+    fn via_header() {
+        const HTTP_09: http::Version = http::Version::HTTP_09;
+        const HTTP_10: http::Version = http::Version::HTTP_10;
+        const HTTP_11: http::Version = http::Version::HTTP_11;
+        #[track_caller]
+        fn assert_via<'a>(
+            version: http::Version,
+            connection_info: impl Into<ConnectionInfo<'a>>,
+            expected: impl Into<Option<&'a str>>,
+        ) {
+            // Option<T> is only PartialEq with Option<T>
+            match (
+                make_via_header(version, &connection_info.into()),
+                expected.into(),
+            ) {
+                (Some(header), Some(expected)) => assert_eq!(header, expected),
+                (header @ Some(_), None) => assert_eq!(header, None),
+                (None, expected @ Some(_)) => assert_eq!(None, expected),
+                (None, None) => {}
+            }
+        }
+        assert_via(HTTP_11, (), None);
+        assert_via(HTTP_11, IpAddr::from(Ipv4Addr::LOCALHOST), None);
+        assert_via(
+            HTTP_11,
+            ConnectionInfo::new().local_ip(Some(Ipv4Addr::LOCALHOST)),
+            "1.1 127.0.0.1",
+        );
+        assert_via(
+            HTTP_11,
+            ConnectionInfo::new().local_ip(Some(Ipv6Addr::LOCALHOST)),
+            "1.1 [::1]",
+        );
+        assert_via(
+            HTTP_11,
+            ConnectionInfo::new()
+                .local_ip(Some(Ipv4Addr::LOCALHOST))
+                .local_port(Some(42)),
+            "1.1 127.0.0.1:42",
+        );
+        assert_via(
+            HTTP_11,
+            ConnectionInfo::new()
+                .local_ip(Some(Ipv6Addr::LOCALHOST))
+                .local_port(Some(42)),
+            "1.1 [::1]:42",
+        );
+        assert_via(
+            HTTP_11,
+            ConnectionInfo::new()
+                .local_ip(Some(Ipv4Addr::LOCALHOST))
+                .obfuscated_local_port(Some("_port".try_into().unwrap())),
+            "1.1 127.0.0.1",
+        );
+        assert_via(HTTP_11, ConnectionInfo::new().local_port(Some(42)), None);
+        assert_via(
+            HTTP_10,
+            ConnectionInfo::new().obfuscated_local_ip(Some("_spork".try_into().unwrap())),
+            "1.0 _spork",
+        );
+        assert_via(
+            HTTP_10,
+            ConnectionInfo::new()
+                .obfuscated_local_ip(Some("_bork".try_into().unwrap()))
+                .local_port(Some(42)),
+            "1.0 _bork",
+        );
+        assert_via(
+            HTTP_10,
+            ConnectionInfo::new()
+                .obfuscated_local_ip(Some("_bork".try_into().unwrap()))
+                .obfuscated_local_port(Some("_port".try_into().unwrap())),
+            "1.0 _bork",
+        );
+
+        assert_via(
+            HTTP_11,
+            ConnectionInfo::new().via_received_by(Some(HeaderValue::from_static("bork"))),
+            "1.1 bork",
+        );
+        assert_via(
+            HTTP_11,
+            ConnectionInfo::new()
+                .local_ip(Some(Ipv4Addr::LOCALHOST))
+                .local_port(Some(42))
+                .via_received_by(Some(HeaderValue::from_static("bork"))),
+            "1.1 bork",
+        );
+        assert_via(
+            HTTP_09,
+            ConnectionInfo::new().via_received_by(Some(HeaderValue::from_static("foo (comment)"))),
+            "0.9 foo (comment)",
+        );
+        assert_via(
+            HTTP_11,
+            ConnectionInfo::new()
+                .local_ip(Some(Ipv4Addr::LOCALHOST))
+                .via_protocol(Some(HeaderValue::from_static("WAT/2.0"))),
+            "WAT/2.0 127.0.0.1",
+        );
+        // Ensure we strip the HTTP name even when it's custom
+        assert_via(
+            HTTP_11,
+            ConnectionInfo::new()
+                .via_received_by(Some(HeaderValue::from_static("bork")))
+                .via_protocol(Some(HeaderValue::from_static("HTTP/2.0"))),
+            "2.0 bork",
+        );
+    }
+}

--- a/tower-http/src/gateway/util.rs
+++ b/tower-http/src/gateway/util.rs
@@ -1,0 +1,134 @@
+//! Helper utilities.
+
+use bytes::BufMut;
+
+/// Appends `bytes` to `buf` as a token or a quoted-string.
+///
+/// # Important
+///
+/// This function ignores control characters (`%x00-08 / %x0A-1F / %x7F`) as those are not valid in
+/// either `token` or `quoted-string`. It's the caller's responsibility to ensure the input does
+/// not contain these bytes.
+pub(super) fn put_token_or_quoted<B: BufMut>(buf: &mut B, bytes: impl AsRef<[u8]>) {
+    let mut bytes = bytes.as_ref();
+    if bytes.is_empty() {
+        buf.put_slice(b"\"\"");
+        return;
+    }
+    match bytes.iter().position(|&b| !is_tchar(b)) {
+        Some(mut skip) => {
+            // quoted-string
+            buf.put_u8(b'"');
+            while let Some(idx) = bytes
+                .iter()
+                .skip(skip)
+                .position(|&b| matches!(b, b'"' | b'\\'))
+            {
+                let chunk = take(&mut bytes, ..idx + skip);
+                buf.put_slice(chunk);
+                buf.put_u8(b'\\');
+                skip = 1;
+            }
+            buf.put_slice(bytes);
+            buf.put_u8(b'"');
+        }
+        None => {
+            // token
+            buf.put_slice(bytes);
+        }
+    }
+}
+
+fn is_tchar(b: u8) -> bool {
+    // https://httpwg.org/specs/rfc7230.html#rule.token.separators
+    matches!(b,
+          b'!' | b'#' | b'$' | b'%' | b'&' | b'\'' | b'*'
+        | b'+' | b'-' | b'.' | b'^' | b'_' | b'`'  | b'|' | b'~'
+        | b'0'..=b'9' | b'A'..=b'Z' | b'a'..=b'z'
+    )
+}
+
+// stable version of `slice::take()`
+fn take<'a>(s: &mut &'a [u8], range: std::ops::RangeTo<usize>) -> &'a [u8] {
+    let (head, tail) = s.split_at(range.end);
+    *s = tail;
+    head
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[track_caller]
+    fn assert_output(bytes: impl AsRef<[u8]>, expected: impl AsRef<[u8]>) {
+        let mut buf = Vec::new();
+        put_token_or_quoted(&mut buf, bytes);
+        assert_eq!(ByteStr(&buf), ByteStr(expected.as_ref()));
+    }
+
+    #[test]
+    fn test_empty() {
+        assert_output("", "\"\"");
+    }
+
+    #[test]
+    fn test_token() {
+        #[track_caller]
+        fn assert_token(bytes: impl AsRef<[u8]>) {
+            let bytes = bytes.as_ref();
+            assert_output(bytes, bytes);
+        }
+        assert_token("a");
+        assert_token("!#$%'*+-.^_`|~");
+        assert_token("some.WORDS.and.239zaq");
+        assert_token("127.0.0.1");
+    }
+
+    #[test]
+    fn test_quoted_string() {
+        assert_output(" ", r#"" ""#);
+        assert_output("one\ttwo", "\"one\ttwo\"");
+        assert_output("\"quoted\\text\"", r#""\"quoted\\text\"""#);
+        assert_output("🦌", r#""🦌""#);
+    }
+
+    /// Helper to print test failures in a more readable fashion.
+    ///
+    /// This prints as much utf-8 as possible, printing `\x##` escapes for non-utf8 bytes. It does
+    /// not escape any characters and omits surrounding double quotes, since the contained string
+    /// likely has backslash escapes and quotes in it and we want to make it easier to read.
+    ///
+    /// There is potential ambiguity between a string that looks like `\x##` and a non-utf8 byte,
+    /// but we're not expecting to run into that.
+    struct ByteStr<'a>(&'a [u8]);
+    impl std::fmt::Debug for ByteStr<'_> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let mut bytes = self.0;
+            loop {
+                let err = match std::str::from_utf8(bytes) {
+                    Ok(s) => return f.write_str(s),
+                    Err(err) => err,
+                };
+                f.write_str(std::str::from_utf8(take(&mut bytes, ..err.valid_up_to())).unwrap())?;
+                match err.error_len() {
+                    None => {
+                        for &b in bytes {
+                            write!(f, "{}", std::ascii::escape_default(b))?;
+                        }
+                        return Ok(());
+                    }
+                    Some(len) => {
+                        for &b in take(&mut bytes, ..len) {
+                            write!(f, "{}", std::ascii::escape_default(b))?;
+                        }
+                    }
+                };
+            }
+        }
+    }
+    impl PartialEq for ByteStr<'_> {
+        fn eq(&self, other: &Self) -> bool {
+            self.0 == other.0
+        }
+    }
+}

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -181,7 +181,6 @@
     clippy::todo,
     clippy::empty_enum,
     clippy::enum_glob_use,
-    clippy::pub_enum_variant_names,
     clippy::mem_forget,
     clippy::unused_self,
     clippy::filter_map_next,

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -305,6 +305,9 @@ pub mod set_status;
 #[cfg(feature = "timeout")]
 pub mod timeout;
 
+#[cfg(feature = "gateway")]
+pub mod gateway;
+
 pub mod classify;
 pub mod services;
 


### PR DESCRIPTION
This PR primarily adds a new HTTP gateway / reverse proxy middleware. It forwards the updated request to an underlying service so it should work with any appropriate transport such as `hyper::Client`. It concerns itself with updating the request URL and headers, including generating forwarding headers and stripping hop-by-hop headers.

This gateway implementation was based on RFC 7230 and RFC 7239, along with referencing MDN docs on various headers. Notably I did not look at any existing production gateway implementations beyond briefly skimming the config options for Apache's mod_proxy. I did make some choices in this implementation that could potentially want to be turned into config options, but I didn't want to overwhelm the config right now. These choices include always generating a `Forwarded` header and generating a `Via` header if possible, as well as keeping the hop-by-hop headers relating to transfer encoding and trailer headers intact. This gateway also does not modify the response beyond stripping hop-by-hop headers. In particular it does not add any headers, it does not rewrite the `Location` header, and it does not touch the body.

The gateway implementation has a few doctests, and has some unit tests for pieces of it, but does not currently have any tests for using the gateway itself.

Besides that, this PR also does some initial maintenance tasks. See the individual commits for details.
