### PR TITLE
Add `NormalizePath` middleware

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- None.
+- Add `NormalizePath` middleware
 
 ## Changed
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -66,6 +66,7 @@ full = [
     "map-request-body",
     "map-response-body",
     "metrics",
+    "normalize-path",
     "propagate-header",
     "redirect",
     "request-id",
@@ -87,6 +88,7 @@ limit = []
 map-request-body = []
 map-response-body = []
 metrics = ["tokio/time"]
+normalize-path = []
 propagate-header = []
 redirect = []
 request-id = ["uuid"]

--- a/tower-http/src/builder.rs
+++ b/tower-http/src/builder.rs
@@ -355,6 +355,16 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
         self,
         limit: usize,
     ) -> ServiceBuilder<Stack<crate::limit::RequestBodyLimitLayer, L>>;
+
+    /// Remove trailing slashes from paths.
+    ///
+    /// See [`tower_http::normalize_path`] for more details.
+    ///
+    /// [`tower_http::normalize_path`]: crate::normalize_path
+    #[cfg(feature = "normalize-path")]
+    fn trim_trailing_slash(
+        self,
+    ) -> ServiceBuilder<Stack<crate::normalize_path::NormalizePathLayer, L>>;
 }
 
 impl<L> crate::sealed::Sealed<L> for ServiceBuilder<L> {}
@@ -577,5 +587,12 @@ impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
         limit: usize,
     ) -> ServiceBuilder<Stack<crate::limit::RequestBodyLimitLayer, L>> {
         self.layer(crate::limit::RequestBodyLimitLayer::new(limit))
+    }
+
+    #[cfg(feature = "normalize-path")]
+    fn trim_trailing_slash(
+        self,
+    ) -> ServiceBuilder<Stack<crate::normalize_path::NormalizePathLayer, L>> {
+        self.layer(crate::normalize_path::NormalizePathLayer::trim_trailing_slash())
     }
 }

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -306,6 +306,9 @@ pub mod set_status;
 #[cfg(feature = "timeout")]
 pub mod timeout;
 
+#[cfg(feature = "normalize-path")]
+pub mod normalize_path;
+
 pub mod classify;
 pub mod services;
 

--- a/tower-http/src/normalize_path.rs
+++ b/tower-http/src/normalize_path.rs
@@ -1,0 +1,192 @@
+//! Middleware that normalizes paths.
+//!
+//! Any trailing slashes from request paths will be removed. For example, a request with `/foo/`
+//! will be changed to `/foo` before reaching the inner service.
+//!
+//! # Example
+//!
+//! ```
+//! use tower_http::normalize_path::NormalizePathLayer;
+//! use http::{Request, Response, StatusCode};
+//! use hyper::Body;
+//! use std::{iter::once, convert::Infallible};
+//! use tower::{ServiceBuilder, Service, ServiceExt};
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
+//!     // `req.uri().path()` will not have trailing slashes
+//!     # Ok(Response::new(Body::empty()))
+//! }
+//!
+//! let mut service = ServiceBuilder::new()
+//!     // trim trailing slashes from paths
+//!     .layer(NormalizePathLayer::trim_trailing_slash())
+//!     .service_fn(handle);
+//!
+//! // call the service
+//! let request = Request::builder()
+//!     // `handle` will see `/foo`
+//!     .uri("/foo/")
+//!     .body(Body::empty())?;
+//!
+//! service.ready().await?.call(request).await?;
+//! #
+//! # Ok(())
+//! # }
+//! ```
+
+use http::{Request, Response, Uri};
+use std::{
+    borrow::Cow,
+    task::{Context, Poll},
+};
+use tower_layer::Layer;
+use tower_service::Service;
+
+/// Layer that applies [`NormalizePath`] which normalizes paths.
+///
+/// See the [module docs](self) for more details.
+#[derive(Debug, Copy, Clone)]
+pub struct NormalizePathLayer {}
+
+impl NormalizePathLayer {
+    /// Create a new [`NormalizePathLayer`].
+    ///
+    /// Any trailing slashes from request paths will be removed. For example, a request with `/foo/`
+    /// will be changed to `/foo` before reaching the inner service.
+    pub fn trim_trailing_slash() -> Self {
+        NormalizePathLayer {}
+    }
+}
+
+impl<S> Layer<S> for NormalizePathLayer {
+    type Service = NormalizePath<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        NormalizePath::trim_trailing_slash(inner)
+    }
+}
+
+/// Middleware that normalizes paths.
+///
+/// See the [module docs](self) for more details.
+#[derive(Debug, Copy, Clone)]
+pub struct NormalizePath<S> {
+    inner: S,
+}
+
+impl<S> NormalizePath<S> {
+    /// Create a new [`NormalizePath`].
+    ///
+    /// Any trailing slashes from request paths will be removed. For example, a request with `/foo/`
+    /// will be changed to `/foo` before reaching the inner service.
+    pub fn trim_trailing_slash(inner: S) -> Self {
+        Self { inner }
+    }
+
+    define_inner_service_accessors!();
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for NormalizePath<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        remove_trailing_slash(req.uri_mut());
+        self.inner.call(req)
+    }
+}
+
+fn remove_trailing_slash(uri: &mut Uri) {
+    if !uri.path().ends_with('/') {
+        return;
+    }
+
+    let new_path = uri.path().trim_end_matches('/');
+
+    let mut parts = uri.clone().into_parts();
+
+    let new_path_and_query = if let Some(path_and_query) = &parts.path_and_query {
+        let new_path_and_query = if let Some(query) = path_and_query.query() {
+            Cow::Owned(format!("{}?{}", new_path, query))
+        } else {
+            new_path.into()
+        }
+        .parse()
+        .unwrap();
+
+        Some(new_path_and_query)
+    } else {
+        None
+    };
+
+    parts.path_and_query = new_path_and_query;
+    *uri = Uri::from_parts(parts).unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::Infallible;
+    use tower::{ServiceBuilder, ServiceExt};
+
+    #[tokio::test]
+    async fn works() {
+        async fn handle(request: Request<()>) -> Result<Response<String>, Infallible> {
+            Ok(Response::new(request.uri().to_string()))
+        }
+
+        let mut svc = ServiceBuilder::new()
+            .layer(NormalizePathLayer::trim_trailing_slash())
+            .service_fn(handle);
+
+        let body = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(Request::builder().uri("/foo/").body(()).unwrap())
+            .await
+            .unwrap()
+            .into_body();
+
+        assert_eq!(body, "/foo");
+    }
+
+    #[test]
+    fn is_noop_if_no_trailing_slash() {
+        let mut uri = "/foo".parse::<Uri>().unwrap();
+        remove_trailing_slash(&mut uri);
+        assert_eq!(uri, "/foo");
+    }
+
+    #[test]
+    fn maintains_query() {
+        let mut uri = "/foo/?a=a".parse::<Uri>().unwrap();
+        remove_trailing_slash(&mut uri);
+        assert_eq!(uri, "/foo?a=a");
+    }
+
+    #[test]
+    fn removes_multiple_trailing_slashes() {
+        let mut uri = "/foo////".parse::<Uri>().unwrap();
+        remove_trailing_slash(&mut uri);
+        assert_eq!(uri, "/foo");
+    }
+
+    #[test]
+    fn removes_multiple_trailing_slashes_even_with_query() {
+        let mut uri = "/foo////?a=a".parse::<Uri>().unwrap();
+        remove_trailing_slash(&mut uri);
+        assert_eq!(uri, "/foo?a=a");
+    }
+}

--- a/tower-http/src/normalize_path.rs
+++ b/tower-http/src/normalize_path.rs
@@ -131,7 +131,9 @@ fn remove_trailing_slash(uri: &mut Uri) {
     };
 
     parts.path_and_query = new_path_and_query;
-    *uri = Uri::from_parts(parts).unwrap();
+    if let Ok(new_uri) = Uri::from_parts(parts) {
+        *uri = new_uri;
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In axum we're removing support for trailing slash redirects (see https://github.com/tokio-rs/axum/issues/1118 for more details). That means its a little more work for users if they want their routes to be matched both with and without a trailing slash. This middleware addresses that.

Example usage with axum:

```rust
// what you'd have to do without this middleware
Router::new()
    .route("/foo", get(handler))
    .route("/foo/", get(handler));

// using the middleware we only have to add one route
NormalizePath::trim_trailing_slash(
    Router::new().route("/foo", get(handler))
);
```

Note that axum's `Router::layer` cannot be used since routing happens before any middleware are called, thus the requests would 404. That is something we have to address separately in axum but I still think this middleware makes sense on its own.