### PR TITLE
fix example in SetStaus middleware

### DIFF
--- a/tower-http/src/set_status.rs
+++ b/tower-http/src/set_status.rs
@@ -16,11 +16,6 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
-//!     // ...
-//!     # Ok(Response::new(Body::empty()))
-//! }
-//!
 //! let mut service = ServiceBuilder::new()
 //!     // change the status to `404 Not Found` regardless what the inner service returns
 //!     .layer(SetStatusLayer::new(StatusCode::NOT_FOUND))


### PR DESCRIPTION
The `async fn handle` was duplicated.
from https://www.youtube.com/watch?v=QtKO9f_iPhI