### PR TITLE
Panic if `*` is used with `AllowOrigin::list`

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -22,8 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 - **trace:** Correctly identify gRPC requests in default `on_response` callback ([#278])
-- **cors:** Correctly handle `*` when constructing `AllowOrigin` via iterators such as
-  `.allow_origin(["*".parse().unwrap()])` ([#285])
+- **cors:** Panic if a wildcard (`*`) is passed to `AllowOrigin::list`. Use
+  `AllowOrigin::any()` instead ([#285])
 
 [#278]: https://github.com/tower-rs/tower-http/pull/278
 [#285]: https://github.com/tower-rs/tower-http/pull/285

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 - **trace:** Correctly identify gRPC requests in default `on_response` callback ([#278])
+- **cors:** Correctly handle `*` when constructing `AllowOrigin` via iterators such as
+  `.allow_origin(["*".parse().unwrap()])`
 
 [#278]: https://github.com/tower-rs/tower-http/pull/278
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -23,9 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **trace:** Correctly identify gRPC requests in default `on_response` callback ([#278])
 - **cors:** Correctly handle `*` when constructing `AllowOrigin` via iterators such as
-  `.allow_origin(["*".parse().unwrap()])`
+  `.allow_origin(["*".parse().unwrap()])` ([#285])
 
 [#278]: https://github.com/tower-rs/tower-http/pull/278
+[#285]: https://github.com/tower-rs/tower-http/pull/285
 
 # 0.3.4 (June 06, 2022)
 

--- a/tower-http/src/cors/allow_origin.rs
+++ b/tower-http/src/cors/allow_origin.rs
@@ -41,11 +41,17 @@ impl AllowOrigin {
     /// See [`CorsLayer::allow_origin`] for more details.
     ///
     /// [`CorsLayer::allow_origin`]: super::CorsLayer::allow_origin
+    #[allow(clippy::borrow_interior_mutable_const)]
     pub fn list<I>(origins: I) -> Self
     where
         I: IntoIterator<Item = HeaderValue>,
     {
-        Self(OriginInner::List(origins.into_iter().collect()))
+        let origins = origins.into_iter().collect::<Vec<_>>();
+        if origins.iter().any(|o| o == WILDCARD) {
+            Self::any()
+        } else {
+            Self(OriginInner::List(origins))
+        }
     }
 
     /// Set the allowed origins from a predicate

--- a/tower-http/src/cors/allow_origin.rs
+++ b/tower-http/src/cors/allow_origin.rs
@@ -40,6 +40,10 @@ impl AllowOrigin {
     ///
     /// See [`CorsLayer::allow_origin`] for more details.
     ///
+    /// # Panics
+    ///
+    /// If the iterator contains a wildcard (`*`).
+    ///
     /// [`CorsLayer::allow_origin`]: super::CorsLayer::allow_origin
     #[allow(clippy::borrow_interior_mutable_const)]
     pub fn list<I>(origins: I) -> Self
@@ -48,7 +52,7 @@ impl AllowOrigin {
     {
         let origins = origins.into_iter().collect::<Vec<_>>();
         if origins.iter().any(|o| o == WILDCARD) {
-            Self::any()
+            panic!("Wildcard origin (`*`) cannot be passed to `AllowOrigin::list`. Use `AllowOrigin::any()` instead");
         } else {
             Self(OriginInner::List(origins))
         }


### PR DESCRIPTION
Fixes https://github.com/tower-rs/tower-http/issues/284

Otherwise https://github.com/tower-rs/tower-http/blob/master/tower-http/src/cors/allow_origin.rs#L87 would compare the origin with `"*"`.