### PR TITLE
Add layer to validate requests

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 - Add `NormalizePath` middleware
+- Add `ValidateRequest` middleware
 
 ## Changed
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -19,7 +19,6 @@ futures-core = "0.3"
 futures-util = { version = "0.3.14", default_features = false, features = [] }
 http = "0.2.2"
 http-body = "0.4.5"
-mime = { version = "0.3", default_features = false }
 pin-project-lite = "0.2.7"
 tower-layer = "0.3"
 tower-service = "0.3"
@@ -29,6 +28,7 @@ async-compression = { version = "0.3", optional = true, features = ["tokio"] }
 base64 = { version = "0.13", optional = true }
 http-range-header = "0.3.0"
 iri-string = { version = "0.4", optional = true }
+mime = { version = "0.3", optional = true, default_features = false }
 mime_guess = { version = "2", optional = true, default_features = false }
 percent-encoding = { version = "2.1.0", optional = true }
 tokio = { version = "1.6", optional = true, default_features = false }

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -76,6 +76,7 @@ full = [
     "timeout",
     "trace",
     "util",
+    "validate-request",
 ]
 
 add-extension = []
@@ -83,7 +84,7 @@ auth = ["base64"]
 catch-panic = ["tracing", "futures-util/std"]
 cors = []
 follow-redirect = ["iri-string", "tower/util"]
-fs = ["tokio/fs", "tokio-util/io", "tokio/io-util", "mime_guess", "percent-encoding", "httpdate", "set-status", "futures-util/alloc"]
+fs = ["tokio/fs", "tokio-util/io", "tokio/io-util", "mime_guess", "mime", "percent-encoding", "httpdate", "set-status", "futures-util/alloc"]
 limit = []
 map-request-body = []
 map-response-body = []
@@ -98,6 +99,7 @@ set-status = []
 timeout = ["tokio/time"]
 trace = ["tracing"]
 util = ["tower"]
+validate-request = ["mime"]
 
 compression-br = ["async-compression/brotli", "tokio-util", "tokio"]
 compression-deflate = ["async-compression/zlib", "tokio-util", "tokio"]

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -19,6 +19,7 @@ futures-core = "0.3"
 futures-util = { version = "0.3.14", default_features = false, features = [] }
 http = "0.2.2"
 http-body = "0.4.5"
+mime = { version = "0.3", default_features = false }
 pin-project-lite = "0.2.7"
 tower-layer = "0.3"
 tower-service = "0.3"
@@ -28,7 +29,6 @@ async-compression = { version = "0.3", optional = true, features = ["tokio"] }
 base64 = { version = "0.13", optional = true }
 http-range-header = "0.3.0"
 iri-string = { version = "0.4", optional = true }
-mime = { version = "0.3", optional = true, default_features = false }
 mime_guess = { version = "2", optional = true, default_features = false }
 percent-encoding = { version = "2.1.0", optional = true }
 tokio = { version = "1.6", optional = true, default_features = false }
@@ -83,7 +83,7 @@ auth = ["base64"]
 catch-panic = ["tracing", "futures-util/std"]
 cors = []
 follow-redirect = ["iri-string", "tower/util"]
-fs = ["tokio/fs", "tokio-util/io", "tokio/io-util", "mime_guess", "mime", "percent-encoding", "httpdate", "set-status", "futures-util/alloc"]
+fs = ["tokio/fs", "tokio-util/io", "tokio/io-util", "mime_guess", "percent-encoding", "httpdate", "set-status", "futures-util/alloc"]
 limit = []
 map-request-body = []
 map-response-body = []

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -23,6 +23,7 @@
 //!     sensitive_headers::SetSensitiveRequestHeadersLayer,
 //!     set_header::SetResponseHeaderLayer,
 //!     trace::TraceLayer,
+//!     validate_request::ValidateRequestHeaderLayer,
 //! };
 //! use tower::{ServiceBuilder, service_fn, make::Shared};
 //! use http::{Request, Response, header::{HeaderName, CONTENT_TYPE, AUTHORIZATION}};
@@ -71,6 +72,8 @@
 //!         .layer(SetResponseHeaderLayer::overriding(CONTENT_TYPE, content_length_from_response))
 //!         // Authorize requests using a token
 //!         .layer(RequireAuthorizationLayer::bearer("passwordlol"))
+//!         // Accept only application/json, application/* and */* in a request's ACCEPT header
+//!         .layer(ValidateRequestHeaderLayer::accept("application/json"))
 //!         // Wrap a `Service` in our middleware stack
 //!         .service_fn(handler);
 //!

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -319,6 +319,8 @@ mod builder;
 #[doc(inline)]
 pub use self::builder::ServiceBuilderExt;
 
+pub mod validate_request;
+
 /// The latency unit used to report latencies by middleware.
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug)]

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -322,6 +322,7 @@ mod builder;
 #[doc(inline)]
 pub use self::builder::ServiceBuilderExt;
 
+#[cfg(feature = "validate-request")]
 pub mod validate_request;
 
 /// The latency unit used to report latencies by middleware.

--- a/tower-http/src/validate_request.rs
+++ b/tower-http/src/validate_request.rs
@@ -338,9 +338,10 @@ impl<ResBody> AcceptHeader<ResBody> {
         ResBody: Body + Default,
     {
         Self {
-            header_value: Arc::new(header_value
-                .parse::<Mime>()
-                .expect("value is not a valid header value")
+            header_value: Arc::new(
+                header_value
+                    .parse::<Mime>()
+                    .expect("value is not a valid header value"),
             ),
             _ty: PhantomData,
         }

--- a/tower-http/src/validate_request.rs
+++ b/tower-http/src/validate_request.rs
@@ -292,7 +292,6 @@ where
         match self.project().kind.project() {
             KindProj::Future { future } => future.poll(cx),
             KindProj::Error { response } => {
-                /* Never panics unless polled after completion */
                 let response = response.take().expect("future polled after completion");
                 Poll::Ready(Ok(response))
             }

--- a/tower-http/src/validate_request.rs
+++ b/tower-http/src/validate_request.rs
@@ -1,0 +1,514 @@
+//! Middleware that validates the requests a service can handle.
+//!
+//! # Example
+//!
+//! ```
+//! use tower_http::validate_request::ValidateRequestHeaderLayer;
+//! use hyper::{Request, Response, Body, Error};
+//! use http::{StatusCode, header::ACCEPT};
+//! use tower::{Service, ServiceExt, ServiceBuilder, service_fn};
+//!
+//! async fn handle(request: Request<Body>) -> Result<Response<Body>, Error> {
+//!     Ok(Response::new(Body::empty()))
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut service = ServiceBuilder::new()
+//!     // Require the `Accept` header to be `application/json`, `*/*` or `application/*`
+//!     .layer(ValidateRequestHeaderLayer::accept("application/json"))
+//!     .service_fn(handle);
+//!
+//! // Requests with the correct value are allowed through
+//! let request = Request::builder()
+//!     .header(ACCEPT, "application/json")
+//!     .body(Body::empty())
+//!     .unwrap();
+//!
+//! let response = service
+//!     .ready()
+//!     .await?
+//!     .call(request)
+//!     .await?;
+//!
+//! assert_eq!(StatusCode::OK, response.status());
+//!
+//! // Requests with an invalid value get a `406 Not Acceptable` response
+//! let request = Request::builder()
+//!     .header(ACCEPT, "text/strings")
+//!     .body(Body::empty())
+//!     .unwrap();
+//!
+//! let response = service
+//!     .ready()
+//!     .await?
+//!     .call(request)
+//!     .await?;
+//!
+//! assert_eq!(StatusCode::NOT_ACCEPTABLE, response.status());
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Custom validation can be made by implementing [`ValidateRequest`]:
+//!
+//! ```
+//! use tower_http::validate_request::{ValidateRequestHeaderLayer, ValidateRequest};
+//! use hyper::{Request, Response, Body, Error};
+//! use http::{StatusCode, header::ACCEPT};
+//! use tower::{Service, ServiceExt, ServiceBuilder, service_fn};
+//!
+//! #[derive(Clone, Copy)]
+//! pub struct MyHeader { }
+//!
+//! impl<B> ValidateRequest<B> for MyHeader {
+//!     type ResponseBody = Body;
+//!
+//!     fn validate(
+//!         &mut self,
+//!         request: &mut Request<B>,
+//!     ) -> Result<(), Response<Self::ResponseBody>> {
+//!         # unimplemented!()
+//!     }
+//! }
+//!
+//! async fn handle(request: Request<Body>) -> Result<Response<Body>, Error> {
+//!     Ok(Response::new(Body::empty()))
+//! }
+//!
+//! 
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let service = ServiceBuilder::new()
+//!     // Validate requests using `MyHeader`
+//!     .layer(ValidateRequestHeaderLayer::custom(MyHeader{}))
+//!     .service_fn(handle);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Or using a closure:
+//!
+//! ```
+//! use tower_http::validate_request::{ValidateRequestHeaderLayer, ValidateRequest};
+//! use hyper::{Request, Response, Body, Error};
+//! use http::{StatusCode, header::ACCEPT};
+//! use tower::{Service, ServiceExt, ServiceBuilder, service_fn};
+//!
+//! async fn handle(request: Request<Body>) -> Result<Response<Body>, Error> {
+//!     # todo!();
+//!     // ...
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let service = ServiceBuilder::new()
+//!     .layer(ValidateRequestHeaderLayer::custom(|request: &mut Request<Body>| {
+//!         // Validate the request
+//!         # Ok::<_, Response<Body>>(())
+//!     }))
+//!     .service_fn(handle);
+//! # Ok(())
+//! # }
+//! ```
+
+use http::{
+    header::{self,HeaderValue},
+    Request, Response, StatusCode,
+};
+use http_body::Body;
+use pin_project_lite::pin_project;
+use std::{
+    fmt,
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower_layer::Layer;
+use tower_service::Service;
+
+/// Layer that applies [`ValidateRequestHeader`] which validates all requests using the
+/// [`ValidateRequest`] header.
+#[derive(Debug, Clone)]
+pub struct ValidateRequestHeaderLayer<T> {
+    valid: T,
+}
+
+impl<ResBody> ValidateRequestHeaderLayer<AcceptHeader<ResBody>> {
+    /// Validate requests have the required Accept header.
+    ///
+    /// The `Accept` header is required to be `*/*`, `type/*` or `type/subtype`,
+    /// as configured.
+    ///
+    /// [`Accept`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
+    pub fn accept(value: &str) -> Self
+    where
+        ResBody: Body + Default,
+    {
+        Self::custom(AcceptHeader::new(value))
+    }
+}
+
+impl<T> ValidateRequestHeaderLayer<T> {
+    /// Validate requests using a custom method.
+    pub fn custom(valid: T) -> ValidateRequestHeaderLayer<T> {
+        Self { valid }
+    }
+}
+
+impl<S, T> Layer<S> for ValidateRequestHeaderLayer<T>
+where
+    T: Clone,
+{
+    type Service = ValidateRequestHeader<S, T>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ValidateRequestHeader::new(inner, self.valid.clone())
+    }
+}
+
+/// Middleware that validates requests.
+#[derive(Clone, Debug)]
+pub struct ValidateRequestHeader<S, T> {
+    inner: S,
+    valid: T,
+}
+
+impl<S, T> ValidateRequestHeader<S, T> {
+    fn new(inner: S, valid: T) -> Self {
+        Self { inner, valid }
+    }
+
+    define_inner_service_accessors!();
+}
+
+impl<S, ResBody> ValidateRequestHeader<S, AcceptHeader<ResBody>> {
+    /// Validate requests have the required Accept header.
+    ///
+    /// The `Accept` header is required to be `*/*`, `type/*` or `type/subtype`,
+    /// as configured.
+    pub fn accept(inner: S, value: &str) -> Self
+    where
+        ResBody: Body + Default,
+    {
+        Self::custom(inner,AcceptHeader::new(value))
+    }
+}
+
+impl<S, T> ValidateRequestHeader<S, T> {
+    /// Validate requests using a custom method.
+    pub fn custom(inner: S, valid: T) -> ValidateRequestHeader<S, T> {
+        Self { inner, valid }
+    }
+}
+
+impl<ReqBody, ResBody, S, V> Service<Request<ReqBody>> for ValidateRequestHeader<S, V>
+where
+    V: ValidateRequest<ReqBody, ResponseBody = ResBody>,
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = Response<ResBody>;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future, ResBody>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        match self.valid.validate(&mut req) {
+            Ok(_) => ResponseFuture::future(self.inner.call(req)),
+            Err(res) => ResponseFuture::invalid_header_value(res),
+        }
+    }
+}
+
+pin_project! {
+    /// Response future for [`ValidateRequestHeader`].
+    pub struct ResponseFuture<F, B> {
+        #[pin]
+        kind: Kind<F, B>,
+    }
+}
+
+impl<F, B> ResponseFuture<F, B> {
+    fn future(future: F) -> Self {
+        Self {
+            kind: Kind::Future { future },
+        }
+    }
+
+    fn invalid_header_value(res: Response<B>) -> Self {
+        Self {
+            kind: Kind::Error {
+                response: Some(res),
+            },
+        }
+    }
+}
+
+pin_project! {
+    #[project = KindProj]
+    enum Kind<F, B> {
+        Future {
+            #[pin]
+            future: F,
+        },
+        Error {
+            response: Option<Response<B>>,
+        },
+    }
+}
+
+impl<F, B, E> Future for ResponseFuture<F, B>
+where
+    F: Future<Output = Result<Response<B>, E>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project().kind.project() {
+            KindProj::Future { future } => future.poll(cx),
+            KindProj::Error { response } => {
+                let response = response.take().unwrap();
+                Poll::Ready(Ok(response))
+            }
+        }
+    }
+}
+
+/// Trait for validating requests.
+pub trait ValidateRequest<B> {
+    /// The body type used for responses to unvalidated requests.
+    type ResponseBody;
+
+    /// Validate the request.
+    ///
+    /// If `Ok(())` is returned then the request is allowed through, otherwise not.
+    fn validate(&mut self, request: &mut Request<B>) -> Result<(), Response<Self::ResponseBody>>;
+}
+
+impl<B, F, ResBody> ValidateRequest<B> for F
+where
+    F: FnMut(&mut Request<B>) -> Result<(), Response<ResBody>>,
+{
+    type ResponseBody = ResBody;
+
+    fn validate(&mut self, request: &mut Request<B>) -> Result<(), Response<Self::ResponseBody>> {
+        self(request)
+    }
+}
+
+/// Type that performs validation of the Accept header.
+pub struct AcceptHeader<ResBody> {
+    header_value: HeaderValue,
+    _ty: PhantomData<fn() -> ResBody>,
+}
+
+impl<ResBody> AcceptHeader<ResBody> {
+    fn new(header_value: &str) -> Self
+    where
+        ResBody: Body + Default,
+    {
+        Self {
+            header_value: header_value
+                .parse()
+                .expect("token is not a valid header value"),
+            _ty: PhantomData,
+        }
+    }
+}
+
+impl<ResBody> Clone for AcceptHeader<ResBody> {
+    fn clone(&self) -> Self {
+        Self {
+            header_value: self.header_value.clone(),
+            _ty: PhantomData,
+        }
+    }
+}
+
+impl<ResBody> fmt::Debug for AcceptHeader<ResBody> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AcceptHeader")
+            .field("header_value", &self.header_value)
+            .finish()
+    }
+}
+
+impl<B, ResBody> ValidateRequest<B> for AcceptHeader<ResBody>
+where
+    ResBody: Body + Default,
+{
+    type ResponseBody = ResBody;
+
+    fn validate(&mut self, req: &mut Request<B>) -> Result<(), Response<Self::ResponseBody>> {
+        if !req.headers().contains_key(header::ACCEPT) {
+            return Ok(())
+        }
+        if req.headers().get_all(header::ACCEPT)
+            .into_iter()
+            .flat_map(|header| header.to_str().ok().into_iter().flat_map(|s| s.split(",").map(|typ| typ.trim())))
+            .any(|h| {
+                    let value = self.header_value.to_str().unwrap();
+                    let primary = format!("{}/*", value.split("/").nth(0).unwrap());
+                    h == "*/*" || h == primary || h == value
+                }) {
+                    return Ok(())
+                }
+        let mut res = Response::new(ResBody::default());
+        *res.status_mut() = StatusCode::NOT_ACCEPTABLE;
+        Err(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[allow(unused_imports)]
+    use super::*;
+    use http::header;
+    use hyper::Body;
+    use tower::{BoxError, ServiceBuilder, ServiceExt};
+
+    #[tokio::test]
+    async fn valid_accept_header() {
+        let mut service = ServiceBuilder::new()
+            .layer(ValidateRequestHeaderLayer::accept("application/json"))
+            .service_fn(echo);
+
+        let request = Request::get("/")
+            .header(
+                header::ACCEPT,
+                "application/json"
+            )
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service.ready().await.unwrap().call(request).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn valid_accept_header_accept_all_json() {
+        let mut service = ServiceBuilder::new()
+            .layer(ValidateRequestHeaderLayer::accept("application/json"))
+            .service_fn(echo);
+
+        let request = Request::get("/")
+            .header(
+                header::ACCEPT,
+                "application/*"
+            )
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service.ready().await.unwrap().call(request).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn valid_accept_header_accept_all() {
+        let mut service = ServiceBuilder::new()
+            .layer(ValidateRequestHeaderLayer::accept("application/json"))
+            .service_fn(echo);
+
+        let request = Request::get("/")
+            .header(
+                header::ACCEPT,
+                "*/*"
+            )
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service.ready().await.unwrap().call(request).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn invalid_accept_header() {
+        let mut service = ServiceBuilder::new()
+            .layer(ValidateRequestHeaderLayer::accept("application/json"))
+            .service_fn(echo);
+
+        let request = Request::get("/")
+            .header(
+                header::ACCEPT,
+                "invalid"
+            )
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service.ready().await.unwrap().call(request).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::NOT_ACCEPTABLE);
+    }
+    #[tokio::test]
+    async fn not_accepted_accept_header() {
+        let mut service = ServiceBuilder::new()
+            .layer(ValidateRequestHeaderLayer::accept("application/json"))
+            .service_fn(echo);
+
+        let request = Request::get("/")
+            .header(
+                header::ACCEPT,
+                "text/strings"
+            )
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service.ready().await.unwrap().call(request).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::NOT_ACCEPTABLE);
+    }
+
+    #[tokio::test]
+    async fn accepted_multiple_header_value() {
+        let mut service = ServiceBuilder::new()
+            .layer(ValidateRequestHeaderLayer::accept("application/json"))
+            .service_fn(echo);
+
+        let request = Request::get("/")
+            .header(
+                header::ACCEPT,
+                "text/strings"
+            )
+            .header(
+                header::ACCEPT,
+                "invalid, application/json"
+            )
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service.ready().await.unwrap().call(request).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn accepted_inner_header_value() {
+        let mut service = ServiceBuilder::new()
+            .layer(ValidateRequestHeaderLayer::accept("application/json"))
+            .service_fn(echo);
+
+        let request = Request::get("/")
+            .header(
+                header::ACCEPT,
+                "text/strings, invalid, application/json"
+            )
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service.ready().await.unwrap().call(request).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    async fn echo(req: Request<Body>) -> Result<Response<Body>, BoxError> {
+        Ok(Response::new(req.into_body()))
+    }
+}
+

--- a/tower-http/src/validate_request.rs
+++ b/tower-http/src/validate_request.rs
@@ -77,7 +77,7 @@
 //!     Ok(Response::new(Body::empty()))
 //! }
 //!
-//! 
+//!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let service = ServiceBuilder::new()
@@ -113,10 +113,7 @@
 //! # }
 //! ```
 
-use http::{
-    header::self,
-    Request, Response, StatusCode,
-};
+use http::{header, Request, Response, StatusCode};
 use http_body::Body;
 use mime::Mime;
 use pin_project_lite::pin_project;
@@ -131,7 +128,7 @@ use tower_layer::Layer;
 use tower_service::Service;
 
 /// Layer that applies [`ValidateRequestHeader`] which validates all requests.
-/// 
+///
 /// See the [module docs](crate::validate_request) for an example.
 #[derive(Debug, Clone)]
 pub struct ValidateRequestHeaderLayer<T> {
@@ -172,7 +169,7 @@ where
 }
 
 /// Middleware that validates requests.
-/// 
+///
 /// See the [module docs](crate::validate_request) for an example.
 #[derive(Clone, Debug)]
 pub struct ValidateRequestHeader<S, T> {
@@ -374,7 +371,7 @@ where
                             (t, s) if t == typ && s == subtype => true,
                             (t, mime::STAR) if t == typ => true,
                             (mime::STAR, mime::STAR) => true,
-                            _ => false
+                            _ => false,
                         }
                     })
                     .unwrap_or(false)
@@ -528,4 +525,3 @@ mod tests {
         Ok(Response::new(req.into_body()))
     }
 }
-


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->
This commit adds a new layer to customize validating requests.

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
The new layer adds support for custom validation of requests. 

In [smithy-rs](https://github.com/awslabs/smithy-rs/), we allow requests based on the `Accept` header. Our use-case could be common to others using tower and more general than just validating a header, hence this layer to validate any request, with headers being a special case.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The new layer takes from the `RequireAuthorization` layer and generalizes it for any request. If this is accepted, we can have the authorization layer be like the `AcceptHeader` layer and use this general validator.

Alternatively, we could have a layer to validate headers specifically or only for the Accept header.