### PR TITLE
Implement require_auth with validate_request

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Removed
 
-- None.
+- Removed `RequireAuthorization` in favor of `ValidateRequest`
 
 ## Fixed
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -80,7 +80,7 @@ full = [
 ]
 
 add-extension = []
-auth = ["base64"]
+auth = ["base64", "validate-request"]
 catch-panic = ["tracing", "futures-util/std"]
 cors = []
 follow-redirect = ["iri-string", "tower/util"]

--- a/tower-http/src/auth/add_authorization.rs
+++ b/tower-http/src/auth/add_authorization.rs
@@ -5,6 +5,7 @@
 //! # Example
 //!
 //! ```
+//! use tower_http::validate_request::{ValidateRequestHeader, ValidateRequestHeaderLayer};
 //! use tower_http::auth::AddAuthorizationLayer;
 //! use hyper::{Request, Response, Body, Error};
 //! use http::{StatusCode, header::AUTHORIZATION};
@@ -15,7 +16,7 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # let service_that_requires_auth = tower_http::auth::RequireAuthorization::basic(
+//! # let service_that_requires_auth = ValidateRequestHeader::basic(
 //! #     tower::service_fn(handle),
 //! #     "username",
 //! #     "password",
@@ -183,9 +184,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::validate_request::ValidateRequestHeaderLayer;
+
     #[allow(unused_imports)]
     use super::*;
-    use crate::auth::RequireAuthorizationLayer;
     use http::{Response, StatusCode};
     use hyper::Body;
     use tower::{BoxError, Service, ServiceBuilder, ServiceExt};
@@ -194,7 +196,7 @@ mod tests {
     async fn basic() {
         // service that requires auth for all requests
         let svc = ServiceBuilder::new()
-            .layer(RequireAuthorizationLayer::basic("foo", "bar"))
+            .layer(ValidateRequestHeaderLayer::basic("foo", "bar"))
             .service_fn(echo);
 
         // make a client that adds auth
@@ -215,7 +217,7 @@ mod tests {
     async fn token() {
         // service that requires auth for all requests
         let svc = ServiceBuilder::new()
-            .layer(RequireAuthorizationLayer::bearer("foo"))
+            .layer(ValidateRequestHeaderLayer::bearer("foo"))
             .service_fn(echo);
 
         // make a client that adds auth
@@ -235,7 +237,7 @@ mod tests {
     #[tokio::test]
     async fn making_header_sensitive() {
         let svc = ServiceBuilder::new()
-            .layer(RequireAuthorizationLayer::bearer("foo"))
+            .layer(ValidateRequestHeaderLayer::bearer("foo"))
             .service_fn(|request: Request<Body>| async move {
                 let auth = request.headers().get(http::header::AUTHORIZATION).unwrap();
                 assert!(auth.is_sensitive());

--- a/tower-http/src/auth/mod.rs
+++ b/tower-http/src/auth/mod.rs
@@ -10,5 +10,4 @@ pub use self::{
     async_require_authorization::{
         AsyncAuthorizeRequest, AsyncRequireAuthorization, AsyncRequireAuthorizationLayer,
     },
-    require_authorization::{AuthorizeRequest, RequireAuthorization, RequireAuthorizationLayer},
 };

--- a/tower-http/src/auth/require_authorization.rs
+++ b/tower-http/src/auth/require_authorization.rs
@@ -1,4 +1,4 @@
-//! Authorize requests using the [`ValidateRequest`] middleware.
+//! Authorize requests using [`ValidateRequest`].
 //!
 //! [`Authorization`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
 //!
@@ -51,8 +51,7 @@
 //! # }
 //! ```
 //!
-//! Custom validation can be made by implementing [`ValidateRequest`]:
-//!
+//! Custom validation can be made by implementing [`ValidateRequest`].
 
 use crate::validate_request::{ValidateRequest, ValidateRequestHeader, ValidateRequestHeaderLayer};
 use http::{
@@ -102,11 +101,11 @@ impl<S, ResBody> ValidateRequestHeader<S, Bearer<ResBody>> {
     /// # Panics
     ///
     /// Panics if the token is not a valid [`HeaderValue`](http::header::HeaderValue).
-    pub fn bearer(inner: S, value: &str) -> Self
+    pub fn bearer(inner: S, token: &str) -> Self
     where
         ResBody: Body + Default,
     {
-        Self::custom(inner, Bearer::new(value))
+        Self::custom(inner, Bearer::new(token))
     }
 }
 

--- a/tower-http/src/auth/require_authorization.rs
+++ b/tower-http/src/auth/require_authorization.rs
@@ -1,11 +1,11 @@
-//! Authorize requests using the [`Authorization`] header.
+//! Authorize requests using the [`ValidateRequest`] middleware.
 //!
 //! [`Authorization`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
 //!
 //! # Example
 //!
 //! ```
-//! use tower_http::auth::RequireAuthorizationLayer;
+//! use tower_http::validate_request::{ValidateRequest, ValidateRequestHeader, ValidateRequestHeaderLayer};
 //! use hyper::{Request, Response, Body, Error};
 //! use http::{StatusCode, header::AUTHORIZATION};
 //! use tower::{Service, ServiceExt, ServiceBuilder, service_fn};
@@ -18,7 +18,7 @@
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut service = ServiceBuilder::new()
 //!     // Require the `Authorization` header to be `Bearer passwordlol`
-//!     .layer(RequireAuthorizationLayer::bearer("passwordlol"))
+//!     .layer(ValidateRequestHeaderLayer::bearer("passwordlol"))
 //!     .service_fn(handle);
 //!
 //! // Requests with the correct token are allowed through
@@ -51,141 +51,37 @@
 //! # }
 //! ```
 //!
-//! Custom authorization schemes can be made by implementing [`AuthorizeRequest`]:
+//! Custom validation can be made by implementing [`ValidateRequest`]:
 //!
-//! ```
-//! use tower_http::auth::{RequireAuthorizationLayer, AuthorizeRequest};
-//! use hyper::{Request, Response, Body, Error};
-//! use http::{StatusCode, header::AUTHORIZATION};
-//! use tower::{Service, ServiceExt, ServiceBuilder, service_fn};
-//!
-//! #[derive(Clone, Copy)]
-//! struct MyAuth;
-//!
-//! impl<B> AuthorizeRequest<B> for MyAuth {
-//!     type ResponseBody = Body;
-//!
-//!     fn authorize(
-//!         &mut self,
-//!         request: &mut Request<B>,
-//!     ) -> Result<(), Response<Self::ResponseBody>> {
-//!         if let Some(user_id) = check_auth(request) {
-//!             // Set `user_id` as a request extension so it can be accessed by other
-//!             // services down the stack.
-//!             request.extensions_mut().insert(user_id);
-//!
-//!             Ok(())
-//!         } else {
-//!             let unauthorized_response = Response::builder()
-//!                 .status(StatusCode::UNAUTHORIZED)
-//!                 .body(Body::empty())
-//!                 .unwrap();
-//!
-//!             Err(unauthorized_response)
-//!         }
-//!     }
-//! }
-//!
-//! fn check_auth<B>(request: &Request<B>) -> Option<UserId> {
-//!     // ...
-//!     # unimplemented!()
-//! }
-//!
-//! #[derive(Debug)]
-//! struct UserId(String);
-//!
-//! async fn handle(request: Request<Body>) -> Result<Response<Body>, Error> {
-//!     // Access the `UserId` that was set in `on_authorized`. If `handle` gets called the
-//!     // request was authorized and `UserId` will be present.
-//!     let user_id = request
-//!         .extensions()
-//!         .get::<UserId>()
-//!         .expect("UserId will be there if request was authorized");
-//!
-//!     println!("request from {:?}", user_id);
-//!
-//!     Ok(Response::new(Body::empty()))
-//! }
-//!
-//! # #[tokio::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let service = ServiceBuilder::new()
-//!     // Authorize requests using `MyAuth`
-//!     .layer(RequireAuthorizationLayer::custom(MyAuth))
-//!     .service_fn(handle);
-//! # Ok(())
-//! # }
-//! ```
-//!
-//! Or using a closure:
-//!
-//! ```
-//! use tower_http::auth::{RequireAuthorizationLayer, AuthorizeRequest};
-//! use hyper::{Request, Response, Body, Error};
-//! use http::{StatusCode, header::AUTHORIZATION};
-//! use tower::{Service, ServiceExt, ServiceBuilder, service_fn};
-//!
-//! async fn handle(request: Request<Body>) -> Result<Response<Body>, Error> {
-//!     # todo!();
-//!     // ...
-//! }
-//!
-//! # #[tokio::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let service = ServiceBuilder::new()
-//!     .layer(RequireAuthorizationLayer::custom(|request: &mut Request<Body>| {
-//!         // authorize the request
-//!         # Ok::<_, Response<Body>>(())
-//!     }))
-//!     .service_fn(handle);
-//! # Ok(())
-//! # }
-//! ```
 
+use crate::validate_request::{ValidateRequest, ValidateRequestHeader, ValidateRequestHeaderLayer};
 use http::{
     header::{self, HeaderValue},
     Request, Response, StatusCode,
 };
 use http_body::Body;
-use pin_project_lite::pin_project;
 use std::{
     fmt,
-    future::Future,
     marker::PhantomData,
-    pin::Pin,
-    task::{Context, Poll},
 };
-use tower_layer::Layer;
-use tower_service::Service;
 
-/// Layer that applies [`RequireAuthorization`] which authorizes all requests using the
-/// [`Authorization`] header.
-///
-/// See the [module docs](crate::auth::require_authorization) for an example.
-///
-/// [`Authorization`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
-#[derive(Debug, Clone)]
-pub struct RequireAuthorizationLayer<T> {
-    auth: T,
-}
-
-impl<ResBody> RequireAuthorizationLayer<Bearer<ResBody>> {
-    /// Authorize requests using a "bearer token". Commonly used for OAuth 2.
+impl<S, ResBody> ValidateRequestHeader<S, Basic<ResBody>> {
+    /// Authorize requests using a username and password pair.
     ///
-    /// The `Authorization` header is required to be `Bearer {token}`.
+    /// The `Authorization` header is required to be `Basic {credentials}` where `credentials` is
+    /// `base64_encode("{username}:{password}")`.
     ///
-    /// # Panics
-    ///
-    /// Panics if the token is not a valid [`HeaderValue`](http::header::HeaderValue).
-    pub fn bearer(token: &str) -> Self
+    /// Since the username and password is sent in clear text it is recommended to use HTTPS/TLS
+    /// with this method. However use of HTTPS/TLS is not enforced by this middleware.
+    pub fn basic(inner: S, username: &str, value: &str) -> Self
     where
         ResBody: Body + Default,
     {
-        Self::custom(Bearer::new(token))
+        Self::custom(inner, Basic::new(username, value))
     }
 }
 
-impl<ResBody> RequireAuthorizationLayer<Basic<ResBody>> {
+impl<ResBody> ValidateRequestHeaderLayer<Basic<ResBody>> {
     /// Authorize requests using a username and password pair.
     ///
     /// The `Authorization` header is required to be `Basic {credentials}` where `credentials` is
@@ -201,44 +97,7 @@ impl<ResBody> RequireAuthorizationLayer<Basic<ResBody>> {
     }
 }
 
-impl<T> RequireAuthorizationLayer<T> {
-    /// Authorize requests using a custom scheme.
-    pub fn custom(auth: T) -> RequireAuthorizationLayer<T> {
-        Self { auth }
-    }
-}
-
-impl<S, T> Layer<S> for RequireAuthorizationLayer<T>
-where
-    T: Clone,
-{
-    type Service = RequireAuthorization<S, T>;
-
-    fn layer(&self, inner: S) -> Self::Service {
-        RequireAuthorization::new(inner, self.auth.clone())
-    }
-}
-
-/// Middleware that authorizes all requests using the [`Authorization`] header.
-///
-/// See the [module docs](crate::auth::require_authorization) for an example.
-///
-/// [`Authorization`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
-#[derive(Clone, Debug)]
-pub struct RequireAuthorization<S, T> {
-    inner: S,
-    auth: T,
-}
-
-impl<S, T> RequireAuthorization<S, T> {
-    fn new(inner: S, auth: T) -> Self {
-        Self { inner, auth }
-    }
-
-    define_inner_service_accessors!();
-}
-
-impl<S, ResBody> RequireAuthorization<S, Bearer<ResBody>> {
+impl<S, ResBody> ValidateRequestHeader<S, Bearer<ResBody>> {
     /// Authorize requests using a "bearer token". Commonly used for OAuth 2.
     ///
     /// The `Authorization` header is required to be `Bearer {token}`.
@@ -246,139 +105,33 @@ impl<S, ResBody> RequireAuthorization<S, Bearer<ResBody>> {
     /// # Panics
     ///
     /// Panics if the token is not a valid [`HeaderValue`](http::header::HeaderValue).
-    pub fn bearer(inner: S, token: &str) -> Self
+    pub fn bearer(inner: S, value: &str) -> Self
     where
         ResBody: Body + Default,
     {
-        Self::custom(inner, Bearer::new(token))
+        Self::custom(inner, Bearer::new(value))
     }
 }
 
-impl<S, ResBody> RequireAuthorization<S, Basic<ResBody>> {
-    /// Authorize requests using a username and password pair.
+impl<ResBody> ValidateRequestHeaderLayer<Bearer<ResBody>> {
+    /// Authorize requests using a "bearer token". Commonly used for OAuth 2.
     ///
-    /// The `Authorization` header is required to be `Basic {credentials}` where `credentials` is
-    /// `base64_encode("{username}:{password}")`.
+    /// The `Authorization` header is required to be `Bearer {token}`.
     ///
-    /// Since the username and password is sent in clear text it is recommended to use HTTPS/TLS
-    /// with this method. However use of HTTPS/TLS is not enforced by this middleware.
-    pub fn basic(inner: S, username: &str, password: &str) -> Self
+    /// # Panics
+    ///
+    /// Panics if the token is not a valid [`HeaderValue`](http::header::HeaderValue).
+    pub fn bearer(token: &str) -> Self
     where
         ResBody: Body + Default,
     {
-        Self::custom(inner, Basic::new(username, password))
-    }
-}
-
-impl<S, T> RequireAuthorization<S, T> {
-    /// Authorize requests using a custom scheme.
-    ///
-    /// The `Authorization` header is required to have the value provided.
-    pub fn custom(inner: S, auth: T) -> RequireAuthorization<S, T> {
-        Self { inner, auth }
-    }
-}
-
-impl<ReqBody, ResBody, S, Auth> Service<Request<ReqBody>> for RequireAuthorization<S, Auth>
-where
-    Auth: AuthorizeRequest<ReqBody, ResponseBody = ResBody>,
-    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
-{
-    type Response = Response<ResBody>;
-    type Error = S::Error;
-    type Future = ResponseFuture<S::Future, ResBody>;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
-        match self.auth.authorize(&mut req) {
-            Ok(_) => ResponseFuture::future(self.inner.call(req)),
-            Err(res) => ResponseFuture::invalid_auth(res),
-        }
-    }
-}
-
-pin_project! {
-    /// Response future for [`RequireAuthorization`].
-    pub struct ResponseFuture<F, B> {
-        #[pin]
-        kind: Kind<F, B>,
-    }
-}
-
-impl<F, B> ResponseFuture<F, B> {
-    fn future(future: F) -> Self {
-        Self {
-            kind: Kind::Future { future },
-        }
-    }
-
-    fn invalid_auth(res: Response<B>) -> Self {
-        Self {
-            kind: Kind::Error {
-                response: Some(res),
-            },
-        }
-    }
-}
-
-pin_project! {
-    #[project = KindProj]
-    enum Kind<F, B> {
-        Future {
-            #[pin]
-            future: F,
-        },
-        Error {
-            response: Option<Response<B>>,
-        },
-    }
-}
-
-impl<F, B, E> Future for ResponseFuture<F, B>
-where
-    F: Future<Output = Result<Response<B>, E>>,
-{
-    type Output = F::Output;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.project().kind.project() {
-            KindProj::Future { future } => future.poll(cx),
-            KindProj::Error { response } => {
-                let response = response.take().unwrap();
-                Poll::Ready(Ok(response))
-            }
-        }
-    }
-}
-
-/// Trait for authorizing requests.
-pub trait AuthorizeRequest<B> {
-    /// The body type used for responses to unauthorized requests.
-    type ResponseBody;
-
-    /// Authorize the request.
-    ///
-    /// If `Ok(())` is returned then the request is allowed through, otherwise not.
-    fn authorize(&mut self, request: &mut Request<B>) -> Result<(), Response<Self::ResponseBody>>;
-}
-
-impl<B, F, ResBody> AuthorizeRequest<B> for F
-where
-    F: FnMut(&mut Request<B>) -> Result<(), Response<ResBody>>,
-{
-    type ResponseBody = ResBody;
-
-    fn authorize(&mut self, request: &mut Request<B>) -> Result<(), Response<Self::ResponseBody>> {
-        self(request)
+        Self::custom(Bearer::new(token))
     }
 }
 
 /// Type that performs "bearer token" authorization.
 ///
-/// See [`RequireAuthorization::bearer`] for more details.
+/// See [`ValidateRequestHeader::bearer`] for more details.
 pub struct Bearer<ResBody> {
     header_value: HeaderValue,
     _ty: PhantomData<fn() -> ResBody>,
@@ -415,13 +168,13 @@ impl<ResBody> fmt::Debug for Bearer<ResBody> {
     }
 }
 
-impl<B, ResBody> AuthorizeRequest<B> for Bearer<ResBody>
+impl<B, ResBody> ValidateRequest<B> for Bearer<ResBody>
 where
     ResBody: Body + Default,
 {
     type ResponseBody = ResBody;
 
-    fn authorize(&mut self, request: &mut Request<B>) -> Result<(), Response<Self::ResponseBody>> {
+    fn validate(&mut self, request: &mut Request<B>) -> Result<(), Response<Self::ResponseBody>> {
         match request.headers().get(header::AUTHORIZATION) {
             Some(actual) if actual == self.header_value => Ok(()),
             _ => {
@@ -435,7 +188,7 @@ where
 
 /// Type that performs basic authorization.
 ///
-/// See [`RequireAuthorization::basic`] for more details.
+/// See [`ValidateRequestHeader::basic`] for more details.
 pub struct Basic<ResBody> {
     header_value: HeaderValue,
     _ty: PhantomData<fn() -> ResBody>,
@@ -472,13 +225,13 @@ impl<ResBody> fmt::Debug for Basic<ResBody> {
     }
 }
 
-impl<B, ResBody> AuthorizeRequest<B> for Basic<ResBody>
+impl<B, ResBody> ValidateRequest<B> for Basic<ResBody>
 where
     ResBody: Body + Default,
 {
     type ResponseBody = ResBody;
 
-    fn authorize(&mut self, request: &mut Request<B>) -> Result<(), Response<Self::ResponseBody>> {
+    fn validate(&mut self, request: &mut Request<B>) -> Result<(), Response<Self::ResponseBody>> {
         match request.headers().get(header::AUTHORIZATION) {
             Some(actual) if actual == self.header_value => Ok(()),
             _ => {
@@ -494,16 +247,19 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::validate_request::ValidateRequestHeaderLayer;
+
     #[allow(unused_imports)]
     use super::*;
     use http::header;
     use hyper::Body;
     use tower::{BoxError, ServiceBuilder, ServiceExt};
+    use tower_service::Service;
 
     #[tokio::test]
     async fn valid_basic_token() {
         let mut service = ServiceBuilder::new()
-            .layer(RequireAuthorizationLayer::basic("foo", "bar"))
+            .layer(ValidateRequestHeaderLayer::basic("foo", "bar"))
             .service_fn(echo);
 
         let request = Request::get("/")
@@ -522,7 +278,7 @@ mod tests {
     #[tokio::test]
     async fn invalid_basic_token() {
         let mut service = ServiceBuilder::new()
-            .layer(RequireAuthorizationLayer::basic("foo", "bar"))
+            .layer(ValidateRequestHeaderLayer::basic("foo", "bar"))
             .service_fn(echo);
 
         let request = Request::get("/")
@@ -544,7 +300,7 @@ mod tests {
     #[tokio::test]
     async fn valid_bearer_token() {
         let mut service = ServiceBuilder::new()
-            .layer(RequireAuthorizationLayer::bearer("foobar"))
+            .layer(ValidateRequestHeaderLayer::bearer("foobar"))
             .service_fn(echo);
 
         let request = Request::get("/")
@@ -560,7 +316,7 @@ mod tests {
     #[tokio::test]
     async fn basic_auth_is_case_sensitive_in_prefix() {
         let mut service = ServiceBuilder::new()
-            .layer(RequireAuthorizationLayer::basic("foo", "bar"))
+            .layer(ValidateRequestHeaderLayer::basic("foo", "bar"))
             .service_fn(echo);
 
         let request = Request::get("/")
@@ -579,7 +335,7 @@ mod tests {
     #[tokio::test]
     async fn basic_auth_is_case_sensitive_in_value() {
         let mut service = ServiceBuilder::new()
-            .layer(RequireAuthorizationLayer::basic("foo", "bar"))
+            .layer(ValidateRequestHeaderLayer::basic("foo", "bar"))
             .service_fn(echo);
 
         let request = Request::get("/")
@@ -598,7 +354,7 @@ mod tests {
     #[tokio::test]
     async fn invalid_bearer_token() {
         let mut service = ServiceBuilder::new()
-            .layer(RequireAuthorizationLayer::bearer("foobar"))
+            .layer(ValidateRequestHeaderLayer::bearer("foobar"))
             .service_fn(echo);
 
         let request = Request::get("/")
@@ -614,7 +370,7 @@ mod tests {
     #[tokio::test]
     async fn bearer_token_is_case_sensitive_in_prefix() {
         let mut service = ServiceBuilder::new()
-            .layer(RequireAuthorizationLayer::bearer("foobar"))
+            .layer(ValidateRequestHeaderLayer::bearer("foobar"))
             .service_fn(echo);
 
         let request = Request::get("/")
@@ -630,7 +386,7 @@ mod tests {
     #[tokio::test]
     async fn bearer_token_is_case_sensitive_in_token() {
         let mut service = ServiceBuilder::new()
-            .layer(RequireAuthorizationLayer::bearer("foobar"))
+            .layer(ValidateRequestHeaderLayer::bearer("foobar"))
             .service_fn(echo);
 
         let request = Request::get("/")

--- a/tower-http/src/auth/require_authorization.rs
+++ b/tower-http/src/auth/require_authorization.rs
@@ -60,10 +60,7 @@ use http::{
     Request, Response, StatusCode,
 };
 use http_body::Body;
-use std::{
-    fmt,
-    marker::PhantomData,
-};
+use std::{fmt, marker::PhantomData};
 
 impl<S, ResBody> ValidateRequestHeader<S, Basic<ResBody>> {
     /// Authorize requests using a username and password pair.

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -19,7 +19,6 @@
 //!     add_extension::AddExtensionLayer,
 //!     compression::CompressionLayer,
 //!     propagate_header::PropagateHeaderLayer,
-//!     auth::RequireAuthorizationLayer,
 //!     sensitive_headers::SetSensitiveRequestHeadersLayer,
 //!     set_header::SetResponseHeaderLayer,
 //!     trace::TraceLayer,
@@ -71,7 +70,7 @@
 //!         // If the response has a known size set the `Content-Length` header
 //!         .layer(SetResponseHeaderLayer::overriding(CONTENT_TYPE, content_length_from_response))
 //!         // Authorize requests using a token
-//!         .layer(RequireAuthorizationLayer::bearer("passwordlol"))
+//!         .layer(ValidateRequestHeaderLayer::bearer("passwordlol"))
 //!         // Accept only application/json, application/* and */* in a request's ACCEPT header
 //!         .layer(ValidateRequestHeaderLayer::accept("application/json"))
 //!         // Wrap a `Service` in our middleware stack


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

This is a follow-up to: https://github.com/tower-rs/tower-http/pull/289
`ValidateRequest` is an abstraction of a validator and `RequireAuthorization` is an instance, but the latter has yet to be implemented in terms of the former. They now are two independent types.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
`RequireAuthorization` is now implemented by `ValidateRequest`.

This is a breaking change.