### PR TITLE
Fix implementation of CorsLayer::very_permissive

### DIFF
--- a/tower-http/src/cors/mod.rs
+++ b/tower-http/src/cors/mod.rs
@@ -143,6 +143,7 @@ impl CorsLayer {
     /// - No headers are currently exposed, but this may change in the future.
     pub fn very_permissive() -> Self {
         Self::new()
+            .allow_credentials(true)
             .allow_headers(AllowHeaders::mirror_request())
             .allow_methods(AllowMethods::mirror_request())
             .allow_origin(AllowOrigin::mirror_request())


### PR DESCRIPTION
## Motivation

Fixes #297.

## Solution

Align `CorsLayer::very_permissive` with its documentation.