### PR TITLE
Bump MSRV to 1.56

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,7 +81,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.51
+        toolchain: 1.56
         profile: minimal
         override: true
     - name: Run tests

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The [examples] folder contains various examples of how to use Tower HTTP:
 
 ## Minimum supported Rust version
 
-tower-http's MSRV is 1.51.
+tower-http's MSRV is 1.56.
 
 ## Getting Help
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/tower-rs/tower-http"
 homepage = "https://github.com/tower-rs/tower-http"
 categories = ["asynchronous", "network-programming", "web-programming"]
 keywords = ["io", "async", "futures", "service", "http"]
-rust-version = "1.51"
+rust-version = "1.56"
 
 [dependencies]
 bitflags = "1.3.1"

--- a/tower-http/src/content_encoding.rs
+++ b/tower-http/src/content_encoding.rs
@@ -215,11 +215,7 @@ pub(crate) fn encodings(
             };
 
             let qval = if let Some(qval) = v.next() {
-                if let Some(qval) = QValue::parse(qval.trim()) {
-                    qval
-                } else {
-                    return None;
-                }
+                QValue::parse(qval.trim())?
             } else {
                 QValue::one()
             };


### PR DESCRIPTION
## Motivation

The `once_cell` crate has raised its MSRV to 1.56.

## Solution

Bump the MSRV. We could also deal with this by telling people to use a version of with a lower MSRV via `Cargo.lock`, and test the same setup in our own CI but I'm not sure it's necessary with 1.56 being almost a year old by now.