### PR TITLE
Timeout on body

### DIFF
--- a/tower-http/src/timeout/body.rs
+++ b/tower-http/src/timeout/body.rs
@@ -319,7 +319,7 @@ mod tests {
 
     impl Error for MockError {}
     impl Display for MockError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             todo!()
         }
     }

--- a/tower-http/src/timeout/body.rs
+++ b/tower-http/src/timeout/body.rs
@@ -102,7 +102,7 @@ where
                 if let Poll::Ready(_) = this.sleep.as_pin_mut().unwrap().poll(cx) {
                     return Poll::Ready(Some(Err(Box::new(TimeoutError))))
                 }
-                Poll::Ready(data.transpose().map_err(|_| Box::new(TimeoutError) as Self::Error).transpose())
+                Poll::Ready(data.transpose().map_err(|_| Box::new(TimeoutError).into()).transpose())
             }
             Poll::Pending => Poll::Pending
         }
@@ -120,7 +120,7 @@ where
             Poll::Ready(()) => return Poll::Ready(Err(Box::new(TimeoutError))),
         }
 
-        this.body.poll_trailers(cx).map_err(|_| Box::new(TimeoutError) as Self::Error)
+        this.body.poll_trailers(cx).map_err(|_| Box::new(TimeoutError).into())
     }
 }
 

--- a/tower-http/src/timeout/body.rs
+++ b/tower-http/src/timeout/body.rs
@@ -55,7 +55,7 @@ pin_project! {
 }
 
 impl<B> TimeoutBody<B> {
-    /// Create a new [`TimeoutBody`].
+    /// Creates a new [`TimeoutBody`].
     pub fn new(timeout: Duration, body: B) -> Self {
         TimeoutBody {
             timeout,
@@ -136,14 +136,14 @@ impl std::fmt::Display for TimeoutError {
     }
 }
 
-/// Apply a TimeoutBody to the request body.
+/// Applies a TimeoutBody to the request body.
 #[derive(Clone, Debug)]
 pub struct RequestBodyTimeoutLayer {
     timeout: Duration,
 }
 
 impl RequestBodyTimeoutLayer {
-    /// Create a new [`RequestBodyTimeoutLayer`].
+    /// Creates a new [`RequestBodyTimeoutLayer`].
     pub fn new(timeout: Duration) -> Self {
         Self { timeout }
     }
@@ -166,7 +166,7 @@ pub struct RequestBodyTimeout<S> {
 }
 
 impl<S> RequestBodyTimeout<S> {
-    /// Create a new [`RequestBodyTimeout`].
+    /// Creates a new [`RequestBodyTimeout`].
     pub fn new(service: S, timeout: Duration) -> Self {
         Self { inner: service, timeout }
     }
@@ -207,7 +207,7 @@ pub struct ResponseBodyTimeoutLayer {
 }
 
 impl ResponseBodyTimeoutLayer {
-    /// Create a new [`ResponseBodyTimeoutLayer`].
+    /// Creates a new [`ResponseBodyTimeoutLayer`].
     pub fn new(timeout: Duration) -> Self {
         Self { timeout }
     }
@@ -221,7 +221,7 @@ impl<S> Layer<S> for ResponseBodyTimeoutLayer {
     }
 }
 
-/// Apply a TimeoutBody to the response body.
+/// Applies a TimeoutBody to the response body.
 #[derive(Clone)]
 pub struct ResponseBodyTimeout<S> {
     inner: S,
@@ -229,7 +229,7 @@ pub struct ResponseBodyTimeout<S> {
 }
 
 impl<S> ResponseBodyTimeout<S> {
-    /// Create a new [`ResponseBodyTimeout`].
+    /// Creates a new [`ResponseBodyTimeout`].
     pub fn new(service: S, timeout: Duration) -> Self {
         Self { inner: service, timeout }
     }

--- a/tower-http/src/timeout/body.rs
+++ b/tower-http/src/timeout/body.rs
@@ -3,9 +3,9 @@
 //! Bodies must produce data at most within the specified timeout.
 //! If the body does not produce a requested data frame within the timeout period, it will return an error.
 //!
-//! # Differences from [`tower_http::timeout::Timeout`]
+//! # Differences from [`crate::timeout::Timeout`]
 //!
-//! [`tower_http::timeout::Timeout`] applies a timeout to the request future, not body.
+//! [`crate::timeout::Timeout`] applies a timeout to the request future, not body.
 //! That timeout is not reset when bytes are handled, whether the request is active or not.
 //! Bodies are handled asynchronously outside of the tower stack's future and thus needs an additional timeout.
 //!
@@ -18,7 +18,7 @@
 //! use hyper::Body;
 //! use std::time::Duration;
 //! use tower::ServiceBuilder;
-//! use tower_http::timeout::body::RequestBodyTimeoutLayer;
+//! use tower_http::timeout::RequestBodyTimeoutLayer;
 //!
 //! async fn handle(_: Request<Body>) -> Result<Response<Body>, std::convert::Infallible> {
 //!     // ...

--- a/tower-http/src/timeout/body.rs
+++ b/tower-http/src/timeout/body.rs
@@ -3,12 +3,12 @@
 //! Bodies must produce data at most within the specified timeout.
 //! If they are inactive, an error will be generated.
 //!
-//! # Differences from `tower_http::timeout::service::Timeout`
+//! # Differences from [`tower_http::timeout::service::Timeout`]
 //!
 //! [`tower_http::timeout::service::Timeout`] applies a timeout on the full request.
 //! That timeout is not reset when bytes are handled, whether the request is active or not.
 //!
-//! This middleware will return a `TimeoutError`.
+//! This middleware will return a [`TimeoutError`].
 //!
 //! # Example
 //!
@@ -44,7 +44,7 @@ use tower_layer::Layer;
 use tower_service::Service;
 
 pin_project! {
-    /// Wrapper around a `http_body::Body` to time out if data is not ready within the specified duration.
+    /// Wrapper around a [`http_body::Body`] to time out if data is not ready within the specified duration.
     pub struct TimeoutBody<B> {
         timeout: Duration,
         #[pin]
@@ -158,7 +158,7 @@ impl<S> Layer<S> for RequestBodyTimeoutLayer
     }
 }
 
-/// Apply a TimeoutBody to the request body.
+/// Applies a TimeoutBody to the request body.
 #[derive(Clone, Debug)]
 pub struct RequestBodyTimeout<S> {
     inner: S,
@@ -171,7 +171,7 @@ impl<S> RequestBodyTimeout<S> {
         Self { inner: service, timeout }
     }
 
-    /// Returns a new [`Layer`] that wraps services with a `RequestBodyTimeoutLayer` middleware.
+    /// Returns a new [`Layer`] that wraps services with a [`RequestBodyTimeoutLayer`] middleware.
     ///
     /// [`Layer`]: tower_layer::Layer
     pub fn layer(timeout: Duration) -> RequestBodyTimeoutLayer {
@@ -200,7 +200,7 @@ where
     }
 }
 
-/// Apply a TimeoutBody to the response body.
+/// Applies a TimeoutBody to the response body.
 #[derive(Clone)]
 pub struct ResponseBodyTimeoutLayer {
     timeout: Duration,
@@ -234,7 +234,7 @@ impl<S> ResponseBodyTimeout<S> {
         Self { inner: service, timeout }
     }
 
-    /// Returns a new [`Layer`] that wraps services with a `ResponseBodyTimeoutLayer` middleware.
+    /// Returns a new [`Layer`] that wraps services with a [`ResponseBodyTimeoutLayer`] middleware.
     ///
     /// [`Layer`]: tower_layer::Layer
     pub fn layer(timeout: Duration) -> ResponseBodyTimeoutLayer {

--- a/tower-http/src/timeout/body.rs
+++ b/tower-http/src/timeout/body.rs
@@ -34,6 +34,7 @@
 //! # }
 //! ```
 
+use crate::BoxError;
 use futures_core::{ready, Future};
 use http::{Request, Response};
 use http_body::Body;
@@ -44,7 +45,6 @@ use std::{
     time::Duration,
 };
 use tokio::time::{sleep, Sleep};
-use tower::BoxError;
 use tower_layer::Layer;
 use tower_service::Service;
 

--- a/tower-http/src/timeout/body.rs
+++ b/tower-http/src/timeout/body.rs
@@ -1,12 +1,13 @@
-//! Middleware that applies a timeout to bodies.
+//! Middleware that applies a timeout to request and response bodies.
 //!
 //! Bodies must produce data at most within the specified timeout.
-//! If they are inactive, an error will be generated.
+//! If the body does not produce a requested data frame within the timeout period, it will return an error.
 //!
-//! # Differences from `tower_http::timeout::service::Timeout`
+//! # Differences from [`tower_http::timeout::service::Timeout`]
 //!
-//! `tower_http::timeout::service::Timeout` applies a timeout on the full request.
+//! [`tower_http::timeout::service::Timeout`] applies a timeout to the request future, not body.
 //! That timeout is not reset when bytes are handled, whether the request is active or not.
+//! Bodies are handled asynchronously outside of the tower stack's future and thus needs an additional timeout.
 //!
 //! This middleware will return a [`TimeoutError`].
 //!

--- a/tower-http/src/timeout/body.rs
+++ b/tower-http/src/timeout/body.rs
@@ -38,13 +38,13 @@ use futures_core::{ready, Future};
 use http::{Request, Response};
 use http_body::Body;
 use pin_project_lite::pin_project;
-use tower::BoxError;
 use std::{
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
 };
 use tokio::time::{sleep, Sleep};
+use tower::BoxError;
 use tower_layer::Layer;
 use tower_service::Service;
 
@@ -94,7 +94,7 @@ where
 
         // Error if the timeout has expired.
         if let Poll::Ready(()) = sleep_pinned.poll(cx) {
-            return Poll::Ready(Some(Err(Box::new(TimeoutError(())))))
+            return Poll::Ready(Some(Err(Box::new(TimeoutError(())))));
         }
 
         // Check for body data.
@@ -102,11 +102,7 @@ where
         // Some data is ready. Reset the `Sleep`...
         this.sleep.set(None);
 
-        Poll::Ready(
-            data.transpose()
-                .map_err(Into::into)
-                .transpose(),
-        )
+        Poll::Ready(data.transpose().map_err(Into::into).transpose())
     }
 
     fn poll_trailers(
@@ -124,12 +120,10 @@ where
 
         // Error if the timeout has expired.
         if let Poll::Ready(()) = sleep_pinned.poll(cx) {
-            return Poll::Ready(Err(Box::new(TimeoutError(()))))
+            return Poll::Ready(Err(Box::new(TimeoutError(()))));
         }
 
-        this.body
-            .poll_trailers(cx)
-            .map_err(Into::into)
+        this.body.poll_trailers(cx).map_err(Into::into)
     }
 }
 

--- a/tower-http/src/timeout/body.rs
+++ b/tower-http/src/timeout/body.rs
@@ -1,0 +1,345 @@
+//! Middleware that applies a timeout to bodies.
+//!
+//! Bodies must produce data at most within the specified timeout.
+//! If they are inactive, an error will be generated.
+//!
+//! # Differences from `tower_http::timeout::service::Timeout`
+//!
+//! [`tower_http::timeout::service::Timeout`] applies a timeout on the full request.
+//! That timeout is not reset when bytes are handled, whether the request is active or not.
+//!
+//! This middleware will return a `TimeoutError`.
+//!
+//! # Example
+//!
+//! ```
+//! use http::{Request, Response};
+//! use hyper::Body;
+//! use std::time::Duration;
+//! use tower::ServiceBuilder;
+//! use tower_http::timeout::body::RequestTimeoutBodyLayer;
+//!
+//! async fn handle(_: Request<Body>) -> Result<Response<Body>, Infallible> {
+//!     // ...
+//!     # Ok(Response::new(Body::empty()))
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let svc = ServiceBuilder::new()
+//!     // Timeout bodies after 30 seconds of inactivity
+//!     .layer(RequestTimeoutBodyLayer::new(Duration::from_secs(30)))
+//!     .service_fn(handle);
+//! # Ok(())
+//! # }
+//! ```
+
+use std::{time::Duration, task::{Context, Poll}, pin::Pin};
+use http_body::Body;
+use futures_core::Future;
+use pin_project_lite::pin_project;
+use tokio::time::{Sleep, sleep};
+use http::{Request, Response};
+use tower_layer::Layer;
+use tower_service::Service;
+
+pin_project! {
+    /// Wrapper around a `http_body::Body` to time out if data is not ready within the specified duration.
+    pub struct TimeoutBody<B> {
+        timeout: Duration,
+        #[pin]
+        sleep: Option<Sleep>,
+        #[pin]
+        body: B,
+    }
+}
+
+impl<B> TimeoutBody<B> {
+    /// Create a new [`TimeoutBody`].
+    pub fn new(timeout: Duration, body: B) -> Self {
+        TimeoutBody {
+            timeout,
+            sleep: None,
+            body,
+        }
+    }
+}
+
+impl<B> Body for TimeoutBody<B>
+where
+    B: Body,
+{
+    type Data = B::Data;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    fn poll_data(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        let mut this = self.project();
+        
+        // Start the `Sleep` if not active.
+        let sleep_pinned = if let Some(some) = this.sleep.as_mut().as_pin_mut() {
+            some
+        } else {
+            this.sleep.set(Some(sleep(*this.timeout)));
+            this.sleep.as_mut().as_pin_mut().unwrap()
+        };
+
+        // Error if the timeout has expired.
+        match sleep_pinned.poll(cx) {
+            Poll::Pending => (),
+            Poll::Ready(()) => return Poll::Ready(Some(Err(Box::new(TimeoutError)))),
+        }
+
+        // Check for body data.
+        match this.body.poll_data(cx) {
+            Poll::Ready(data) => {
+                // Some data is ready. Reset the `Sleep`...
+                this.sleep.set(Some(sleep(*this.timeout)));
+
+                // ...then `poll` it to get awoken.
+                let _ = this.sleep.as_pin_mut().unwrap().poll(cx);
+                Poll::Ready(data.transpose().map_err(|_| Box::new(TimeoutError) as Self::Error).transpose())
+            }
+            Poll::Pending => Poll::Pending
+        }
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
+        let this = self.project();
+
+        // Error if the timeout has expired.
+        match this.sleep.as_pin_mut().expect("poll_data was not called").poll(cx) {
+            Poll::Pending => (),
+            Poll::Ready(()) => return Poll::Ready(Err(Box::new(TimeoutError))),
+        }
+
+        this.body.poll_trailers(cx).map_err(|_| Box::new(TimeoutError) as Self::Error)
+    }
+}
+
+/// Error for [`TimeoutBody`].
+#[derive(Debug)]
+pub struct TimeoutError;
+
+impl std::error::Error for TimeoutError {}
+
+impl std::fmt::Display for TimeoutError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TimeoutError")
+    }
+}
+
+/// Apply a TimeoutBody to the request body.
+#[derive(Clone, Debug)]
+pub struct RequestBodyTimeoutLayer {
+    timeout: Duration,
+}
+
+impl RequestBodyTimeoutLayer {
+    /// Create a new [`RequestBodyTimeoutLayer`].
+    pub fn new(timeout: Duration) -> Self {
+        Self { timeout }
+    }
+}
+
+impl<S> Layer<S> for RequestBodyTimeoutLayer
+{
+    type Service = RequestBodyTimeout<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RequestBodyTimeout::new(inner, self.timeout)
+    }
+}
+
+/// Apply a TimeoutBody to the request body.
+#[derive(Clone, Debug)]
+pub struct RequestBodyTimeout<S> {
+    inner: S,
+    timeout: Duration,
+}
+
+impl<S> RequestBodyTimeout<S> {
+    /// Create a new [`RequestBodyTimeout`].
+    pub fn new(service: S, timeout: Duration) -> Self {
+        Self { inner: service, timeout }
+    }
+
+    /// Returns a new [`Layer`] that wraps services with a `RequestBodyTimeoutLayer` middleware.
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(timeout: Duration) -> RequestBodyTimeoutLayer {
+        RequestBodyTimeoutLayer::new(timeout)
+    }
+
+    define_inner_service_accessors!();
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for RequestBodyTimeout<S>
+where
+    S: Service<Request<TimeoutBody<ReqBody>>, Response = Response<ResBody>>,
+    S::Error: Into<Box<dyn std::error::Error>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let req = req.map(|body| TimeoutBody::new(self.timeout, body));
+        self.inner.call(req)
+    }
+}
+
+/// Apply a TimeoutBody to the response body.
+#[derive(Clone)]
+pub struct ResponseBodyTimeoutLayer {
+    timeout: Duration,
+}
+
+impl ResponseBodyTimeoutLayer {
+    /// Create a new [`ResponseBodyTimeoutLayer`].
+    pub fn new(timeout: Duration) -> Self {
+        Self { timeout }
+    }
+}
+
+impl<S> Layer<S> for ResponseBodyTimeoutLayer {
+    type Service = ResponseBodyTimeout<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ResponseBodyTimeout::new(inner, self.timeout)
+    }
+}
+
+/// Apply a TimeoutBody to the response body.
+#[derive(Clone)]
+pub struct ResponseBodyTimeout<S> {
+    inner: S,
+    timeout: Duration,
+}
+
+impl<S> ResponseBodyTimeout<S> {
+    /// Create a new [`ResponseBodyTimeout`].
+    pub fn new(service: S, timeout: Duration) -> Self {
+        Self { inner: service, timeout }
+    }
+
+    /// Returns a new [`Layer`] that wraps services with a `ResponseBodyTimeoutLayer` middleware.
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(timeout: Duration) -> ResponseBodyTimeoutLayer {
+        ResponseBodyTimeoutLayer::new(timeout)
+    }
+
+    define_inner_service_accessors!();
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for ResponseBodyTimeout<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    S::Error: Into<Box<dyn std::error::Error>>,
+{
+    type Response = Response<TimeoutBody<ResBody>>;
+    type Error = S::Error;
+    type Future = ResponseBodyTimeoutFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        ResponseBodyTimeoutFuture { inner: self.inner.call(req), timeout: self.timeout }
+    }
+}
+
+pin_project! {
+    /// Response future for [`ResponseBodyTimeout`].
+    pub struct ResponseBodyTimeoutFuture<Fut> {
+        #[pin]
+        inner: Fut,
+        timeout: Duration,
+    }
+}
+
+use futures_core::ready;
+impl<Fut, ResBody, E> Future for ResponseBodyTimeoutFuture<Fut>
+where
+    Fut: Future<Output = Result<Response<ResBody>, E>>
+{
+    type Output = Result<Response<TimeoutBody<ResBody>>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let timeout = self.timeout;
+        let this = self.project();
+        let res = ready!(this.inner.poll(cx)?);
+        Poll::Ready(Ok(res.map(|body| TimeoutBody::new(timeout, body))))
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bytes::Bytes;
+    use pin_project_lite::pin_project;
+
+    struct MockError;
+
+    pin_project! {
+        struct MockBody {
+            #[pin]
+            sleep: Sleep
+        }
+    }
+
+    impl Body for MockBody {
+        type Data = Bytes;
+        type Error = MockError;
+
+        fn poll_data(
+                self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+            ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+            let this = self.project();
+            this.sleep.poll(cx).map(|_| Some(Ok(vec![].into())))
+        }
+
+        fn poll_trailers(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
+            todo!()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_body_available_within_timeout() {
+        let mock_sleep = Duration::from_secs(1);
+        let timeout_sleep = Duration::from_secs(2);
+
+        let mock_body = MockBody { sleep: sleep(mock_sleep) };
+        let timeout_body = TimeoutBody::new(timeout_sleep, mock_body);
+
+        assert!(timeout_body.boxed().data().await.unwrap().is_ok());
+    }
+    
+    #[tokio::test]
+    async fn test_body_unavailable_within_timeout_error() {
+        let mock_sleep = Duration::from_secs(2);
+        let timeout_sleep = Duration::from_secs(1);
+
+        let mock_body = MockBody { sleep: sleep(mock_sleep) };
+        let timeout_body = TimeoutBody::new(timeout_sleep, mock_body);
+
+        assert!(timeout_body.boxed().data().await.unwrap().is_err());
+    }
+}

--- a/tower-http/src/timeout/body.rs
+++ b/tower-http/src/timeout/body.rs
@@ -99,7 +99,9 @@ where
                 this.sleep.set(Some(sleep(*this.timeout)));
 
                 // ...then `poll` it to get awoken.
-                let _ = this.sleep.as_pin_mut().unwrap().poll(cx);
+                if let Poll::Ready(_) = this.sleep.as_pin_mut().unwrap().poll(cx) {
+                    return Poll::Ready(Some(Err(Box::new(TimeoutError))))
+                }
                 Poll::Ready(data.transpose().map_err(|_| Box::new(TimeoutError) as Self::Error).transpose())
             }
             Poll::Pending => Poll::Pending

--- a/tower-http/src/timeout/mod.rs
+++ b/tower-http/src/timeout/mod.rs
@@ -4,4 +4,7 @@ mod body;
 mod service;
 
 pub use body::{TimeoutBody, TimeoutError};
-pub use service::{RequestBodyTimeout, RequestBodyTimeoutLayer, ResponseBodyTimeout, ResponseBodyTimeoutLayer, Timeout, TimeoutLayer};
+pub use service::{
+    RequestBodyTimeout, RequestBodyTimeoutLayer, ResponseBodyTimeout, ResponseBodyTimeoutLayer,
+    Timeout, TimeoutLayer,
+};

--- a/tower-http/src/timeout/mod.rs
+++ b/tower-http/src/timeout/mod.rs
@@ -1,0 +1,4 @@
+//! Middleware for setting timeouts on requests and responses.
+
+pub mod body;
+pub mod service;

--- a/tower-http/src/timeout/mod.rs
+++ b/tower-http/src/timeout/mod.rs
@@ -3,11 +3,5 @@
 mod body;
 mod service;
 
-pub use body::TimeoutBody;
-pub use body::TimeoutError;
-pub use service::RequestBodyTimeout;
-pub use service::RequestBodyTimeoutLayer;
-pub use service::ResponseBodyTimeout;
-pub use service::ResponseBodyTimeoutLayer;
-pub use service::Timeout;
-pub use service::TimeoutLayer;
+pub use body::{TimeoutBody, TimeoutError};
+pub use service::{RequestBodyTimeout, RequestBodyTimeoutLayer, ResponseBodyTimeout, ResponseBodyTimeoutLayer, Timeout, TimeoutLayer};

--- a/tower-http/src/timeout/mod.rs
+++ b/tower-http/src/timeout/mod.rs
@@ -1,4 +1,13 @@
 //! Middleware for setting timeouts on requests and responses.
 
-pub mod body;
-pub mod service;
+mod body;
+mod service;
+
+pub use body::TimeoutBody;
+pub use body::TimeoutError;
+pub use service::RequestBodyTimeout;
+pub use service::RequestBodyTimeoutLayer;
+pub use service::ResponseBodyTimeout;
+pub use service::ResponseBodyTimeoutLayer;
+pub use service::Timeout;
+pub use service::TimeoutLayer;

--- a/tower-http/src/timeout/service.rs
+++ b/tower-http/src/timeout/service.rs
@@ -20,7 +20,7 @@
 //! use hyper::Body;
 //! use std::{convert::Infallible, time::Duration};
 //! use tower::ServiceBuilder;
-//! use tower_http::timeout::TimeoutLayer;
+//! use tower_http::timeout::service::TimeoutLayer;
 //!
 //! async fn handle(_: Request<Body>) -> Result<Response<Body>, Infallible> {
 //!     // ...

--- a/tower-http/src/timeout/service.rs
+++ b/tower-http/src/timeout/service.rs
@@ -20,7 +20,7 @@
 //! use hyper::Body;
 //! use std::{convert::Infallible, time::Duration};
 //! use tower::ServiceBuilder;
-//! use tower_http::timeout::service::TimeoutLayer;
+//! use tower_http::timeout::TimeoutLayer;
 //!
 //! async fn handle(_: Request<Body>) -> Result<Response<Body>, Infallible> {
 //!     // ...
@@ -244,7 +244,6 @@ impl<S> Layer<S> for ResponseBodyTimeoutLayer {
     }
 }
 
-
 /// Applies a [`TimeoutBody`] to the response body.
 #[derive(Clone)]
 pub struct ResponseBodyTimeout<S> {
@@ -314,4 +313,3 @@ where
         Poll::Ready(Ok(res.map(|body| TimeoutBody::new(timeout, body))))
     }
 }
-

--- a/tower-http/src/timeout/service.rs
+++ b/tower-http/src/timeout/service.rs
@@ -39,6 +39,8 @@
 //!
 //! [`Infallible`]: std::convert::Infallible
 
+use crate::timeout::body::TimeoutBody;
+use futures_core::ready;
 use http::{Request, Response, StatusCode};
 use pin_project_lite::pin_project;
 use std::{
@@ -154,3 +156,162 @@ where
         this.inner.poll(cx)
     }
 }
+
+/// Applies a [`TimeoutBody`] to the request body.
+#[derive(Clone, Debug)]
+pub struct RequestBodyTimeoutLayer {
+    timeout: Duration,
+}
+
+impl RequestBodyTimeoutLayer {
+    /// Creates a new [`RequestBodyTimeoutLayer`].
+    pub fn new(timeout: Duration) -> Self {
+        Self { timeout }
+    }
+}
+
+impl<S> Layer<S> for RequestBodyTimeoutLayer {
+    type Service = RequestBodyTimeout<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RequestBodyTimeout::new(inner, self.timeout)
+    }
+}
+
+/// Applies a [`TimeoutBody`] to the request body.
+#[derive(Clone, Debug)]
+pub struct RequestBodyTimeout<S> {
+    inner: S,
+    timeout: Duration,
+}
+
+impl<S> RequestBodyTimeout<S> {
+    /// Creates a new [`RequestBodyTimeout`].
+    pub fn new(service: S, timeout: Duration) -> Self {
+        Self {
+            inner: service,
+            timeout,
+        }
+    }
+
+    /// Returns a new [`Layer`] that wraps services with a [`RequestBodyTimeoutLayer`] middleware.
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(timeout: Duration) -> RequestBodyTimeoutLayer {
+        RequestBodyTimeoutLayer::new(timeout)
+    }
+
+    define_inner_service_accessors!();
+}
+
+impl<S, ReqBody> Service<Request<ReqBody>> for RequestBodyTimeout<S>
+where
+    S: Service<Request<TimeoutBody<ReqBody>>>,
+    S::Error: Into<Box<dyn std::error::Error>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let req = req.map(|body| TimeoutBody::new(self.timeout, body));
+        self.inner.call(req)
+    }
+}
+
+/// Applies a [`TimeoutBody`] to the response body.
+#[derive(Clone)]
+pub struct ResponseBodyTimeoutLayer {
+    timeout: Duration,
+}
+
+impl ResponseBodyTimeoutLayer {
+    /// Creates a new [`ResponseBodyTimeoutLayer`].
+    pub fn new(timeout: Duration) -> Self {
+        Self { timeout }
+    }
+}
+
+impl<S> Layer<S> for ResponseBodyTimeoutLayer {
+    type Service = ResponseBodyTimeout<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ResponseBodyTimeout::new(inner, self.timeout)
+    }
+}
+
+
+/// Applies a [`TimeoutBody`] to the response body.
+#[derive(Clone)]
+pub struct ResponseBodyTimeout<S> {
+    inner: S,
+    timeout: Duration,
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for ResponseBodyTimeout<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    S::Error: Into<Box<dyn std::error::Error>>,
+{
+    type Response = Response<TimeoutBody<ResBody>>;
+    type Error = S::Error;
+    type Future = ResponseBodyTimeoutFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        ResponseBodyTimeoutFuture {
+            inner: self.inner.call(req),
+            timeout: self.timeout,
+        }
+    }
+}
+
+impl<S> ResponseBodyTimeout<S> {
+    /// Creates a new [`ResponseBodyTimeout`].
+    pub fn new(service: S, timeout: Duration) -> Self {
+        Self {
+            inner: service,
+            timeout,
+        }
+    }
+
+    /// Returns a new [`Layer`] that wraps services with a [`ResponseBodyTimeoutLayer`] middleware.
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(timeout: Duration) -> ResponseBodyTimeoutLayer {
+        ResponseBodyTimeoutLayer::new(timeout)
+    }
+
+    define_inner_service_accessors!();
+}
+
+pin_project! {
+    /// Response future for [`ResponseBodyTimeout`].
+    pub struct ResponseBodyTimeoutFuture<Fut> {
+        #[pin]
+        inner: Fut,
+        timeout: Duration,
+    }
+}
+
+impl<Fut, ResBody, E> Future for ResponseBodyTimeoutFuture<Fut>
+where
+    Fut: Future<Output = Result<Response<ResBody>, E>>,
+{
+    type Output = Result<Response<TimeoutBody<ResBody>>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let timeout = self.timeout;
+        let this = self.project();
+        let res = ready!(this.inner.poll(cx))?;
+        Poll::Ready(Ok(res.map(|body| TimeoutBody::new(timeout, body))))
+    }
+}
+

--- a/tower-http/src/timeout/service.rs
+++ b/tower-http/src/timeout/service.rs
@@ -60,7 +60,7 @@ pub struct TimeoutLayer {
 }
 
 impl TimeoutLayer {
-    /// Create a new [`TimeoutLayer`].
+    /// Creates a new [`TimeoutLayer`].
     pub fn new(timeout: Duration) -> Self {
         TimeoutLayer { timeout }
     }
@@ -87,7 +87,7 @@ pub struct Timeout<S> {
 }
 
 impl<S> Timeout<S> {
-    /// Create a new [`Timeout`].
+    /// Creates a new [`Timeout`].
     pub fn new(inner: S, timeout: Duration) -> Self {
         Self { inner, timeout }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

Explained in #295. This PR closes #295.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Wrap the body in a `TimeoutBody`. `TimeoutBody` will poll a sleep future to check whether the body is inactive and register itself to be awoken. The sleep future is polled and checked right after creation to avoid a potential delay in execution making the executor to never poll the sleep future again. That is, if between creation and `poll` on sleep the time runs out and the sleep is done, a timeout error is immediately returned
