### PR TITLE
Bump MSRV to 1.60

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.60
+        toolchain: 1.60.0
         profile: minimal
         override: true
     - name: Run tests
@@ -88,6 +88,7 @@ jobs:
       with:
         command: test
         args: -p tower-http --all-features
+        toolchain: 1.60.0
 
   style:
     needs: check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,14 +74,13 @@ jobs:
         args: --workspace --all-features
 
   test-msrv:
-    # some examples don't compile on 1.46, so just test tower-http itself
     needs: check
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.56
+        toolchain: 1.60
         profile: minimal
         override: true
     - name: Run tests

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The [examples] folder contains various examples of how to use Tower HTTP:
 
 ## Minimum supported Rust version
 
-tower-http's MSRV is 1.56.
+tower-http's MSRV is 1.60.
 
 ## Getting Help
 


### PR DESCRIPTION
## Motivation

It isn't strictly necessary to bump tower-http's MSRV but updating the axum example to axum 0.6.0 requires it (see https://github.com/tower-rs/tower-http/actions/runs/3572751813/jobs/6006052913)

1.56 is also quite old so probably fine to bump anyways.

## Solution

Bump it!

Bumping MSRV is generally not considered a breaking change.