### PR TITLE
Call `ServeDir`'s fallback on non-uft8 request paths

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -25,10 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **trace:** Correctly identify gRPC requests in default `on_response` callback ([#278])
 - **cors:** Panic if a wildcard (`*`) is passed to `AllowOrigin::list`. Use
   `AllowOrigin::any()` instead ([#285])
-- **serve_dir:** Call the fallback on non-uft8 request paths
+- **serve_dir:** Call the fallback on non-uft8 request paths ([#310])
 
 [#278]: https://github.com/tower-rs/tower-http/pull/278
 [#285]: https://github.com/tower-rs/tower-http/pull/285
+[#310]: https://github.com/tower-rs/tower-http/pull/310
 
 # 0.3.4 (June 06, 2022)
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **trace:** Correctly identify gRPC requests in default `on_response` callback ([#278])
 - **cors:** Panic if a wildcard (`*`) is passed to `AllowOrigin::list`. Use
   `AllowOrigin::any()` instead ([#285])
+- **serve_dir:** Call the fallback on non-uft8 request paths
 
 [#278]: https://github.com/tower-rs/tower-http/pull/278
 [#285]: https://github.com/tower-rs/tower-http/pull/285


### PR DESCRIPTION
Fixes https://github.com/tower-rs/tower-http/issues/308