### PR TITLE
Bump iri-string to 0.7.0 and use shorter type names

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -27,7 +27,7 @@ tower-service = "0.3"
 async-compression = { version = "0.3", optional = true, features = ["tokio"] }
 base64 = { version = "0.13", optional = true }
 http-range-header = "0.3.0"
-iri-string = { version = "0.4", optional = true }
+iri-string = { version = "0.7.0", optional = true }
 mime = { version = "0.3", optional = true, default_features = false }
 mime_guess = { version = "2", optional = true, default_features = false }
 percent-encoding = { version = "2.1.0", optional = true }

--- a/tower-http/src/follow_redirect/mod.rs
+++ b/tower-http/src/follow_redirect/mod.rs
@@ -99,10 +99,7 @@ use http::{
     header::LOCATION, HeaderMap, HeaderValue, Method, Request, Response, StatusCode, Uri, Version,
 };
 use http_body::Body;
-use iri_string::{
-    spec::UriSpec,
-    types::{RiAbsoluteString, RiReferenceStr},
-};
+use iri_string::types::{UriAbsoluteString, UriReferenceStr};
 use pin_project_lite::pin_project;
 use std::{
     convert::TryFrom,
@@ -380,10 +377,10 @@ where
 
 /// Try to resolve a URI reference `relative` against a base URI `base`.
 fn resolve_uri(relative: &str, base: &Uri) -> Option<Uri> {
-    let relative = RiReferenceStr::<UriSpec>::new(relative).ok()?;
-    let base = RiAbsoluteString::try_from(base.to_string()).ok()?;
-    let uri = relative.resolve_against(&base);
-    Uri::try_from(uri.as_str()).ok()
+    let relative = UriReferenceStr::new(relative).ok()?;
+    let base = UriAbsoluteString::try_from(base.to_string()).ok()?;
+    let uri = relative.resolve_against(&base).to_string();
+    Uri::try_from(uri).ok()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR bumps the internal dependency to iri-string crate to the latest stable version.

(Disclaimer: I am the author of iri-string crate.)

This is retry of #225.

## Motivation

* Better performance
* Reduced indirect dependencies
## Solution

Bump the dependency to `iri-string` from 0.4.0 to 0.7.0.