### PR TITLE
Support configurable backend for `ServeDir`

### DIFF
--- a/test-files/subdir/foo.txt
+++ b/test-files/subdir/foo.txt
@@ -1,0 +1,1 @@
+Hi from foo.txt

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -50,6 +50,7 @@ tower = { version = "0.4.10", features = ["buffer", "util", "retry", "make", "ti
 tracing-subscriber = "0.3"
 uuid = { version = "1.0", features = ["v4"] }
 serde_json = "1.0"
+rust-embed = "6.4"
 
 [features]
 default = []

--- a/tower-http/src/services/fs/backend.rs
+++ b/tower-http/src/services/fs/backend.rs
@@ -1,0 +1,98 @@
+use futures_util::future::BoxFuture;
+use std::{future::Future, io, path::Path, time::SystemTime};
+use tokio::io::{AsyncRead, AsyncSeek};
+
+// TODO(david): try and rewrite this using async-trait to see if that matters much
+// currently this requires GATs which is maybe pushing tower-http's MSRV a bit?
+//
+// async-trait is unfortunate because it requires syn+quote and requiring allocations
+// futures is unfortunate if the data is in the binary, as for rust-embed
+
+// TODO(david): implement a backend using rust-embed to prove that its possible
+
+pub trait Backend: Clone + Send + Sync + 'static {
+    type File: File<Metadata = Self::Metadata>;
+    type Metadata: Metadata;
+
+    type OpenFuture: Future<Output = io::Result<Self::File>> + Send;
+    type MetadataFuture: Future<Output = io::Result<Self::Metadata>> + Send;
+
+    fn open<A>(&self, path: A) -> Self::OpenFuture
+    where
+        A: AsRef<Path>;
+
+    fn metadata<A>(&self, path: A) -> Self::MetadataFuture
+    where
+        A: AsRef<Path>;
+}
+
+pub trait Metadata: Send + 'static {
+    fn is_dir(&self) -> bool;
+
+    fn modified(&self) -> io::Result<SystemTime>;
+
+    fn len(&self) -> u64;
+}
+
+pub trait File: AsyncRead + AsyncSeek + Unpin + Send + Sync {
+    type Metadata: Metadata;
+    type MetadataFuture<'a>: Future<Output = io::Result<Self::Metadata>> + Send
+    where
+        Self: 'a;
+
+    fn metadata(&self) -> Self::MetadataFuture<'_>;
+}
+
+#[derive(Default, Debug, Clone)]
+#[non_exhaustive]
+pub struct TokioBackend;
+
+impl Backend for TokioBackend {
+    type File = tokio::fs::File;
+    type Metadata = std::fs::Metadata;
+
+    type OpenFuture = BoxFuture<'static, io::Result<Self::File>>;
+    type MetadataFuture = BoxFuture<'static, io::Result<Self::Metadata>>;
+
+    fn open<A>(&self, path: A) -> Self::OpenFuture
+    where
+        A: AsRef<Path>,
+    {
+        let path = path.as_ref().to_owned();
+        Box::pin(tokio::fs::File::open(path))
+    }
+
+    fn metadata<A>(&self, path: A) -> Self::MetadataFuture
+    where
+        A: AsRef<Path>,
+    {
+        let path = path.as_ref().to_owned();
+        Box::pin(tokio::fs::metadata(path))
+    }
+}
+
+impl File for tokio::fs::File {
+    type Metadata = std::fs::Metadata;
+    type MetadataFuture<'a> = BoxFuture<'a, io::Result<Self::Metadata>>;
+
+    fn metadata(&self) -> Self::MetadataFuture<'_> {
+        Box::pin(self.metadata())
+    }
+}
+
+impl Metadata for std::fs::Metadata {
+    #[inline]
+    fn is_dir(&self) -> bool {
+        self.is_dir()
+    }
+
+    #[inline]
+    fn modified(&self) -> io::Result<SystemTime> {
+        self.modified()
+    }
+
+    #[inline]
+    fn len(&self) -> u64 {
+        self.len()
+    }
+}

--- a/tower-http/src/services/fs/mod.rs
+++ b/tower-http/src/services/fs/mod.rs
@@ -13,10 +13,12 @@ use std::{
 use tokio::io::{AsyncRead, AsyncReadExt, Take};
 use tokio_util::io::ReaderStream;
 
+mod backend;
 mod serve_dir;
 mod serve_file;
 
 pub use self::{
+    backend::{Backend, File, Metadata},
     serve_dir::{
         future::ResponseFuture as ServeFileSystemResponseFuture,
         DefaultServeDirFallback,


### PR DESCRIPTION
Still work-in-progress. I wanna actually implement a backend using [rust-embed](https://crates.io/crates/rust-embed) to make sure it works and there are some TODOs with unanswered questions in the code.

Fixes https://github.com/tower-rs/tower-http/issues/309