### PR TITLE
Don't include identity in Content-Encoding header

### DIFF
--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -2,7 +2,7 @@ use super::{
     open_file::{FileOpened, FileRequestExtent, OpenFileOutput},
     DefaultServeDirFallback, ResponseBody,
 };
-use crate::{services::fs::AsyncReadBody, BoxError, content_encoding::Encoding};
+use crate::{content_encoding::Encoding, services::fs::AsyncReadBody, BoxError};
 use bytes::Bytes;
 use futures_util::{
     future::{BoxFuture, FutureExt, TryFutureExt},
@@ -214,11 +214,11 @@ fn build_response(output: FileOpened) -> Response<ResponseBody> {
         .header(header::CONTENT_TYPE, output.mime_header_value)
         .header(header::ACCEPT_RANGES, "bytes");
 
-    if let Some(encoding) = output.maybe_encoding {
-        // Identity encoding should not be included in the header
-        if encoding != Encoding::Identity {
-            builder = builder.header(header::CONTENT_ENCODING, encoding.into_header_value());
-        }
+    if let Some(encoding) = output
+        .maybe_encoding
+        .filter(|encoding| *encoding != Encoding::Identity)
+    {
+        builder = builder.header(header::CONTENT_ENCODING, encoding.into_header_value());
     }
 
     if let Some(last_modified) = output.last_modified {

--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -2,7 +2,7 @@ use super::{
     open_file::{FileOpened, FileRequestExtent, OpenFileOutput},
     DefaultServeDirFallback, ResponseBody,
 };
-use crate::{services::fs::AsyncReadBody, BoxError};
+use crate::{services::fs::AsyncReadBody, BoxError, content_encoding::Encoding};
 use bytes::Bytes;
 use futures_util::{
     future::{BoxFuture, FutureExt, TryFutureExt},
@@ -215,7 +215,10 @@ fn build_response(output: FileOpened) -> Response<ResponseBody> {
         .header(header::ACCEPT_RANGES, "bytes");
 
     if let Some(encoding) = output.maybe_encoding {
-        builder = builder.header(header::CONTENT_ENCODING, encoding.into_header_value());
+        // Identity encoding should not be included in the header
+        if encoding != Encoding::Identity {
+            builder = builder.header(header::CONTENT_ENCODING, encoding.into_header_value());
+        }
     }
 
     if let Some(last_modified) = output.last_modified {

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -516,6 +516,21 @@ async fn read_partial_errs_on_bad_range() {
         &format!("bytes */{}", file_contents.len())
     )
 }
+
+#[tokio::test]
+async fn accept_encoding_identity() {
+    let svc = ServeDir::new("..");
+    let req = Request::builder()
+        .uri("/README.md")
+        .header("Accept-Encoding", "identity")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    // Identity encoding should not be included in the response headers
+    assert!(res.headers().get("content-encoding").is_none());
+}
+
 #[tokio::test]
 async fn last_modified() {
     let svc = ServeDir::new("..");


### PR DESCRIPTION
According to the [spec][1] `identity` should only be used for the Accept-Encoding header and not be included in Content-Encoding.

In practice this change fixes chunked video loading in Firefox when using `ServeDir`. (making seeking possible without downloading the whole video file)

[1]: https://httpwg.org/specs/rfc9110.html#field.content-encoding
