### PR TITLE
Do compress SVGs

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -25,11 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 - Don't include identity in Content-Encoding header ([#317])
-- **compression:** Do compress SVGs
+- **compression:** Do compress SVGs ([#321])
 
 [#290]: https://github.com/tower-rs/tower-http/pull/290
 [#283]: https://github.com/tower-rs/tower-http/pull/283
 [#317]: https://github.com/tower-rs/tower-http/pull/317
+[#321]: https://github.com/tower-rs/tower-http/pull/321
 
 # 0.3.5 (December 02, 2022)
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 - Don't include identity in Content-Encoding header ([#317])
+- **compression:** Do compress SVGs
 
 [#290]: https://github.com/tower-rs/tower-http/pull/290
 [#283]: https://github.com/tower-rs/tower-http/pull/283

--- a/tower-http/src/compression/predicate.rs
+++ b/tower-http/src/compression/predicate.rs
@@ -145,7 +145,7 @@ impl Predicate for DefaultPredicate {
 pub struct SizeAbove(u16);
 
 impl SizeAbove {
-    const DEFAULT_MIN_SIZE: u16 = 32;
+    pub(crate) const DEFAULT_MIN_SIZE: u16 = 32;
 
     /// Create a new `SizeAbove` predicate that will only compress responses larger than
     /// `min_size_bytes`.
@@ -185,23 +185,35 @@ impl Predicate for SizeAbove {
 
 /// Predicate that wont allow responses with a specific `content-type` to be compressed.
 #[derive(Clone, Debug)]
-pub struct NotForContentType(Str);
+pub struct NotForContentType {
+    content_type: Str,
+    exception: Option<Str>,
+}
 
 impl NotForContentType {
     /// Predicate that wont compress gRPC responses.
     pub const GRPC: Self = Self::const_new("application/grpc");
 
     /// Predicate that wont compress images.
-    pub const IMAGES: Self = Self::const_new("image/");
+    pub const IMAGES: Self = Self {
+        content_type: Str::Static("image/"),
+        exception: Some(Str::Static("image/svg+xml")),
+    };
 
     /// Create a new `NotForContentType`.
     pub fn new(content_type: &str) -> Self {
-        Self(Str::Shared(content_type.into()))
+        Self {
+            content_type: Str::Shared(content_type.into()),
+            exception: None,
+        }
     }
 
     /// Create a new `NotForContentType` from a static string.
     pub const fn const_new(content_type: &'static str) -> Self {
-        Self(Str::Static(content_type))
+        Self {
+            content_type: Str::Static(content_type),
+            exception: None,
+        }
     }
 }
 
@@ -210,11 +222,13 @@ impl Predicate for NotForContentType {
     where
         B: Body,
     {
-        let str = match &self.0 {
-            Str::Static(str) => *str,
-            Str::Shared(arc) => &*arc,
-        };
-        !content_type(response).starts_with(str)
+        if let Some(except) = &self.exception {
+            if content_type(response) == except.as_str() {
+                return true;
+            }
+        }
+
+        !content_type(response).starts_with(self.content_type.as_str())
     }
 }
 
@@ -222,6 +236,15 @@ impl Predicate for NotForContentType {
 enum Str {
     Static(&'static str),
     Shared(Arc<str>),
+}
+
+impl Str {
+    fn as_str(&self) -> &str {
+        match self {
+            Str::Static(s) => s,
+            Str::Shared(s) => s,
+        }
+    }
 }
 
 impl fmt::Debug for Str {


### PR DESCRIPTION
Even though they're images they're really just xml, so should still be compressed.

Fixes https://github.com/tower-rs/tower-http/issues/320