### PR TITLE
Impl `Default` for `CompressionBody` when possible

### DIFF
--- a/tower-http/src/compression/body.rs
+++ b/tower-http/src/compression/body.rs
@@ -38,6 +38,19 @@ pin_project! {
     }
 }
 
+impl<B> Default for CompressionBody<B>
+where
+    B: Body + Default,
+{
+    fn default() -> Self {
+        Self {
+            inner: BodyInner::Identity {
+                inner: B::default(),
+            },
+        }
+    }
+}
+
 impl<B> CompressionBody<B>
 where
     B: Body,


### PR DESCRIPTION
This allows interop with `tonic::transport::Server` and `tonic::transport::server::Router::serve_with_shutdown` which require that the responses implement `Default`.

**EDIT**: It turns out that this `Default` requirement was actually coming from `CorsMiddleware` from this crate.

I was able to work around this by switching the order of the middleware to put `CompressionLayer` before `CorsLayer`.  It's up to you all if you still want to merge this, but yeah.

## Motivation

When trying to use `CompressionLayer` in a `tonic::transport::Server`, I was unable to due to missing `Default` implementation on the `CompressionBody`.

```
error[E0277]: the trait bound `CompressionBody<UnsyncBoxBody<bytes::Bytes, tonic::Status>>: std::default::Default` is not satisfied
   --> control_plane/src/server.rs:158:10
    |
158 |         .serve_with_shutdown(addr, shutdown_signal())
    |          ^^^^^^^^^^^^^^^^^^^ the trait `std::default::Default` is not implemented for `CompressionBody<UnsyncBoxBody<bytes::Bytes, tonic::Status>>`
    |
    = help: the trait `Service<http::Request<hyper::Body>>` is implemented for `foundation::middleware::request_id::RequestIdMiddleware<S>`
    = note: required for `tower_http::cors::Cors<Compression<Routes, OnlyCompressGrpcWebPredicate>>` to implement `Service<http::Request<hyper::Body>>`
    = note: 2 redundant requirements hidden
    = note: required for `foundation::middleware::request_id::RequestIdMiddleware<foundation::middleware::logging::LoggingMiddleware<tower_http::propagate_header::PropagateHeader<tower_http::cors::Cors<Compression<Routes, OnlyCompressGrpcWebPredicate>>>>>` to implement `Service<http::Request<hyper::Body>>`
```

## Solution

This implements a trivial `Default` for `CompressionBody` when the inner `Body` also implements `Default`.
