### PR TITLE
ServeDir: convert io::ErrorKind::NotADirectory to not_found

### DIFF
--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -124,9 +124,13 @@ where
                     }
 
                     Err(err) => {
-                        if let io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied =
-                            err.kind()
-                        {
+                        if matches!(
+                            err.kind(),
+                            io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied
+                        ) || (
+                            //20 = libc::ENOTDIR => "not a directory
+                            err.raw_os_error() == Some(20)
+                        ) {
                             if let Some((mut fallback, request)) = fallback_and_request.take() {
                                 call_fallback(&mut fallback, request)
                             } else {

--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -35,6 +35,8 @@ const DEFAULT_CAPACITY: usize = 65536;
 /// - The file doesn't exist
 /// - Any segment of the path contains `..`
 /// - Any segment of the path contains a backslash
+/// - On unix, any segment of the path referenced as directory is actually an
+///   existing file (`/file.html/something`)
 /// - We don't have necessary permissions to read the file
 ///
 /// # Example

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -289,6 +289,7 @@ async fn not_found() {
     assert!(body.is_empty());
 }
 
+#[cfg(unix)]
 #[tokio::test]
 async fn not_found_when_not_a_directory() {
     let svc = ServeDir::new("../test-files");

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -290,6 +290,26 @@ async fn not_found() {
 }
 
 #[tokio::test]
+async fn not_found_when_not_a_directory() {
+    let svc = ServeDir::new("../test-files");
+
+    // `index.html` is a file, and we are trying to request
+    // it as a directory.
+    let req = Request::builder()
+        .uri("/index.html/some_file")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    // This should lead to a 404
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    assert!(res.headers().get(header::CONTENT_TYPE).is_none());
+
+    let body = body_into_text(res.into_body()).await;
+    assert!(body.is_empty());
+}
+
+#[tokio::test]
 async fn not_found_precompressed() {
     let svc = ServeDir::new("../test-files").precompressed_gzip();
 


### PR DESCRIPTION
## Motivation

In docs.rs we were seeing server errors on requests like `/-/static/index.js/979790` when `index.js` actually existed. 

The error we are seeing was:  "Not a directory (os error 20)". 

## Solution

If I'm not missing something this should be a "not found" error. 

I'm not 100% certain if accessing `raw_os_error` is good enough here, but `ErrorKind::NotADirectory` is not on stable yet (see [`io_error_more`](https://github.com/rust-lang/rust/issues/86442)). ~~Since this is coming from libc I assume this is portable.~~ 

I'm happy to add any needed changes, to close this if you disagree with my solution. 

