### PR TITLE
Expose compression quality on the CompressionLayer

### DIFF
--- a/tower-http/src/compression/body.rs
+++ b/tower-http/src/compression/body.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
 
-use crate::compression::Level;
+use crate::compression::CompressionLevel;
 use crate::{
     compression_utils::{AsyncReadBody, BodyIntoStream, DecorateAsyncRead, WrapBody},
     BoxError,
@@ -296,7 +296,7 @@ where
     type Input = AsyncReadBody<B>;
     type Output = GzipEncoder<Self::Input>;
 
-    fn apply(input: Self::Input, quality: Level) -> Self::Output {
+    fn apply(input: Self::Input, quality: CompressionLevel) -> Self::Output {
         GzipEncoder::with_quality(input, quality.into())
     }
 
@@ -313,7 +313,7 @@ where
     type Input = AsyncReadBody<B>;
     type Output = ZlibEncoder<Self::Input>;
 
-    fn apply(input: Self::Input, quality: Level) -> Self::Output {
+    fn apply(input: Self::Input, quality: CompressionLevel) -> Self::Output {
         ZlibEncoder::with_quality(input, quality.into())
     }
 
@@ -330,7 +330,7 @@ where
     type Input = AsyncReadBody<B>;
     type Output = BrotliEncoder<Self::Input>;
 
-    fn apply(input: Self::Input, quality: Level) -> Self::Output {
+    fn apply(input: Self::Input, quality: CompressionLevel) -> Self::Output {
         BrotliEncoder::with_quality(input, quality.into())
     }
 
@@ -347,7 +347,7 @@ where
     type Input = AsyncReadBody<B>;
     type Output = ZstdEncoder<Self::Input>;
 
-    fn apply(input: Self::Input, quality: Level) -> Self::Output {
+    fn apply(input: Self::Input, quality: CompressionLevel) -> Self::Output {
         ZstdEncoder::with_quality(input, quality.into())
     }
 

--- a/tower-http/src/compression/body.rs
+++ b/tower-http/src/compression/body.rs
@@ -24,6 +24,7 @@ use std::{
     task::{Context, Poll},
 };
 use tokio_util::io::StreamReader;
+use crate::compression::Level;
 
 use super::pin_project_cfg::pin_project_cfg;
 
@@ -295,8 +296,8 @@ where
     type Input = AsyncReadBody<B>;
     type Output = GzipEncoder<Self::Input>;
 
-    fn apply(input: Self::Input) -> Self::Output {
-        GzipEncoder::new(input)
+    fn apply(input: Self::Input, quality: Level) -> Self::Output {
+        GzipEncoder::with_quality(input, quality.into())
     }
 
     fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {
@@ -312,8 +313,8 @@ where
     type Input = AsyncReadBody<B>;
     type Output = ZlibEncoder<Self::Input>;
 
-    fn apply(input: Self::Input) -> Self::Output {
-        ZlibEncoder::new(input)
+    fn apply(input: Self::Input, quality: Level) -> Self::Output {
+        ZlibEncoder::with_quality(input, quality.into())
     }
 
     fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {
@@ -329,8 +330,8 @@ where
     type Input = AsyncReadBody<B>;
     type Output = BrotliEncoder<Self::Input>;
 
-    fn apply(input: Self::Input) -> Self::Output {
-        BrotliEncoder::new(input)
+    fn apply(input: Self::Input, quality: Level) -> Self::Output {
+        BrotliEncoder::with_quality(input, quality.into())
     }
 
     fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {
@@ -346,8 +347,8 @@ where
     type Input = AsyncReadBody<B>;
     type Output = ZstdEncoder<Self::Input>;
 
-    fn apply(input: Self::Input) -> Self::Output {
-        ZstdEncoder::new(input)
+    fn apply(input: Self::Input, quality: Level) -> Self::Output {
+        ZstdEncoder::with_quality(input, quality.into())
     }
 
     fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {

--- a/tower-http/src/compression/body.rs
+++ b/tower-http/src/compression/body.rs
@@ -1,5 +1,6 @@
 #![allow(unused_imports)]
 
+use crate::compression::Level;
 use crate::{
     compression_utils::{AsyncReadBody, BodyIntoStream, DecorateAsyncRead, WrapBody},
     BoxError,
@@ -24,7 +25,6 @@ use std::{
     task::{Context, Poll},
 };
 use tokio_util::io::StreamReader;
-use crate::compression::Level;
 
 use super::pin_project_cfg::pin_project_cfg;
 

--- a/tower-http/src/compression/body.rs
+++ b/tower-http/src/compression/body.rs
@@ -13,6 +13,7 @@ use async_compression::tokio::bufread::GzipEncoder;
 use async_compression::tokio::bufread::ZlibEncoder;
 #[cfg(feature = "compression-zstd")]
 use async_compression::tokio::bufread::ZstdEncoder;
+
 use bytes::{Buf, Bytes};
 use futures_util::ready;
 use http::HeaderMap;
@@ -297,7 +298,7 @@ where
     type Output = GzipEncoder<Self::Input>;
 
     fn apply(input: Self::Input, quality: CompressionLevel) -> Self::Output {
-        GzipEncoder::with_quality(input, quality.into())
+        GzipEncoder::with_quality(input, quality.into_async_compression())
     }
 
     fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {
@@ -314,7 +315,7 @@ where
     type Output = ZlibEncoder<Self::Input>;
 
     fn apply(input: Self::Input, quality: CompressionLevel) -> Self::Output {
-        ZlibEncoder::with_quality(input, quality.into())
+        ZlibEncoder::with_quality(input, quality.into_async_compression())
     }
 
     fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {
@@ -331,7 +332,7 @@ where
     type Output = BrotliEncoder<Self::Input>;
 
     fn apply(input: Self::Input, quality: CompressionLevel) -> Self::Output {
-        BrotliEncoder::with_quality(input, quality.into())
+        BrotliEncoder::with_quality(input, quality.into_async_compression())
     }
 
     fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {
@@ -348,7 +349,7 @@ where
     type Output = ZstdEncoder<Self::Input>;
 
     fn apply(input: Self::Input, quality: CompressionLevel) -> Self::Output {
-        ZstdEncoder::with_quality(input, quality.into())
+        ZstdEncoder::with_quality(input, quality.into_async_compression())
     }
 
     fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {

--- a/tower-http/src/compression/future.rs
+++ b/tower-http/src/compression/future.rs
@@ -2,7 +2,7 @@
 
 use super::{body::BodyInner, CompressionBody};
 use crate::compression::predicate::Predicate;
-use crate::compression::Level;
+use crate::compression::CompressionLevel;
 use crate::compression_utils::WrapBody;
 use crate::content_encoding::Encoding;
 use futures_util::ready;
@@ -25,7 +25,7 @@ pin_project! {
         pub(crate) inner: F,
         pub(crate) encoding: Encoding,
         pub(crate) predicate: P,
-        pub(crate) quality: Level,
+        pub(crate) quality: CompressionLevel,
     }
 }
 

--- a/tower-http/src/compression/future.rs
+++ b/tower-http/src/compression/future.rs
@@ -2,9 +2,9 @@
 
 use super::{body::BodyInner, CompressionBody};
 use crate::compression::predicate::Predicate;
+use crate::compression::Level;
 use crate::compression_utils::WrapBody;
 use crate::content_encoding::Encoding;
-use crate::compression::Level;
 use futures_util::ready;
 use http::{header, HeaderMap, HeaderValue, Response};
 use http_body::Body;
@@ -57,13 +57,21 @@ where
             }
 
             #[cfg(feature = "compression-gzip")]
-            (_, Encoding::Gzip) => CompressionBody::new(BodyInner::gzip(WrapBody::new(body, self.quality))),
+            (_, Encoding::Gzip) => {
+                CompressionBody::new(BodyInner::gzip(WrapBody::new(body, self.quality)))
+            }
             #[cfg(feature = "compression-deflate")]
-            (_, Encoding::Deflate) => CompressionBody::new(BodyInner::deflate(WrapBody::new(body, self.quality))),
+            (_, Encoding::Deflate) => {
+                CompressionBody::new(BodyInner::deflate(WrapBody::new(body, self.quality)))
+            }
             #[cfg(feature = "compression-br")]
-            (_, Encoding::Brotli) => CompressionBody::new(BodyInner::brotli(WrapBody::new(body, self.quality))),
+            (_, Encoding::Brotli) => {
+                CompressionBody::new(BodyInner::brotli(WrapBody::new(body, self.quality)))
+            }
             #[cfg(feature = "compression-zstd")]
-            (_, Encoding::Zstd) => CompressionBody::new(BodyInner::zstd(WrapBody::new(body, self.quality))),
+            (_, Encoding::Zstd) => {
+                CompressionBody::new(BodyInner::zstd(WrapBody::new(body, self.quality)))
+            }
             #[cfg(feature = "fs")]
             (true, _) => {
                 // This should never happen because the `AcceptEncoding` struct which is used to determine

--- a/tower-http/src/compression/future.rs
+++ b/tower-http/src/compression/future.rs
@@ -4,6 +4,7 @@ use super::{body::BodyInner, CompressionBody};
 use crate::compression::predicate::Predicate;
 use crate::compression_utils::WrapBody;
 use crate::content_encoding::Encoding;
+use crate::compression::Level;
 use futures_util::ready;
 use http::{header, HeaderMap, HeaderValue, Response};
 use http_body::Body;
@@ -23,7 +24,8 @@ pin_project! {
         #[pin]
         pub(crate) inner: F,
         pub(crate) encoding: Encoding,
-        pub(crate) predicate: P
+        pub(crate) predicate: P,
+        pub(crate) quality: Level,
     }
 }
 
@@ -55,17 +57,17 @@ where
             }
 
             #[cfg(feature = "compression-gzip")]
-            (_, Encoding::Gzip) => CompressionBody::new(BodyInner::gzip(WrapBody::new(body))),
+            (_, Encoding::Gzip) => CompressionBody::new(BodyInner::gzip(WrapBody::new(body, self.quality))),
             #[cfg(feature = "compression-deflate")]
-            (_, Encoding::Deflate) => CompressionBody::new(BodyInner::deflate(WrapBody::new(body))),
+            (_, Encoding::Deflate) => CompressionBody::new(BodyInner::deflate(WrapBody::new(body, self.quality))),
             #[cfg(feature = "compression-br")]
-            (_, Encoding::Brotli) => CompressionBody::new(BodyInner::brotli(WrapBody::new(body))),
+            (_, Encoding::Brotli) => CompressionBody::new(BodyInner::brotli(WrapBody::new(body, self.quality))),
             #[cfg(feature = "compression-zstd")]
-            (_, Encoding::Zstd) => CompressionBody::new(BodyInner::zstd(WrapBody::new(body))),
+            (_, Encoding::Zstd) => CompressionBody::new(BodyInner::zstd(WrapBody::new(body, self.quality))),
             #[cfg(feature = "fs")]
             (true, _) => {
                 // This should never happen because the `AcceptEncoding` struct which is used to determine
-                // `self.encoding` will only enable the different compression algorightms if the
+                // `self.encoding` will only enable the different compression algorithms if the
                 // corresponding crate feature has been enabled. This means
                 // Encoding::[Gzip|Brotli|Deflate] should be impossible at this point without the
                 // features enabled.
@@ -76,7 +78,7 @@ where
                 // to compile without this branch even though it will never be reached.
                 //
                 // To safeguard against refactors that changes this relationship or other bugs the
-                // server will return an uncompressed response instead of panicing since that could
+                // server will return an uncompressed response instead of panicking since that could
                 // become a ddos attack vector.
                 return Poll::Ready(Ok(Response::from_parts(
                     parts,

--- a/tower-http/src/compression/layer.rs
+++ b/tower-http/src/compression/layer.rs
@@ -1,6 +1,7 @@
 use super::{Compression, Predicate};
 use crate::compression::predicate::DefaultPredicate;
 use crate::compression_utils::AcceptEncoding;
+use crate::compression::Level;
 use tower_layer::Layer;
 
 /// Compress response bodies of the underlying service.
@@ -13,6 +14,7 @@ use tower_layer::Layer;
 pub struct CompressionLayer<P = DefaultPredicate> {
     accept: AcceptEncoding,
     predicate: P,
+    quality: Level
 }
 
 impl<S, P> Layer<S> for CompressionLayer<P>
@@ -26,6 +28,7 @@ where
             inner,
             accept: self.accept,
             predicate: self.predicate.clone(),
+            quality: self.quality,
         }
     }
 }
@@ -61,6 +64,12 @@ impl CompressionLayer {
     #[cfg(feature = "compression-zstd")]
     pub fn zstd(mut self, enable: bool) -> Self {
         self.accept.set_zstd(enable);
+        self
+    }
+
+    /// Sets the compression quality.
+    pub fn quality(mut self, quality: Level) -> Self {
+        self.quality = quality;
         self
     }
 
@@ -106,6 +115,7 @@ impl CompressionLayer {
         CompressionLayer {
             accept: self.accept,
             predicate,
+            quality: self.quality,
         }
     }
 }

--- a/tower-http/src/compression/layer.rs
+++ b/tower-http/src/compression/layer.rs
@@ -1,7 +1,7 @@
 use super::{Compression, Predicate};
 use crate::compression::predicate::DefaultPredicate;
-use crate::compression_utils::AcceptEncoding;
 use crate::compression::Level;
+use crate::compression_utils::AcceptEncoding;
 use tower_layer::Layer;
 
 /// Compress response bodies of the underlying service.
@@ -14,7 +14,7 @@ use tower_layer::Layer;
 pub struct CompressionLayer<P = DefaultPredicate> {
     accept: AcceptEncoding,
     predicate: P,
-    quality: Level
+    quality: Level,
 }
 
 impl<S, P> Layer<S> for CompressionLayer<P>

--- a/tower-http/src/compression/layer.rs
+++ b/tower-http/src/compression/layer.rs
@@ -1,6 +1,6 @@
 use super::{Compression, Predicate};
 use crate::compression::predicate::DefaultPredicate;
-use crate::compression::Level;
+use crate::compression::CompressionLevel;
 use crate::compression_utils::AcceptEncoding;
 use tower_layer::Layer;
 
@@ -14,7 +14,7 @@ use tower_layer::Layer;
 pub struct CompressionLayer<P = DefaultPredicate> {
     accept: AcceptEncoding,
     predicate: P,
-    quality: Level,
+    quality: CompressionLevel,
 }
 
 impl<S, P> Layer<S> for CompressionLayer<P>
@@ -68,7 +68,7 @@ impl CompressionLayer {
     }
 
     /// Sets the compression quality.
-    pub fn quality(mut self, quality: Level) -> Self {
+    pub fn quality(mut self, quality: CompressionLevel) -> Self {
         self.quality = quality;
         self
     }

--- a/tower-http/src/compression/mod.rs
+++ b/tower-http/src/compression/mod.rs
@@ -403,7 +403,7 @@ mod tests {
                 Ok::<_, std::io::Error>(DATA.as_bytes())
             }));
             let reader = StreamReader::new(stream);
-            let mut enc = BrotliEncoder::with_quality(reader, level.into());
+            let mut enc = BrotliEncoder::with_quality(reader, level.into_async_compression());
 
             let mut buf = Vec::new();
             enc.read_to_end(&mut buf).await.unwrap();

--- a/tower-http/src/compression/mod.rs
+++ b/tower-http/src/compression/mod.rs
@@ -80,7 +80,7 @@ pub use self::{
     predicate::{DefaultPredicate, Predicate},
     service::Compression,
 };
-pub use crate::compression_utils::Level;
+pub use crate::compression_utils::CompressionLevel;
 
 #[cfg(test)]
 mod tests {
@@ -368,7 +368,7 @@ mod tests {
     #[tokio::test]
     async fn compress_with_quality() {
         const DATA: &str = "Check compression quality level! Check compression quality level! Check compression quality level!";
-        let level = Level::Best;
+        let level = CompressionLevel::Best;
 
         let svc = service_fn(|_| async {
             let resp = Response::builder()

--- a/tower-http/src/compression/mod.rs
+++ b/tower-http/src/compression/mod.rs
@@ -80,6 +80,7 @@ pub use self::{
     predicate::{DefaultPredicate, Predicate},
     service::Compression,
 };
+pub use crate::compression_utils::Level;
 
 #[cfg(test)]
 mod tests {

--- a/tower-http/src/compression/service.rs
+++ b/tower-http/src/compression/service.rs
@@ -1,11 +1,11 @@
 use super::{CompressionBody, CompressionLayer, ResponseFuture};
 use crate::compression::predicate::{DefaultPredicate, Predicate};
+use crate::compression::Level;
 use crate::{compression_utils::AcceptEncoding, content_encoding::Encoding};
 use http::{Request, Response};
 use http_body::Body;
 use std::task::{Context, Poll};
 use tower_service::Service;
-use crate::compression::Level;
 
 /// Compress response bodies of the underlying service.
 ///

--- a/tower-http/src/compression/service.rs
+++ b/tower-http/src/compression/service.rs
@@ -1,6 +1,6 @@
 use super::{CompressionBody, CompressionLayer, ResponseFuture};
 use crate::compression::predicate::{DefaultPredicate, Predicate};
-use crate::compression::Level;
+use crate::compression::CompressionLevel;
 use crate::{compression_utils::AcceptEncoding, content_encoding::Encoding};
 use http::{Request, Response};
 use http_body::Body;
@@ -18,7 +18,7 @@ pub struct Compression<S, P = DefaultPredicate> {
     pub(crate) inner: S,
     pub(crate) accept: AcceptEncoding,
     pub(crate) predicate: P,
-    pub(crate) quality: Level,
+    pub(crate) quality: CompressionLevel,
 }
 
 impl<S> Compression<S, DefaultPredicate> {
@@ -28,7 +28,7 @@ impl<S> Compression<S, DefaultPredicate> {
             inner: service,
             accept: AcceptEncoding::default(),
             predicate: DefaultPredicate::default(),
-            quality: Level::default(),
+            quality: CompressionLevel::default(),
         }
     }
 }
@@ -72,7 +72,7 @@ impl<S, P> Compression<S, P> {
     }
 
     /// Sets the compression quality.
-    pub fn quality(mut self, quality: Level) -> Self {
+    pub fn quality(mut self, quality: CompressionLevel) -> Self {
         self.quality = quality;
         self
     }

--- a/tower-http/src/compression/service.rs
+++ b/tower-http/src/compression/service.rs
@@ -5,6 +5,7 @@ use http::{Request, Response};
 use http_body::Body;
 use std::task::{Context, Poll};
 use tower_service::Service;
+use crate::compression::Level;
 
 /// Compress response bodies of the underlying service.
 ///
@@ -17,6 +18,7 @@ pub struct Compression<S, P = DefaultPredicate> {
     pub(crate) inner: S,
     pub(crate) accept: AcceptEncoding,
     pub(crate) predicate: P,
+    pub(crate) quality: Level,
 }
 
 impl<S> Compression<S, DefaultPredicate> {
@@ -26,6 +28,7 @@ impl<S> Compression<S, DefaultPredicate> {
             inner: service,
             accept: AcceptEncoding::default(),
             predicate: DefaultPredicate::default(),
+            quality: Level::default(),
         }
     }
 }
@@ -65,6 +68,12 @@ impl<S, P> Compression<S, P> {
     #[cfg(feature = "compression-zstd")]
     pub fn zstd(mut self, enable: bool) -> Self {
         self.accept.set_zstd(enable);
+        self
+    }
+
+    /// Sets the compression quality.
+    pub fn quality(mut self, quality: Level) -> Self {
+        self.quality = quality;
         self
     }
 
@@ -143,6 +152,7 @@ impl<S, P> Compression<S, P> {
             inner: self.inner,
             accept: self.accept,
             predicate,
+            quality: self.quality,
         }
     }
 }
@@ -169,6 +179,7 @@ where
             inner: self.inner.call(req),
             encoding,
             predicate: self.predicate.clone(),
+            quality: self.quality,
         }
     }
 }

--- a/tower-http/src/compression_utils.rs
+++ b/tower-http/src/compression_utils.rs
@@ -360,9 +360,9 @@ impl Default for CompressionLevel {
     }
 }
 
-impl From<CompressionLevel> for AsyncCompressionLevel {
-    fn from(level: CompressionLevel) -> Self {
-        match level {
+impl CompressionLevel {
+    pub(crate) fn into_async_compression(self) -> AsyncCompressionLevel {
+        match self {
             CompressionLevel::Fastest => AsyncCompressionLevel::Fastest,
             CompressionLevel::Best => AsyncCompressionLevel::Best,
             CompressionLevel::Default => AsyncCompressionLevel::Default,

--- a/tower-http/src/compression_utils.rs
+++ b/tower-http/src/compression_utils.rs
@@ -1,6 +1,7 @@
 //! Types used by compression and decompression middleware.
 
 use crate::{content_encoding::SupportedEncodings, BoxError};
+use async_compression::Level as AsyncCompressionLevel;
 use bytes::{Bytes, BytesMut};
 use futures_core::Stream;
 use futures_util::ready;
@@ -14,7 +15,6 @@ use std::{
 };
 use tokio::io::AsyncRead;
 use tokio_util::io::{poll_read_buf, StreamReader};
-use async_compression::Level as AsyncCompressionLevel;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct AcceptEncoding {
@@ -337,10 +337,9 @@ where
 
 pub(crate) const SENTINEL_ERROR_CODE: i32 = -837459418;
 
-
 /// Level of compression data should be compressed with.
 #[non_exhaustive]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Level {
     /// Fastest quality of compression, usually produces bigger size.
     Fastest,

--- a/tower-http/src/compression_utils.rs
+++ b/tower-http/src/compression_utils.rs
@@ -140,7 +140,7 @@ pub(crate) trait DecorateAsyncRead {
     type Output: AsyncRead;
 
     /// Apply the decorator
-    fn apply(input: Self::Input, quality: Level) -> Self::Output;
+    fn apply(input: Self::Input, quality: CompressionLevel) -> Self::Output;
 
     /// Get a pinned mutable reference to the original input.
     ///
@@ -158,7 +158,7 @@ pin_project! {
 
 impl<M: DecorateAsyncRead> WrapBody<M> {
     #[allow(dead_code)]
-    pub(crate) fn new<B>(body: B, quality: Level) -> Self
+    pub(crate) fn new<B>(body: B, quality: CompressionLevel) -> Self
     where
         B: Body,
         M: DecorateAsyncRead<Input = AsyncReadBody<B>>,
@@ -340,7 +340,7 @@ pub(crate) const SENTINEL_ERROR_CODE: i32 = -837459418;
 /// Level of compression data should be compressed with.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Level {
+pub enum CompressionLevel {
     /// Fastest quality of compression, usually produces bigger size.
     Fastest,
     /// Best quality of compression, usually produces the smallest size.
@@ -354,19 +354,19 @@ pub enum Level {
     Precise(u32),
 }
 
-impl Default for Level {
+impl Default for CompressionLevel {
     fn default() -> Self {
-        Level::Default
+        CompressionLevel::Default
     }
 }
 
-impl From<Level> for AsyncCompressionLevel {
-    fn from(level: Level) -> Self {
+impl From<CompressionLevel> for AsyncCompressionLevel {
+    fn from(level: CompressionLevel) -> Self {
         match level {
-            Level::Fastest => AsyncCompressionLevel::Fastest,
-            Level::Best => AsyncCompressionLevel::Best,
-            Level::Default => AsyncCompressionLevel::Default,
-            Level::Precise(quality) => AsyncCompressionLevel::Precise(quality),
+            CompressionLevel::Fastest => AsyncCompressionLevel::Fastest,
+            CompressionLevel::Best => AsyncCompressionLevel::Best,
+            CompressionLevel::Default => AsyncCompressionLevel::Default,
+            CompressionLevel::Precise(quality) => AsyncCompressionLevel::Precise(quality),
         }
     }
 }

--- a/tower-http/src/compression_utils.rs
+++ b/tower-http/src/compression_utils.rs
@@ -15,14 +15,6 @@ use std::{
 use tokio::io::AsyncRead;
 use tokio_util::io::{poll_read_buf, StreamReader};
 
-#[cfg(any(
-    feature = "compression-br",
-    feature = "compression-deflate",
-    feature = "compression-gzip",
-    feature = "compression-zstd",
-))]
-use async_compression::Level as AsyncCompressionLevel;
-
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct AcceptEncoding {
     pub(crate) gzip: bool,
@@ -345,18 +337,9 @@ where
 pub(crate) const SENTINEL_ERROR_CODE: i32 = -837459418;
 
 /// Level of compression data should be compressed with.
-#[cfg_attr(
-    not(any(
-        feature = "compression-br",
-        feature = "compression-deflate",
-        feature = "compression-gzip",
-        feature = "compression-zstd",
-    )),
-    allow(dead_code)
-)]
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum CompressionLevel {
+pub enum CompressionLevel {
     /// Fastest quality of compression, usually produces bigger size.
     Fastest,
     /// Best quality of compression, usually produces the smallest size.
@@ -370,27 +353,27 @@ pub(crate) enum CompressionLevel {
     Precise(u32),
 }
 
-#[cfg(any(
-    feature = "compression-br",
-    feature = "compression-deflate",
-    feature = "compression-gzip",
-    feature = "compression-zstd",
-))]
-pub use self::CompressionLevel;
-
 impl Default for CompressionLevel {
     fn default() -> Self {
         CompressionLevel::Default
     }
 }
 
+#[cfg(any(
+    feature = "compression-br",
+    feature = "compression-gzip",
+    feature = "compression-deflate",
+    feature = "compression-zstd"
+))]
+use async_compression::Level as AsyncCompressionLevel;
+
+#[cfg(any(
+    feature = "compression-br",
+    feature = "compression-gzip",
+    feature = "compression-deflate",
+    feature = "compression-zstd"
+))]
 impl CompressionLevel {
-    #[cfg(any(
-        feature = "compression-br",
-        feature = "compression-deflate",
-        feature = "compression-gzip",
-        feature = "compression-zstd",
-    ))]
     pub(crate) fn into_async_compression(self) -> AsyncCompressionLevel {
         match self {
             CompressionLevel::Fastest => AsyncCompressionLevel::Fastest,

--- a/tower-http/src/decompression/body.rs
+++ b/tower-http/src/decompression/body.rs
@@ -1,5 +1,6 @@
 #![allow(unused_imports)]
 
+use crate::compression_utils::Level;
 use crate::{
     compression_utils::{AsyncReadBody, BodyIntoStream, DecorateAsyncRead, WrapBody},
     BoxError,
@@ -20,7 +21,6 @@ use pin_project_lite::pin_project;
 use std::task::Context;
 use std::{io, marker::PhantomData, pin::Pin, task::Poll};
 use tokio_util::io::StreamReader;
-use crate::compression_utils::Level;
 
 pin_project! {
     /// Response body of [`RequestDecompression`] and [`Decompression`].

--- a/tower-http/src/decompression/body.rs
+++ b/tower-http/src/decompression/body.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
 
-use crate::compression_utils::Level;
+use crate::compression_utils::CompressionLevel;
 use crate::{
     compression_utils::{AsyncReadBody, BodyIntoStream, DecorateAsyncRead, WrapBody},
     BoxError,
@@ -345,7 +345,7 @@ where
     type Input = AsyncReadBody<B>;
     type Output = GzipDecoder<Self::Input>;
 
-    fn apply(input: Self::Input, _quality: Level) -> Self::Output {
+    fn apply(input: Self::Input, _quality: CompressionLevel) -> Self::Output {
         GzipDecoder::new(input)
     }
 
@@ -362,7 +362,7 @@ where
     type Input = AsyncReadBody<B>;
     type Output = ZlibDecoder<Self::Input>;
 
-    fn apply(input: Self::Input, _quality: Level) -> Self::Output {
+    fn apply(input: Self::Input, _quality: CompressionLevel) -> Self::Output {
         ZlibDecoder::new(input)
     }
 
@@ -379,7 +379,7 @@ where
     type Input = AsyncReadBody<B>;
     type Output = BrotliDecoder<Self::Input>;
 
-    fn apply(input: Self::Input, _quality: Level) -> Self::Output {
+    fn apply(input: Self::Input, _quality: CompressionLevel) -> Self::Output {
         BrotliDecoder::new(input)
     }
 
@@ -396,7 +396,7 @@ where
     type Input = AsyncReadBody<B>;
     type Output = ZstdDecoder<Self::Input>;
 
-    fn apply(input: Self::Input, _quality: Level) -> Self::Output {
+    fn apply(input: Self::Input, _quality: CompressionLevel) -> Self::Output {
         ZstdDecoder::new(input)
     }
 

--- a/tower-http/src/decompression/body.rs
+++ b/tower-http/src/decompression/body.rs
@@ -20,6 +20,7 @@ use pin_project_lite::pin_project;
 use std::task::Context;
 use std::{io, marker::PhantomData, pin::Pin, task::Poll};
 use tokio_util::io::StreamReader;
+use crate::compression_utils::Level;
 
 pin_project! {
     /// Response body of [`RequestDecompression`] and [`Decompression`].
@@ -344,7 +345,7 @@ where
     type Input = AsyncReadBody<B>;
     type Output = GzipDecoder<Self::Input>;
 
-    fn apply(input: Self::Input) -> Self::Output {
+    fn apply(input: Self::Input, _quality: Level) -> Self::Output {
         GzipDecoder::new(input)
     }
 
@@ -361,7 +362,7 @@ where
     type Input = AsyncReadBody<B>;
     type Output = ZlibDecoder<Self::Input>;
 
-    fn apply(input: Self::Input) -> Self::Output {
+    fn apply(input: Self::Input, _quality: Level) -> Self::Output {
         ZlibDecoder::new(input)
     }
 
@@ -378,7 +379,7 @@ where
     type Input = AsyncReadBody<B>;
     type Output = BrotliDecoder<Self::Input>;
 
-    fn apply(input: Self::Input) -> Self::Output {
+    fn apply(input: Self::Input, _quality: Level) -> Self::Output {
         BrotliDecoder::new(input)
     }
 
@@ -395,7 +396,7 @@ where
     type Input = AsyncReadBody<B>;
     type Output = ZstdDecoder<Self::Input>;
 
-    fn apply(input: Self::Input) -> Self::Output {
+    fn apply(input: Self::Input, _quality: Level) -> Self::Output {
         ZstdDecoder::new(input)
     }
 

--- a/tower-http/src/decompression/future.rs
+++ b/tower-http/src/decompression/future.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 
 use super::{body::BodyInner, DecompressionBody};
-use crate::compression_utils::{AcceptEncoding, WrapBody};
+use crate::compression_utils::{AcceptEncoding, Level, WrapBody};
 use crate::content_encoding::SupportedEncodings;
 use futures_util::ready;
 use http::{header, Response};
@@ -42,22 +42,22 @@ where
                 let body = match entry.get().as_bytes() {
                     #[cfg(feature = "decompression-gzip")]
                     b"gzip" if self.accept.gzip() => {
-                        DecompressionBody::new(BodyInner::gzip(WrapBody::new(body)))
+                        DecompressionBody::new(BodyInner::gzip(WrapBody::new(body, Level::default())))
                     }
 
                     #[cfg(feature = "decompression-deflate")]
                     b"deflate" if self.accept.deflate() => {
-                        DecompressionBody::new(BodyInner::deflate(WrapBody::new(body)))
+                        DecompressionBody::new(BodyInner::deflate(WrapBody::new(body, Level::default())))
                     }
 
                     #[cfg(feature = "decompression-br")]
                     b"br" if self.accept.br() => {
-                        DecompressionBody::new(BodyInner::brotli(WrapBody::new(body)))
+                        DecompressionBody::new(BodyInner::brotli(WrapBody::new(body, Level::default())))
                     }
 
                     #[cfg(feature = "decompression-zstd")]
                     b"zstd" if self.accept.zstd() => {
-                        DecompressionBody::new(BodyInner::zstd(WrapBody::new(body)))
+                        DecompressionBody::new(BodyInner::zstd(WrapBody::new(body, Level::default())))
                     }
 
                     _ => {

--- a/tower-http/src/decompression/future.rs
+++ b/tower-http/src/decompression/future.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 
 use super::{body::BodyInner, DecompressionBody};
-use crate::compression_utils::{AcceptEncoding, Level, WrapBody};
+use crate::compression_utils::{AcceptEncoding, CompressionLevel, WrapBody};
 use crate::content_encoding::SupportedEncodings;
 use futures_util::ready;
 use http::{header, Response};
@@ -42,22 +42,22 @@ where
                 let body = match entry.get().as_bytes() {
                     #[cfg(feature = "decompression-gzip")]
                     b"gzip" if self.accept.gzip() => DecompressionBody::new(BodyInner::gzip(
-                        WrapBody::new(body, Level::default()),
+                        WrapBody::new(body, CompressionLevel::default()),
                     )),
 
                     #[cfg(feature = "decompression-deflate")]
                     b"deflate" if self.accept.deflate() => DecompressionBody::new(
-                        BodyInner::deflate(WrapBody::new(body, Level::default())),
+                        BodyInner::deflate(WrapBody::new(body, CompressionLevel::default())),
                     ),
 
                     #[cfg(feature = "decompression-br")]
                     b"br" if self.accept.br() => DecompressionBody::new(BodyInner::brotli(
-                        WrapBody::new(body, Level::default()),
+                        WrapBody::new(body, CompressionLevel::default()),
                     )),
 
                     #[cfg(feature = "decompression-zstd")]
                     b"zstd" if self.accept.zstd() => DecompressionBody::new(BodyInner::zstd(
-                        WrapBody::new(body, Level::default()),
+                        WrapBody::new(body, CompressionLevel::default()),
                     )),
 
                     _ => {

--- a/tower-http/src/decompression/future.rs
+++ b/tower-http/src/decompression/future.rs
@@ -41,24 +41,24 @@ where
             if let header::Entry::Occupied(entry) = parts.headers.entry(header::CONTENT_ENCODING) {
                 let body = match entry.get().as_bytes() {
                     #[cfg(feature = "decompression-gzip")]
-                    b"gzip" if self.accept.gzip() => {
-                        DecompressionBody::new(BodyInner::gzip(WrapBody::new(body, Level::default())))
-                    }
+                    b"gzip" if self.accept.gzip() => DecompressionBody::new(BodyInner::gzip(
+                        WrapBody::new(body, Level::default()),
+                    )),
 
                     #[cfg(feature = "decompression-deflate")]
-                    b"deflate" if self.accept.deflate() => {
-                        DecompressionBody::new(BodyInner::deflate(WrapBody::new(body, Level::default())))
-                    }
+                    b"deflate" if self.accept.deflate() => DecompressionBody::new(
+                        BodyInner::deflate(WrapBody::new(body, Level::default())),
+                    ),
 
                     #[cfg(feature = "decompression-br")]
-                    b"br" if self.accept.br() => {
-                        DecompressionBody::new(BodyInner::brotli(WrapBody::new(body, Level::default())))
-                    }
+                    b"br" if self.accept.br() => DecompressionBody::new(BodyInner::brotli(
+                        WrapBody::new(body, Level::default()),
+                    )),
 
                     #[cfg(feature = "decompression-zstd")]
-                    b"zstd" if self.accept.zstd() => {
-                        DecompressionBody::new(BodyInner::zstd(WrapBody::new(body, Level::default())))
-                    }
+                    b"zstd" if self.accept.zstd() => DecompressionBody::new(BodyInner::zstd(
+                        WrapBody::new(body, Level::default()),
+                    )),
 
                     _ => {
                         return Poll::Ready(Ok(Response::from_parts(

--- a/tower-http/src/decompression/request/service.rs
+++ b/tower-http/src/decompression/request/service.rs
@@ -9,6 +9,7 @@ use http::{header, Request, Response};
 use http_body::{combinators::UnsyncBoxBody, Body};
 use std::task::{Context, Poll};
 use tower_service::Service;
+use crate::compression_utils::Level;
 
 #[cfg(any(
     feature = "decompression-gzip",
@@ -63,25 +64,25 @@ where
                     b"gzip" if self.accept.gzip() => {
                         entry.remove();
                         parts.headers.remove(header::CONTENT_LENGTH);
-                        BodyInner::gzip(crate::compression_utils::WrapBody::new(body))
+                        BodyInner::gzip(crate::compression_utils::WrapBody::new(body, Level::default()))
                     }
                     #[cfg(feature = "decompression-deflate")]
                     b"deflate" if self.accept.deflate() => {
                         entry.remove();
                         parts.headers.remove(header::CONTENT_LENGTH);
-                        BodyInner::deflate(crate::compression_utils::WrapBody::new(body))
+                        BodyInner::deflate(crate::compression_utils::WrapBody::new(body, Level::default()))
                     }
                     #[cfg(feature = "decompression-br")]
                     b"br" if self.accept.br() => {
                         entry.remove();
                         parts.headers.remove(header::CONTENT_LENGTH);
-                        BodyInner::brotli(crate::compression_utils::WrapBody::new(body))
+                        BodyInner::brotli(crate::compression_utils::WrapBody::new(body, Level::default()))
                     }
                     #[cfg(feature = "decompression-zstd")]
                     b"zstd" if self.accept.zstd() => {
                         entry.remove();
                         parts.headers.remove(header::CONTENT_LENGTH);
-                        BodyInner::zstd(crate::compression_utils::WrapBody::new(body))
+                        BodyInner::zstd(crate::compression_utils::WrapBody::new(body, Level::default()))
                     }
                     b"identity" => BodyInner::identity(body),
                     _ if self.pass_through_unaccepted => BodyInner::identity(body),

--- a/tower-http/src/decompression/request/service.rs
+++ b/tower-http/src/decompression/request/service.rs
@@ -1,5 +1,6 @@
 use super::future::RequestDecompressionFuture as ResponseFuture;
 use super::layer::RequestDecompressionLayer;
+use crate::compression_utils::Level;
 use crate::{
     compression_utils::AcceptEncoding, decompression::body::BodyInner,
     decompression::DecompressionBody, BoxError,
@@ -9,7 +10,6 @@ use http::{header, Request, Response};
 use http_body::{combinators::UnsyncBoxBody, Body};
 use std::task::{Context, Poll};
 use tower_service::Service;
-use crate::compression_utils::Level;
 
 #[cfg(any(
     feature = "decompression-gzip",
@@ -64,25 +64,37 @@ where
                     b"gzip" if self.accept.gzip() => {
                         entry.remove();
                         parts.headers.remove(header::CONTENT_LENGTH);
-                        BodyInner::gzip(crate::compression_utils::WrapBody::new(body, Level::default()))
+                        BodyInner::gzip(crate::compression_utils::WrapBody::new(
+                            body,
+                            Level::default(),
+                        ))
                     }
                     #[cfg(feature = "decompression-deflate")]
                     b"deflate" if self.accept.deflate() => {
                         entry.remove();
                         parts.headers.remove(header::CONTENT_LENGTH);
-                        BodyInner::deflate(crate::compression_utils::WrapBody::new(body, Level::default()))
+                        BodyInner::deflate(crate::compression_utils::WrapBody::new(
+                            body,
+                            Level::default(),
+                        ))
                     }
                     #[cfg(feature = "decompression-br")]
                     b"br" if self.accept.br() => {
                         entry.remove();
                         parts.headers.remove(header::CONTENT_LENGTH);
-                        BodyInner::brotli(crate::compression_utils::WrapBody::new(body, Level::default()))
+                        BodyInner::brotli(crate::compression_utils::WrapBody::new(
+                            body,
+                            Level::default(),
+                        ))
                     }
                     #[cfg(feature = "decompression-zstd")]
                     b"zstd" if self.accept.zstd() => {
                         entry.remove();
                         parts.headers.remove(header::CONTENT_LENGTH);
-                        BodyInner::zstd(crate::compression_utils::WrapBody::new(body, Level::default()))
+                        BodyInner::zstd(crate::compression_utils::WrapBody::new(
+                            body,
+                            Level::default(),
+                        ))
                     }
                     b"identity" => BodyInner::identity(body),
                     _ if self.pass_through_unaccepted => BodyInner::identity(body),

--- a/tower-http/src/decompression/request/service.rs
+++ b/tower-http/src/decompression/request/service.rs
@@ -1,6 +1,6 @@
 use super::future::RequestDecompressionFuture as ResponseFuture;
 use super::layer::RequestDecompressionLayer;
-use crate::compression_utils::Level;
+use crate::compression_utils::CompressionLevel;
 use crate::{
     compression_utils::AcceptEncoding, decompression::body::BodyInner,
     decompression::DecompressionBody, BoxError,
@@ -66,7 +66,7 @@ where
                         parts.headers.remove(header::CONTENT_LENGTH);
                         BodyInner::gzip(crate::compression_utils::WrapBody::new(
                             body,
-                            Level::default(),
+                            CompressionLevel::default(),
                         ))
                     }
                     #[cfg(feature = "decompression-deflate")]
@@ -75,7 +75,7 @@ where
                         parts.headers.remove(header::CONTENT_LENGTH);
                         BodyInner::deflate(crate::compression_utils::WrapBody::new(
                             body,
-                            Level::default(),
+                            CompressionLevel::default(),
                         ))
                     }
                     #[cfg(feature = "decompression-br")]
@@ -84,7 +84,7 @@ where
                         parts.headers.remove(header::CONTENT_LENGTH);
                         BodyInner::brotli(crate::compression_utils::WrapBody::new(
                             body,
-                            Level::default(),
+                            CompressionLevel::default(),
                         ))
                     }
                     #[cfg(feature = "decompression-zstd")]
@@ -93,7 +93,7 @@ where
                         parts.headers.remove(header::CONTENT_LENGTH);
                         BodyInner::zstd(crate::compression_utils::WrapBody::new(
                             body,
-                            Level::default(),
+                            CompressionLevel::default(),
                         ))
                     }
                     b"identity" => BodyInner::identity(body),

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -279,7 +279,19 @@ mod content_encoding;
     feature = "decompression-gzip",
     feature = "decompression-zstd",
 ))]
-pub mod compression_utils;
+mod compression_utils;
+
+#[cfg(any(
+    feature = "compression-br",
+    feature = "compression-deflate",
+    feature = "compression-gzip",
+    feature = "compression-zstd",
+    feature = "decompression-br",
+    feature = "decompression-deflate",
+    feature = "decompression-gzip",
+    feature = "decompression-zstd",
+))]
+pub use compression_utils::CompressionLevel;
 
 #[cfg(feature = "map-response-body")]
 pub mod map_response_body;

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -279,7 +279,7 @@ mod content_encoding;
     feature = "decompression-gzip",
     feature = "decompression-zstd",
 ))]
-mod compression_utils;
+pub mod compression_utils;
 
 #[cfg(feature = "map-response-body")]
 pub mod map_response_body;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

Fixes #245
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Allows setting the compression quality level for responses. The ticket suggested to use `.level(the_level)`, but after reading the full context I've settled with `.quality(the_level)` as it represents better [the underlying feature](https://docs.rs/async-compression/latest/async_compression/futures/bufread/struct.BrotliEncoder.html#method.with_quality).
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
