### PR TITLE
Derive Default for ServeFileSystemResponseBody

### DIFF
--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -522,6 +522,7 @@ impl ServeVariant {
 
 opaque_body! {
     /// Response body for [`ServeDir`] and [`ServeFile`].
+    #[derive(Default)]
     pub type ResponseBody = UnsyncBoxBody<Bytes, io::Error>;
 }
 


### PR DESCRIPTION
## Motivation

Some layers such as the CORS layer require the response body type to implement `Default`.

## Solution

Derive `Default` for `ServeFileSystemResponseBody`.