### PR TITLE
Update to bitflags 2

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["io", "async", "futures", "service", "http"]
 rust-version = "1.56"
 
 [dependencies]
-bitflags = "1.3.1"
+bitflags = "2.0.2"
 bytes = "1"
 futures-core = "0.3"
 futures-util = { version = "0.3.14", default_features = false, features = [] }

--- a/tower-http/src/classify/grpc_errors_as_failures.rs
+++ b/tower-http/src/classify/grpc_errors_as_failures.rs
@@ -71,6 +71,7 @@ impl GrpcCode {
 }
 
 bitflags! {
+    #[derive(Debug, Clone, Copy)]
     pub(crate) struct GrpcCodeBitmask: u32 {
         const OK                  = 0b00000000000000001;
         const CANCELLED           = 0b00000000000000010;


### PR DESCRIPTION
## Motivation

Updates to [bitflags version 2](https://github.com/bitflags/bitflags/releases/tag/2.0.2).

## Solution

Updates the manifest.