### PR TITLE
Add cargo-public-api-crates to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,4 +136,4 @@ jobs:
       run: |
         cargo install --git https://github.com/davidpdrsn/cargo-public-api-crates
     - name: cargo public-api-crates check
-      run: cargo public-api-crates --all-features --manifest-path tower-http/Cargo.toml check
+      run: cargo public-api-crates --manifest-path tower-http/Cargo.toml check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -121,3 +121,19 @@ jobs:
         with:
           command: check ${{ matrix.checks }}
           arguments: --all-features --manifest-path tower-http/Cargo.toml
+
+  cargo-public-api-crates:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: nightly
+        override: true
+        profile: minimal
+    - uses: Swatinem/rust-cache@v1
+    - name: Install cargo-public-api-crates
+      run: |
+        cargo install --git https://github.com/davidpdrsn/cargo-public-api-crates
+    - name: cargo public-api-crates check
+      run: cargo public-api-crates --all-features --manifest-path tower-http/Cargo.toml check

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -120,3 +120,17 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
 features = ["full"]
+
+[package.metadata.cargo-public-api-crates]
+allowed = [
+    "bytes",
+    "http",
+    "http_body",
+    "mime",
+    "tokio",
+    "tower",
+    "tower_layer",
+    "tower_service",
+    "tracing",
+    "tracing_core",
+]


### PR DESCRIPTION
[`cargo-public-api-crates`](https://github.com/davidpdrsn/cargo-public-api-crates) can find crates your public API so you can
check that on CI.

Been using it on axum for a while with good success. Figured it would be
nice to use here as well.

Note that `cargo-public-api-crates` is maintained by yours truly.
