### PR TITLE
feat(ValidateRequestHeaderLayer): add has_header("...").with_value("...") function

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   feature entries; the underlying dependencies are still pulled in transitively
   by the features that need them (e.g. `compression-gzip`, `fs`, `timeout`).
   ([#628])
-- **validate-request:** Add `ValidateRequestHeaderLayer::has_header()` builder to reject requests when a header does not have an expected value ([#360])
+- **validate-request:** Add `ValidateRequestHeaderLayer::has_header_value()` to reject requests when a header does not have an expected value ([#360])
 
 
 [#215]: https://github.com/tower-rs/tower-http/issues/215

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -402,6 +402,7 @@ http-range-header to `0.4`
 [#335]: https://github.com/tower-rs/tower-http/pull/335
 [#336]: https://github.com/tower-rs/tower-http/pull/336
 [#354]: https://github.com/tower-rs/tower-http/pull/354
+[#360]: https://github.com/tower-rs/tower-http/pull/360
 
 # 0.4.0 (February 24, 2023)
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -32,15 +32,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   feature entries; the underlying dependencies are still pulled in transitively
   by the features that need them (e.g. `compression-gzip`, `fs`, `timeout`).
   ([#628])
-- **validate-request:** Add `ValidateRequestHeaderLayer::has_header_value()` to reject requests when a header does not have an expected value ([#360])
-
 
 [#215]: https://github.com/tower-rs/tower-http/issues/215
+[#360]: https://github.com/tower-rs/tower-http/pull/360
 [#628]: https://github.com/tower-rs/tower-http/pull/628
 [#642]: https://github.com/tower-rs/tower-http/pull/642
 
 ## Added
 
+- **validate-request:** Add `ValidateRequestHeaderLayer::has_header_value()` to reject requests when a header does not have an expected value ([#360])
 - `body`: `UnsyncBoxBody::new()` constructor and `From<ServeFileSystemResponseBody>` conversion to avoid double-boxing when combining `ServeDir` responses with other body types ([#537])
 
 # 0.6.11
@@ -404,7 +404,6 @@ http-range-header to `0.4`
 [#335]: https://github.com/tower-rs/tower-http/pull/335
 [#336]: https://github.com/tower-rs/tower-http/pull/336
 [#354]: https://github.com/tower-rs/tower-http/pull/354
-[#360]: https://github.com/tower-rs/tower-http/pull/360
 
 # 0.4.0 (February 24, 2023)
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   feature entries; the underlying dependencies are still pulled in transitively
   by the features that need them (e.g. `compression-gzip`, `fs`, `timeout`).
   ([#628])
+- **validate-request:** Add `ValidateRequestHeaderLayer::has_header()` builder to reject requests when a header does not have an expected value ([#360])
+
 
 [#215]: https://github.com/tower-rs/tower-http/issues/215
 [#628]: https://github.com/tower-rs/tower-http/pull/628

--- a/tower-http/src/validate_request.rs
+++ b/tower-http/src/validate_request.rs
@@ -53,7 +53,7 @@
 //! # }
 //! ```
 //!
-//! Validation of a custom header can be made by using [`ValidateRequestHeaderLayer::has_header()`]:
+//! Validation of a custom header can be made by using [`ValidateRequestHeaderLayer::has_header_value()`]:
 //!
 //! ```
 //! use tower_http::validate_request::ValidateRequestHeaderLayer;
@@ -70,11 +70,10 @@
 //! # async fn main() -> Result<(), BoxError> {
 //! let mut service = ServiceBuilder::new()
 //!     // Require a `X-Custom-Header` header to have the value `random-value-1234567890` or reject with a `403 Forbidden` response
-//!     .layer(
-//!         ValidateRequestHeaderLayer::has_header("x-custom-header")
-//!             .with_value("random-value-1234567890")
-//!             .with_status_code(StatusCode::FORBIDDEN),
-//!     )
+//!     .layer(ValidateRequestHeaderLayer::has_header_value(
+//!         "x-custom-header",
+//!         "random-value-1234567890",
+//!     ))
 //!     .service_fn(handle);
 //!
 //! // Requests with the correct value are allowed through
@@ -122,6 +121,62 @@
 //! # }
 //! ```
 //!
+//! To require only that a header is present, use [`ValidateRequestHeaderLayer::custom()`]:
+//!
+//! ```
+//! use tower_http::validate_request::ValidateRequestHeaderLayer;
+//! use http::{Request, Response, StatusCode};
+//! use http_body_util::Full;
+//! use bytes::Bytes;
+//! use tower::{ServiceBuilder, service_fn, BoxError};
+//!
+//! async fn handle(request: Request<Full<Bytes>>) -> Result<Response<Full<Bytes>>, BoxError> {
+//!     Ok(Response::new(Full::default()))
+//! }
+//!
+//! # fn main() {
+//! let service = ServiceBuilder::new()
+//!     .layer(ValidateRequestHeaderLayer::custom(|req: &mut Request<Full<Bytes>>| {
+//!         if req.headers().contains_key("x-custom-header") {
+//!             Ok(())
+//!         } else {
+//!             let mut res = Response::new(Full::<Bytes>::default());
+//!             *res.status_mut() = StatusCode::FORBIDDEN;
+//!             Err(res)
+//!         }
+//!     }))
+//!     .service_fn(handle);
+//! # }
+//! ```
+//!
+//! To serve a custom response when validation fails, also use [`ValidateRequestHeaderLayer::custom()`]:
+//!
+//! ```
+//! use tower_http::validate_request::ValidateRequestHeaderLayer;
+//! use http::{Request, Response, StatusCode};
+//! use http_body_util::Full;
+//! use bytes::Bytes;
+//! use tower::{ServiceBuilder, service_fn, BoxError};
+//!
+//! async fn handle(request: Request<Full<Bytes>>) -> Result<Response<Full<Bytes>>, BoxError> {
+//!     Ok(Response::new(Full::default()))
+//! }
+//!
+//! # fn main() {
+//! let service = ServiceBuilder::new()
+//!     .layer(ValidateRequestHeaderLayer::custom(|req: &mut Request<Full<Bytes>>| {
+//!         match req.headers().get("x-custom-header").map(|v| v.as_bytes()) {
+//!             Some(b"random-value-1234567890") => Ok(()),
+//!             _ => Err(Response::builder()
+//!                 .status(StatusCode::FORBIDDEN)
+//!                 .body(Full::<Bytes>::default())
+//!                 .unwrap()),
+//!         }
+//!     }))
+//!     .service_fn(handle);
+//! # }
+//! ```
+//!
 //! Custom validation can be made by implementing [`ValidateRequest`]:
 //!
 //! ```
@@ -156,32 +211,6 @@
 //! let service = ServiceBuilder::new()
 //!     // Validate requests using `MyHeader`
 //!     .layer(ValidateRequestHeaderLayer::custom(MyHeader { /* ... */ }))
-//!     .service_fn(handle);
-//! # Ok(())
-//! # }
-//! ```
-//!
-//! Or using a closure:
-//!
-//! ```
-//! use tower_http::validate_request::{ValidateRequestHeaderLayer, ValidateRequest};
-//! use http::{Request, Response, StatusCode, header::ACCEPT};
-//! use bytes::Bytes;
-//! use http_body_util::Full;
-//! use tower::{Service, ServiceExt, ServiceBuilder, service_fn, BoxError};
-//!
-//! async fn handle(request: Request<Full<Bytes>>) -> Result<Response<Full<Bytes>>, BoxError> {
-//!     # todo!();
-//!     // ...
-//! }
-//!
-//! # #[tokio::main]
-//! # async fn main() -> Result<(), BoxError> {
-//! let service = ServiceBuilder::new()
-//!     .layer(ValidateRequestHeaderLayer::custom(|request: &mut Request<Full<Bytes>>| {
-//!         // Validate the request
-//!         # Ok::<_, Response<Full<Bytes>>>(())
-//!     }))
 //!     .service_fn(handle);
 //! # Ok(())
 //! # }
@@ -241,68 +270,49 @@ impl<ResBody> ValidateRequestHeaderLayer<AcceptHeader<ResBody>> {
     }
 }
 
-impl ValidateRequestHeaderLayer<AssertHeaderOrReject<()>> {
+impl<ResBody> ValidateRequestHeaderLayer<AssertHeaderOrReject<ResBody>> {
     /// Validate requests have a required header with a specific value.
+    ///
+    /// Rejects with `403 Forbidden` if the header is missing or does not have the expected value.
     ///
     /// # Example
     ///
     /// ```
-    /// use http::StatusCode;
+    /// use http::{Request, Response, StatusCode};
     /// use http_body_util::Full;
     /// use bytes::Bytes;
+    /// use tower::{Service, ServiceBuilder, ServiceExt, service_fn};
     /// use tower_http::validate_request::ValidateRequestHeaderLayer;
     ///
-    /// let _layer = ValidateRequestHeaderLayer::has_header("x-custom-header")
-    ///     .with_value("random-value-1234567890")
-    ///     .with_status_code::<Full<Bytes>>(StatusCode::FORBIDDEN);
+    /// async fn handle(request: Request<Full<Bytes>>) -> Result<Response<Full<Bytes>>, std::convert::Infallible> {
+    ///     Ok(Response::new(request.into_body()))
+    /// }
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let mut service = ServiceBuilder::new()
+    ///     .layer(ValidateRequestHeaderLayer::has_header_value(
+    ///         "x-custom-header",
+    ///         "random-value-1234567890",
+    ///     ))
+    ///     .service_fn(handle);
+    ///
+    /// let request = Request::builder()
+    ///     .header("x-custom-header", "random-value-1234567890")
+    ///     .body(Full::default())
+    ///     .unwrap();
+    ///
+    /// let response = service.ready().await.unwrap().call(request).await.unwrap();
+    /// assert_eq!(response.status(), StatusCode::OK);
+    /// # }
     /// ```
-    pub fn has_header(expected_header_name: &str) -> HasHeaderBuilder {
-        HasHeaderBuilder::new(expected_header_name)
-    }
-}
-
-/// Builder for [`ValidateRequestHeaderLayer::has_header`].
-#[derive(Debug, Clone)]
-pub struct HasHeaderBuilder {
-    expected_header_name: String,
-}
-
-/// Builder returned by [`HasHeaderBuilder::with_value`].
-#[derive(Debug, Clone)]
-pub struct HasHeaderWithValueBuilder {
-    expected_header_name: String,
-    expected_header_value: String,
-}
-
-impl HasHeaderBuilder {
-    fn new(expected_header_name: &str) -> Self {
-        Self {
-            expected_header_name: expected_header_name.to_string(),
-        }
-    }
-
-    /// Require the header to have this value.
-    pub fn with_value(self, expected_header_value: &str) -> HasHeaderWithValueBuilder {
-        HasHeaderWithValueBuilder {
-            expected_header_name: self.expected_header_name,
-            expected_header_value: expected_header_value.to_string(),
-        }
-    }
-}
-
-impl HasHeaderWithValueBuilder {
-    /// Set the response status code when validation fails.
-    pub fn with_status_code<ResBody>(
-        self,
-        response_status_code: StatusCode,
-    ) -> ValidateRequestHeaderLayer<AssertHeaderOrReject<ResBody>>
+    pub fn has_header_value(expected_header_name: &str, expected_header_value: &str) -> Self
     where
         ResBody: Default,
     {
-        ValidateRequestHeaderLayer::custom(AssertHeaderOrReject::new(
-            &self.expected_header_name,
-            &self.expected_header_value,
-            response_status_code,
+        Self::custom(AssertHeaderOrReject::new(
+            expected_header_name,
+            expected_header_value,
         ))
     }
 }
@@ -554,24 +564,17 @@ where
 pub struct AssertHeaderOrReject<ResBody> {
     expected_header_name: String,
     expected_header_value: String,
-    response_status_code: StatusCode,
     _ty: PhantomData<fn() -> ResBody>,
 }
 
 impl<ResBody> AssertHeaderOrReject<ResBody> {
-    /// Create a new `AssertHeaderOrReject` struct.
-    fn new(
-        expected_header_name: &str,
-        expected_header_value: &str,
-        response_status_code: StatusCode,
-    ) -> Self
+    fn new(expected_header_name: &str, expected_header_value: &str) -> Self
     where
         ResBody: Default,
     {
         Self {
             expected_header_name: expected_header_name.to_string(),
             expected_header_value: expected_header_value.to_string(),
-            response_status_code,
             _ty: PhantomData,
         }
     }
@@ -582,7 +585,6 @@ impl<ResBody> Clone for AssertHeaderOrReject<ResBody> {
         Self {
             expected_header_name: self.expected_header_name.clone(),
             expected_header_value: self.expected_header_value.clone(),
-            response_status_code: self.response_status_code,
             _ty: PhantomData,
         }
     }
@@ -593,7 +595,6 @@ impl<ResBody> fmt::Debug for AssertHeaderOrReject<ResBody> {
         f.debug_struct("AssertHeaderOrReject")
             .field("expected_header_name", &self.expected_header_name)
             .field("expected_header_value", &self.expected_header_value)
-            .field("response_status_code", &self.response_status_code)
             .finish()
     }
 }
@@ -612,7 +613,7 @@ where
 
         if request_header_value != Some(&self.expected_header_value) {
             let mut res = Response::new(ResBody::default());
-            *res.status_mut() = self.response_status_code;
+            *res.status_mut() = StatusCode::FORBIDDEN;
             return Err(res);
         }
 
@@ -793,11 +794,10 @@ mod tests {
     #[tokio::test]
     async fn valid_custom_header() {
         let mut service = ServiceBuilder::new()
-            .layer(
-                ValidateRequestHeaderLayer::has_header("x-custom-header")
-                    .with_value("random-value-1234567890")
-                    .with_status_code(StatusCode::FORBIDDEN),
-            )
+            .layer(ValidateRequestHeaderLayer::has_header_value(
+                "x-custom-header",
+                "random-value-1234567890",
+            ))
             .service_fn(echo);
 
         let request = Request::get("/")
@@ -813,11 +813,10 @@ mod tests {
     #[tokio::test]
     async fn invalid_custom_header() {
         let mut service = ServiceBuilder::new()
-            .layer(
-                ValidateRequestHeaderLayer::has_header("x-custom-header")
-                    .with_value("random-value-1234567890")
-                    .with_status_code(StatusCode::FORBIDDEN),
-            )
+            .layer(ValidateRequestHeaderLayer::has_header_value(
+                "x-custom-header",
+                "random-value-1234567890",
+            ))
             .service_fn(echo);
 
         let request = Request::get("/")
@@ -833,11 +832,10 @@ mod tests {
     #[tokio::test]
     async fn missing_custom_header() {
         let mut service = ServiceBuilder::new()
-            .layer(
-                ValidateRequestHeaderLayer::has_header("x-custom-header")
-                    .with_value("random-value-1234567890")
-                    .with_status_code(StatusCode::FORBIDDEN),
-            )
+            .layer(ValidateRequestHeaderLayer::has_header_value(
+                "x-custom-header",
+                "random-value-1234567890",
+            ))
             .service_fn(echo);
 
         let request = Request::get("/").body(Body::empty()).unwrap();

--- a/tower-http/src/validate_request.rs
+++ b/tower-http/src/validate_request.rs
@@ -2,6 +2,8 @@
 //!
 //! # Example
 //!
+//! Validation of the `Accept` header can be made by using [`ValidateRequestHeaderLayer::accept()`]:
+//!
 //! ```
 //! use tower_http::validate_request::ValidateRequestHeaderLayer;
 //! use http::{Request, Response, StatusCode, header::ACCEPT};
@@ -47,6 +49,70 @@
 //!     .await?;
 //!
 //! assert_eq!(StatusCode::NOT_ACCEPTABLE, response.status());
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Validation of a custom header can be made by using [`ValidateRequestHeaderLayer::assert()`]:
+//!
+//! ```
+//! use tower_http::validate_request::ValidateRequestHeaderLayer;
+//! use hyper::{Request, Response, Body, Error};
+//! use http::StatusCode;
+//! use tower::{Service, ServiceExt, ServiceBuilder, service_fn};
+//!
+//! async fn handle(request: Request<Body>) -> Result<Response<Body>, Error> {
+//!     Ok(Response::new(Body::empty()))
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut service = ServiceBuilder::new()
+//!     // Require a `X-Custom-Header` header to have the value `random-value-1234567890` or reject with a `403 Forbidden` response
+//!     .layer(ValidateRequestHeaderLayer::assert("x-custom-header", "random-value-1234567890", StatusCode::FORBIDDEN))
+//!     .service_fn(handle);
+//!
+//! // Requests with the correct value are allowed through
+//! let request = Request::builder()
+//!     .header("x-custom-header", "random-value-1234567890")
+//!     .body(Body::empty())
+//!     .unwrap();
+//!
+//! let response = service
+//!     .ready()
+//!     .await?
+//!     .call(request)
+//!     .await?;
+//!
+//! assert_eq!(StatusCode::OK, response.status());
+//!
+//! // Requests with an invalid value get a `403 Forbidden` response
+//! let request = Request::builder()
+//!     .header("x-custom-header", "wrong-value")
+//!     .body(Body::empty())
+//!     .unwrap();
+//!
+//! let response = service
+//!     .ready()
+//!     .await?
+//!     .call(request)
+//!     .await?;
+//!
+//! assert_eq!(StatusCode::FORBIDDEN, response.status());
+//! #
+//! # // Requests without the expected header also get a `403 Forbidden` response
+//! # let request = Request::builder()
+//! #    .body(Body::empty())
+//! #    .unwrap();
+//! #
+//! # let response = service
+//! #    .ready()
+//! #    .await?
+//! #    .call(request)
+//! #    .await?;
+//! #
+//! # assert_eq!(StatusCode::FORBIDDEN, response.status());
+//! #
 //! # Ok(())
 //! # }
 //! ```
@@ -115,6 +181,8 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! [`Accept`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
 
 use http::{header, Request, Response, StatusCode};
 use mime::{Mime, MimeIter};
@@ -165,6 +233,34 @@ impl<ResBody> ValidateRequestHeaderLayer<AcceptHeader<ResBody>> {
         ResBody: Default,
     {
         Self::custom(AcceptHeader::new(value))
+    }
+}
+
+impl<ResBody> ValidateRequestHeaderLayer<AssertHeaderOrReject<ResBody>> {
+    /// Validate requests have a required header with a specific value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use http::StatusCode;
+    /// use hyper::Body;
+    /// use tower_http::validate_request::{AssertHeaderOrReject, ValidateRequestHeaderLayer};
+    ///
+    /// let layer = ValidateRequestHeaderLayer::<AssertHeaderOrReject<Body>>::assert("x-custom-header", "random-value-1234567890", StatusCode::FORBIDDEN);
+    /// ```
+    pub fn assert(
+        expected_header_name: &str,
+        expected_header_value: &str,
+        response_status_code: StatusCode,
+    ) -> Self
+    where
+        ResBody: Body + Default,
+    {
+        Self::custom(AssertHeaderOrReject::new(
+            expected_header_name,
+            expected_header_value,
+            response_status_code,
+        ))
     }
 }
 
@@ -408,6 +504,76 @@ where
         let mut res = Response::new(ResBody::default());
         *res.status_mut() = StatusCode::NOT_ACCEPTABLE;
         Err(res)
+    }
+}
+
+/// Type that rejects requests if a header is not present or does not have an expected value.
+pub struct AssertHeaderOrReject<ResBody> {
+    expected_header_name: String,
+    expected_header_value: String,
+    response_status_code: StatusCode,
+    _ty: PhantomData<fn() -> ResBody>,
+}
+
+impl<ResBody> AssertHeaderOrReject<ResBody> {
+    /// Create a new `AssertHeaderOrReject` struct.
+    fn new(
+        expected_header_name: &str,
+        expected_header_value: &str,
+        response_status_code: StatusCode,
+    ) -> Self
+    where
+        ResBody: Body + Default,
+    {
+        Self {
+            expected_header_name: expected_header_name.to_string(),
+            expected_header_value: expected_header_value.to_string(),
+            response_status_code,
+            _ty: PhantomData,
+        }
+    }
+}
+
+impl<ResBody> Clone for AssertHeaderOrReject<ResBody> {
+    fn clone(&self) -> Self {
+        Self {
+            expected_header_name: self.expected_header_name.clone(),
+            expected_header_value: self.expected_header_value.clone(),
+            response_status_code: self.response_status_code.clone(),
+            _ty: PhantomData,
+        }
+    }
+}
+
+impl<ResBody> fmt::Debug for AssertHeaderOrReject<ResBody> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AssertHeaderOrReject")
+            .field("expected_header_name", &self.expected_header_name)
+            .field("expected_header_value", &self.expected_header_value)
+            .field("response_status_code", &self.response_status_code)
+            .finish()
+    }
+}
+
+impl<B, ResBody> ValidateRequest<B> for AssertHeaderOrReject<ResBody>
+where
+    ResBody: Body + Default,
+{
+    type ResponseBody = ResBody;
+
+    fn validate(&mut self, req: &mut Request<B>) -> Result<(), Response<Self::ResponseBody>> {
+        let request_header_value = req
+            .headers()
+            .get(&self.expected_header_name)
+            .and_then(|v| v.to_str().ok());
+
+        if request_header_value != Some(&self.expected_header_value) {
+            let mut res = Response::new(ResBody::default());
+            *res.status_mut() = self.response_status_code;
+            return Err(res);
+        }
+
+        Ok(())
     }
 }
 

--- a/tower-http/src/validate_request.rs
+++ b/tower-http/src/validate_request.rs
@@ -73,7 +73,7 @@
 //!     .layer(ValidateRequestHeaderLayer::has_header_value(
 //!         "x-custom-header",
 //!         "random-value-1234567890",
-//!     ))
+//!     ).expect("invalid validate header"))
 //!     .service_fn(handle);
 //!
 //! // Requests with the correct value are allowed through
@@ -103,20 +103,6 @@
 //!     .await?;
 //!
 //! assert_eq!(StatusCode::FORBIDDEN, response.status());
-//! #
-//! # // Requests without the expected header also get a `403 Forbidden` response
-//! # let request = Request::builder()
-//! #    .body(Full::default())
-//! #    .unwrap();
-//! #
-//! # let response = service
-//! #    .ready()
-//! #    .await?
-//! #    .call(request)
-//! #    .await?;
-//! #
-//! # assert_eq!(StatusCode::FORBIDDEN, response.status());
-//! #
 //! # Ok(())
 //! # }
 //! ```
@@ -218,7 +204,8 @@
 //!
 //! [`Accept`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
 
-use http::{header, Request, Response, StatusCode};
+use http::header::InvalidHeaderName;
+use http::{header, header::HeaderName, Request, Response, StatusCode};
 use mime::{Mime, MimeIter};
 use pin_project_lite::pin_project;
 use std::{
@@ -270,10 +257,19 @@ impl<ResBody> ValidateRequestHeaderLayer<AcceptHeader<ResBody>> {
     }
 }
 
-impl<ResBody> ValidateRequestHeaderLayer<AssertHeaderOrReject<ResBody>> {
+impl<ResBody> ValidateRequestHeaderLayer<RequiredHeaderValue<ResBody>> {
     /// Validate requests have a required header with a specific value.
     ///
     /// Rejects with `403 Forbidden` if the header is missing or does not have the expected value.
+    /// Header values that are not valid UTF-8 are treated as non-matching.
+    ///
+    /// If the request contains multiple values for the header, only the first occurrence is
+    /// checked.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `expected_header_name` is not a valid HTTP header name per RFC 7230
+    /// (non-empty, at most 32,768 bytes, containing only valid token characters).
     ///
     /// # Example
     ///
@@ -294,7 +290,7 @@ impl<ResBody> ValidateRequestHeaderLayer<AssertHeaderOrReject<ResBody>> {
     ///     .layer(ValidateRequestHeaderLayer::has_header_value(
     ///         "x-custom-header",
     ///         "random-value-1234567890",
-    ///     ))
+    ///     ).expect("invalid validate header"))
     ///     .service_fn(handle);
     ///
     /// let request = Request::builder()
@@ -306,14 +302,17 @@ impl<ResBody> ValidateRequestHeaderLayer<AssertHeaderOrReject<ResBody>> {
     /// assert_eq!(response.status(), StatusCode::OK);
     /// # }
     /// ```
-    pub fn has_header_value(expected_header_name: &str, expected_header_value: &str) -> Self
+    pub fn has_header_value(
+        expected_header_name: &str,
+        expected_header_value: &str,
+    ) -> Result<Self, InvalidHeaderName>
     where
         ResBody: Default,
     {
-        Self::custom(AssertHeaderOrReject::new(
-            expected_header_name,
+        Ok(Self::custom(RequiredHeaderValue::new(
+            expected_header_name.parse::<HeaderName>()?,
             expected_header_value,
-        ))
+        )))
     }
 }
 
@@ -561,26 +560,26 @@ where
 }
 
 /// Type that rejects requests if a header is not present or does not have an expected value.
-pub struct AssertHeaderOrReject<ResBody> {
-    expected_header_name: String,
-    expected_header_value: String,
+pub struct RequiredHeaderValue<ResBody> {
+    expected_header_name: HeaderName,
+    expected_header_value: Arc<str>,
     _ty: PhantomData<fn() -> ResBody>,
 }
 
-impl<ResBody> AssertHeaderOrReject<ResBody> {
-    fn new(expected_header_name: &str, expected_header_value: &str) -> Self
+impl<ResBody> RequiredHeaderValue<ResBody> {
+    fn new(expected_header_name: HeaderName, expected_header_value: &str) -> Self
     where
         ResBody: Default,
     {
         Self {
-            expected_header_name: expected_header_name.to_string(),
-            expected_header_value: expected_header_value.to_string(),
+            expected_header_name,
+            expected_header_value: expected_header_value.into(),
             _ty: PhantomData,
         }
     }
 }
 
-impl<ResBody> Clone for AssertHeaderOrReject<ResBody> {
+impl<ResBody> Clone for RequiredHeaderValue<ResBody> {
     fn clone(&self) -> Self {
         Self {
             expected_header_name: self.expected_header_name.clone(),
@@ -590,16 +589,16 @@ impl<ResBody> Clone for AssertHeaderOrReject<ResBody> {
     }
 }
 
-impl<ResBody> fmt::Debug for AssertHeaderOrReject<ResBody> {
+impl<ResBody> fmt::Debug for RequiredHeaderValue<ResBody> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("AssertHeaderOrReject")
+        f.debug_struct("RequiredHeaderValue")
             .field("expected_header_name", &self.expected_header_name)
             .field("expected_header_value", &self.expected_header_value)
             .finish()
     }
 }
 
-impl<B, ResBody> ValidateRequest<B> for AssertHeaderOrReject<ResBody>
+impl<B, ResBody> ValidateRequest<B> for RequiredHeaderValue<ResBody>
 where
     ResBody: Default,
 {
@@ -611,7 +610,7 @@ where
             .get(&self.expected_header_name)
             .and_then(|v| v.to_str().ok());
 
-        if request_header_value != Some(&self.expected_header_value) {
+        if request_header_value != Some(&*self.expected_header_value) {
             let mut res = Response::new(ResBody::default());
             *res.status_mut() = StatusCode::FORBIDDEN;
             return Err(res);
@@ -794,10 +793,13 @@ mod tests {
     #[tokio::test]
     async fn valid_custom_header() {
         let mut service = ServiceBuilder::new()
-            .layer(ValidateRequestHeaderLayer::has_header_value(
-                "x-custom-header",
-                "random-value-1234567890",
-            ))
+            .layer(
+                ValidateRequestHeaderLayer::has_header_value(
+                    "x-custom-header",
+                    "random-value-1234567890",
+                )
+                .expect("invalid validate header"),
+            )
             .service_fn(echo);
 
         let request = Request::get("/")
@@ -813,10 +815,13 @@ mod tests {
     #[tokio::test]
     async fn invalid_custom_header() {
         let mut service = ServiceBuilder::new()
-            .layer(ValidateRequestHeaderLayer::has_header_value(
-                "x-custom-header",
-                "random-value-1234567890",
-            ))
+            .layer(
+                ValidateRequestHeaderLayer::has_header_value(
+                    "x-custom-header",
+                    "random-value-1234567890",
+                )
+                .expect("invalid validate header"),
+            )
             .service_fn(echo);
 
         let request = Request::get("/")
@@ -832,16 +837,112 @@ mod tests {
     #[tokio::test]
     async fn missing_custom_header() {
         let mut service = ServiceBuilder::new()
-            .layer(ValidateRequestHeaderLayer::has_header_value(
-                "x-custom-header",
-                "random-value-1234567890",
-            ))
+            .layer(
+                ValidateRequestHeaderLayer::has_header_value(
+                    "x-custom-header",
+                    "random-value-1234567890",
+                )
+                .expect("invalid validate header"),
+            )
             .service_fn(echo);
 
         let request = Request::get("/").body(Body::empty()).unwrap();
 
         let res = service.ready().await.unwrap().call(request).await.unwrap();
 
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn custom_header_multiple_values_uses_first() {
+        let mut service = ServiceBuilder::new()
+            .layer(
+                ValidateRequestHeaderLayer::has_header_value("x-custom-header", "correct-value")
+                    .expect("invalid validate header"),
+            )
+            .service_fn(echo);
+
+        // First value matches: should pass
+        let request = Request::get("/")
+            .header("x-custom-header", "correct-value")
+            .header("x-custom-header", "other-value")
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service.ready().await.unwrap().call(request).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        // First value does not match: should reject even if second matches
+        let request = Request::get("/")
+            .header("x-custom-header", "wrong-value")
+            .header("x-custom-header", "correct-value")
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service.ready().await.unwrap().call(request).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn invalid_header_name_returns_error() {
+        let result = ValidateRequestHeaderLayer::<RequiredHeaderValue<Body>>::has_header_value(
+            "invalid header name with spaces",
+            "value",
+        );
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn custom_header_non_utf8_value_rejects() {
+        let mut service = ServiceBuilder::new()
+            .layer(
+                ValidateRequestHeaderLayer::has_header_value("x-custom-header", "expected-value")
+                    .expect("invalid validate header"),
+            )
+            .service_fn(echo);
+
+        let request = Request::get("/")
+            .header("x-custom-header", b"\xff\xfe".as_slice())
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service.ready().await.unwrap().call(request).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn custom_header_name_is_case_insensitive() {
+        let mut service = ServiceBuilder::new()
+            .layer(
+                ValidateRequestHeaderLayer::has_header_value("x-custom-header", "my-value")
+                    .expect("invalid validate header"),
+            )
+            .service_fn(echo);
+
+        let request = Request::get("/")
+            .header("X-Custom-Header", "my-value")
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service.ready().await.unwrap().call(request).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn custom_header_value_is_case_sensitive() {
+        let mut service = ServiceBuilder::new()
+            .layer(
+                ValidateRequestHeaderLayer::has_header_value("x-custom-header", "My-Value")
+                    .expect("invalid validate header"),
+            )
+            .service_fn(echo);
+
+        let request = Request::get("/")
+            .header("x-custom-header", "my-value")
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service.ready().await.unwrap().call(request).await.unwrap();
         assert_eq!(res.status(), StatusCode::FORBIDDEN);
     }
 

--- a/tower-http/src/validate_request.rs
+++ b/tower-http/src/validate_request.rs
@@ -53,29 +53,34 @@
 //! # }
 //! ```
 //!
-//! Validation of a custom header can be made by using [`ValidateRequestHeaderLayer::assert()`]:
+//! Validation of a custom header can be made by using [`ValidateRequestHeaderLayer::has_header()`]:
 //!
 //! ```
 //! use tower_http::validate_request::ValidateRequestHeaderLayer;
-//! use hyper::{Request, Response, Body, Error};
-//! use http::StatusCode;
-//! use tower::{Service, ServiceExt, ServiceBuilder, service_fn};
+//! use http::{Request, Response, StatusCode};
+//! use http_body_util::Full;
+//! use bytes::Bytes;
+//! use tower::{Service, ServiceExt, ServiceBuilder, service_fn, BoxError};
 //!
-//! async fn handle(request: Request<Body>) -> Result<Response<Body>, Error> {
-//!     Ok(Response::new(Body::empty()))
+//! async fn handle(request: Request<Full<Bytes>>) -> Result<Response<Full<Bytes>>, BoxError> {
+//!     Ok(Response::new(Full::default()))
 //! }
 //!
 //! # #[tokio::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # async fn main() -> Result<(), BoxError> {
 //! let mut service = ServiceBuilder::new()
 //!     // Require a `X-Custom-Header` header to have the value `random-value-1234567890` or reject with a `403 Forbidden` response
-//!     .layer(ValidateRequestHeaderLayer::assert("x-custom-header", "random-value-1234567890", StatusCode::FORBIDDEN))
+//!     .layer(
+//!         ValidateRequestHeaderLayer::has_header("x-custom-header")
+//!             .with_value("random-value-1234567890")
+//!             .with_status_code(StatusCode::FORBIDDEN),
+//!     )
 //!     .service_fn(handle);
 //!
 //! // Requests with the correct value are allowed through
 //! let request = Request::builder()
 //!     .header("x-custom-header", "random-value-1234567890")
-//!     .body(Body::empty())
+//!     .body(Full::default())
 //!     .unwrap();
 //!
 //! let response = service
@@ -89,7 +94,7 @@
 //! // Requests with an invalid value get a `403 Forbidden` response
 //! let request = Request::builder()
 //!     .header("x-custom-header", "wrong-value")
-//!     .body(Body::empty())
+//!     .body(Full::default())
 //!     .unwrap();
 //!
 //! let response = service
@@ -102,7 +107,7 @@
 //! #
 //! # // Requests without the expected header also get a `403 Forbidden` response
 //! # let request = Request::builder()
-//! #    .body(Body::empty())
+//! #    .body(Full::default())
 //! #    .unwrap();
 //! #
 //! # let response = service
@@ -236,29 +241,67 @@ impl<ResBody> ValidateRequestHeaderLayer<AcceptHeader<ResBody>> {
     }
 }
 
-impl<ResBody> ValidateRequestHeaderLayer<AssertHeaderOrReject<ResBody>> {
+impl ValidateRequestHeaderLayer<AssertHeaderOrReject<()>> {
     /// Validate requests have a required header with a specific value.
     ///
     /// # Example
     ///
     /// ```
     /// use http::StatusCode;
-    /// use hyper::Body;
-    /// use tower_http::validate_request::{AssertHeaderOrReject, ValidateRequestHeaderLayer};
+    /// use http_body_util::Full;
+    /// use bytes::Bytes;
+    /// use tower_http::validate_request::ValidateRequestHeaderLayer;
     ///
-    /// let layer = ValidateRequestHeaderLayer::<AssertHeaderOrReject<Body>>::assert("x-custom-header", "random-value-1234567890", StatusCode::FORBIDDEN);
+    /// let _layer = ValidateRequestHeaderLayer::has_header("x-custom-header")
+    ///     .with_value("random-value-1234567890")
+    ///     .with_status_code::<Full<Bytes>>(StatusCode::FORBIDDEN);
     /// ```
-    pub fn assert(
-        expected_header_name: &str,
-        expected_header_value: &str,
+    pub fn has_header(expected_header_name: &str) -> HasHeaderBuilder {
+        HasHeaderBuilder::new(expected_header_name)
+    }
+}
+
+/// Builder for [`ValidateRequestHeaderLayer::has_header`].
+#[derive(Debug, Clone)]
+pub struct HasHeaderBuilder {
+    expected_header_name: String,
+}
+
+/// Builder returned by [`HasHeaderBuilder::with_value`].
+#[derive(Debug, Clone)]
+pub struct HasHeaderWithValueBuilder {
+    expected_header_name: String,
+    expected_header_value: String,
+}
+
+impl HasHeaderBuilder {
+    fn new(expected_header_name: &str) -> Self {
+        Self {
+            expected_header_name: expected_header_name.to_string(),
+        }
+    }
+
+    /// Require the header to have this value.
+    pub fn with_value(self, expected_header_value: &str) -> HasHeaderWithValueBuilder {
+        HasHeaderWithValueBuilder {
+            expected_header_name: self.expected_header_name,
+            expected_header_value: expected_header_value.to_string(),
+        }
+    }
+}
+
+impl HasHeaderWithValueBuilder {
+    /// Set the response status code when validation fails.
+    pub fn with_status_code<ResBody>(
+        self,
         response_status_code: StatusCode,
-    ) -> Self
+    ) -> ValidateRequestHeaderLayer<AssertHeaderOrReject<ResBody>>
     where
-        ResBody: Body + Default,
+        ResBody: Default,
     {
-        Self::custom(AssertHeaderOrReject::new(
-            expected_header_name,
-            expected_header_value,
+        ValidateRequestHeaderLayer::custom(AssertHeaderOrReject::new(
+            &self.expected_header_name,
+            &self.expected_header_value,
             response_status_code,
         ))
     }
@@ -523,7 +566,7 @@ impl<ResBody> AssertHeaderOrReject<ResBody> {
         response_status_code: StatusCode,
     ) -> Self
     where
-        ResBody: Body + Default,
+        ResBody: Default,
     {
         Self {
             expected_header_name: expected_header_name.to_string(),
@@ -539,7 +582,7 @@ impl<ResBody> Clone for AssertHeaderOrReject<ResBody> {
         Self {
             expected_header_name: self.expected_header_name.clone(),
             expected_header_value: self.expected_header_value.clone(),
-            response_status_code: self.response_status_code.clone(),
+            response_status_code: self.response_status_code,
             _ty: PhantomData,
         }
     }
@@ -557,7 +600,7 @@ impl<ResBody> fmt::Debug for AssertHeaderOrReject<ResBody> {
 
 impl<B, ResBody> ValidateRequest<B> for AssertHeaderOrReject<ResBody>
 where
-    ResBody: Body + Default,
+    ResBody: Default,
 {
     type ResponseBody = ResBody;
 
@@ -745,6 +788,63 @@ mod tests {
         let res = service.ready().await.unwrap().call(request).await.unwrap();
 
         assert_eq!(res.status(), StatusCode::NOT_ACCEPTABLE);
+    }
+
+    #[tokio::test]
+    async fn valid_custom_header() {
+        let mut service = ServiceBuilder::new()
+            .layer(
+                ValidateRequestHeaderLayer::has_header("x-custom-header")
+                    .with_value("random-value-1234567890")
+                    .with_status_code(StatusCode::FORBIDDEN),
+            )
+            .service_fn(echo);
+
+        let request = Request::get("/")
+            .header("x-custom-header", "random-value-1234567890")
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service.ready().await.unwrap().call(request).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn invalid_custom_header() {
+        let mut service = ServiceBuilder::new()
+            .layer(
+                ValidateRequestHeaderLayer::has_header("x-custom-header")
+                    .with_value("random-value-1234567890")
+                    .with_status_code(StatusCode::FORBIDDEN),
+            )
+            .service_fn(echo);
+
+        let request = Request::get("/")
+            .header("x-custom-header", "wrong-value")
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service.ready().await.unwrap().call(request).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn missing_custom_header() {
+        let mut service = ServiceBuilder::new()
+            .layer(
+                ValidateRequestHeaderLayer::has_header("x-custom-header")
+                    .with_value("random-value-1234567890")
+                    .with_status_code(StatusCode::FORBIDDEN),
+            )
+            .service_fn(echo);
+
+        let request = Request::get("/").body(Body::empty()).unwrap();
+
+        let res = service.ready().await.unwrap().call(request).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
     }
 
     async fn echo(req: Request<Body>) -> Result<Response<Body>, BoxError> {


### PR DESCRIPTION
## Motivation

At my company, we use a CDN (AWS Cloudfront) in front of our Rust applications... 

Then, the AWS recommendation to make sure that all requests come from our CDN (and not from a "hacker" that somehow managed to find the direct IP address of our Rust application) is to make the CDN set a "secret header" with a "secret value" and to assert, in the Rust application, that this "secret header" has been correctly set with the expected "secret value".

AWS documented this behavior [here for classical Cloudfront origins](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/restrict-access-to-load-balancer.html#restrict-alb-add-custom-header) and [here for Lambda URLs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistS3AndCustomOrigins.html#concept_lambda_function_url).

However, since `tower-http` currently does not offer this kind of "header checker", instead of duplicating a `ValidateRequestHeaderLayer::custom()` closure in all our Rust applications, we had to make our own internal Rust crate containing our own "tower http layer" that uses `ValidateRequestHeaderLayer` to do this check... It works fine, but I think it would be best for everyone to have this simple layer directly offered by `tower-http` (under the `validate-request` feature flag).

## Solution

Add a ~`ValidateRequestHeaderLayer::assert()`~ `ValidateRequestHeaderLayer::has_header("...").with_value("...").with_status_code(StatusCode::FORBIDDEN)` function that acts like `ValidateRequestHeaderLayer::accept()` but for any header.