### PR TITLE
[trace] Reduce code bloat of on_xxx function #342

### DIFF
--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -383,6 +383,7 @@
 //! [`Body::poll_trailers`]: http_body::Body::poll_trailers
 //! [`Body::poll_data`]: http_body::Body::poll_data
 
+use crate::LatencyUnit;
 use tracing::Level;
 
 pub use self::{
@@ -411,6 +412,16 @@ mod service;
 
 const DEFAULT_MESSAGE_LEVEL: Level = Level::DEBUG;
 const DEFAULT_ERROR_LEVEL: Level = Level::ERROR;
+
+#[inline]
+fn latency_unit_to_str(latency_unit: LatencyUnit) -> &'static str {
+    match latency_unit {
+        LatencyUnit::Seconds => "s",
+        LatencyUnit::Millis => "ms",
+        LatencyUnit::Micros => "μs",
+        LatencyUnit::Nanos => "ns",
+    }
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Not completly fixing #342 but greatly reduce the pressure.

At the expanse of losing fractional precision when a latency of second is requested, this PR reduce the code generated by on_xxx function by removing the cardinality of selecting the latency unit in the match expression.

Before the LatencyUnit::Seconds was displayed with `xxx.as_secs_f64()`, with this patch it is displayed as `xxx.as_secs()` to be able to cast it to u128 and have an homogenous return type. This allows to remove a cardinality from the huge match we are creating to call the correct log.

before:
```
❯ cargo bloat --feature trace
0.2%   2.5% 243.4KiB         tower_http <tower_http::trace::on_response::DefaultOnResponse as tower_http::trace::on_response::OnResponse<B,A>>::on_response
0.1%   1.2% 112.6KiB         tower_http <tower_http::trace::on_eos::DefaultOnEos as tower_http::trace::on_eos::OnEos<ReqBody>>::on_eos
0.1%   0.7%  70.4KiB         tower_http <tower_http::trace::on_failure::DefaultOnFailure as tower_http::trace::on_failure::OnFailure<FailureClass,ReqBody>>::on_failure
```

after this patch:
```
❯ cargo bloat --feature trace
0.1%   0.7%  64.7KiB         tower_http <tower_http::trace::on_response::DefaultOnResponse as tower_http::trace::on_response::OnResponse<B,A>>::on_response
0.0%   0.3%  30.1KiB         tower_http <tower_http::trace::make_span::DefaultMakeSpan as tower_http::trace::make_span::MakeSpan<B>>::make_span
0.0%   0.3%  30.0KiB         tower_http <tower_http::trace::on_eos::DefaultOnEos as tower_http::trace::on_eos::OnEos<ReqBody>>::on_eos
```