### PR TITLE
Bump base64 to 0.21

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -25,7 +25,7 @@ tower-service = "0.3"
 
 # optional dependencies
 async-compression = { version = "0.3", optional = true, features = ["tokio"] }
-base64 = { version = "0.20", optional = true }
+base64 = { version = "0.21", optional = true }
 http-range-header = "0.3.0"
 iri-string = { version = "0.7.0", optional = true }
 mime = { version = "0.3", optional = true, default_features = false }

--- a/tower-http/src/auth/add_authorization.rs
+++ b/tower-http/src/auth/add_authorization.rs
@@ -70,7 +70,10 @@ impl AddAuthorizationLayer {
     /// Since the username and password is sent in clear text it is recommended to use HTTPS/TLS
     /// with this method. However use of HTTPS/TLS is not enforced by this middleware.
     pub fn basic(username: &str, password: &str) -> Self {
-        let encoded = base64::encode(format!("{}:{}", username, password));
+        use base64::Engine;
+
+        let engine = base64::engine::general_purpose::STANDARD;
+        let encoded = engine.encode(format!("{}:{}", username, password));
         let value = HeaderValue::try_from(format!("Basic {}", encoded)).unwrap();
         Self { value }
     }

--- a/tower-http/src/auth/require_authorization.rs
+++ b/tower-http/src/auth/require_authorization.rs
@@ -195,7 +195,10 @@ impl<ResBody> Basic<ResBody> {
     where
         ResBody: Body + Default,
     {
-        let encoded = base64::encode(format!("{}:{}", username, password));
+        use base64::Engine;
+
+        let engine = base64::engine::general_purpose::STANDARD;
+        let encoded = engine.encode(format!("{}:{}", username, password));
         let header_value = format!("Basic {}", encoded).parse().unwrap();
         Self {
             header_value,
@@ -247,6 +250,7 @@ mod tests {
 
     #[allow(unused_imports)]
     use super::*;
+    use base64::Engine;
     use http::header;
     use hyper::Body;
     use tower::{BoxError, ServiceBuilder, ServiceExt};
@@ -258,10 +262,12 @@ mod tests {
             .layer(ValidateRequestHeaderLayer::basic("foo", "bar"))
             .service_fn(echo);
 
+        let engine = base64::engine::general_purpose::STANDARD;
+
         let request = Request::get("/")
             .header(
                 header::AUTHORIZATION,
-                format!("Basic {}", base64::encode("foo:bar")),
+                format!("Basic {}", engine.encode("foo:bar")),
             )
             .body(Body::empty())
             .unwrap();
@@ -277,10 +283,12 @@ mod tests {
             .layer(ValidateRequestHeaderLayer::basic("foo", "bar"))
             .service_fn(echo);
 
+        let engine = base64::engine::general_purpose::STANDARD;
+
         let request = Request::get("/")
             .header(
                 header::AUTHORIZATION,
-                format!("Basic {}", base64::encode("wrong:credentials")),
+                format!("Basic {}", engine.encode("wrong:credentials")),
             )
             .body(Body::empty())
             .unwrap();
@@ -315,10 +323,12 @@ mod tests {
             .layer(ValidateRequestHeaderLayer::basic("foo", "bar"))
             .service_fn(echo);
 
+        let engine = base64::engine::general_purpose::STANDARD;
+
         let request = Request::get("/")
             .header(
                 header::AUTHORIZATION,
-                format!("basic {}", base64::encode("foo:bar")),
+                format!("basic {}", engine.encode("foo:bar")),
             )
             .body(Body::empty())
             .unwrap();
@@ -334,10 +344,12 @@ mod tests {
             .layer(ValidateRequestHeaderLayer::basic("foo", "bar"))
             .service_fn(echo);
 
+        let engine = base64::engine::general_purpose::STANDARD;
+
         let request = Request::get("/")
             .header(
                 header::AUTHORIZATION,
-                format!("Basic {}", base64::encode("Foo:bar")),
+                format!("Basic {}", engine.encode("Foo:bar")),
             )
             .body(Body::empty())
             .unwrap();


### PR DESCRIPTION
Bump base base64 dependency to 0.21.

## Motivation

- Remove the possibility of panicking during decoded length calculations
- Some functions in base64 were deprecated

## Solution

- Bump version of base64 to 0.21
- Fix code using the deprecated `base64::encode` and `base64::decode` functions