### PR TITLE
Preserve service error type in RequestDecompression

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 
 - Bump Minimum Supported Rust Version to 1.66 ([#433])
+- Preserve service error type in RequestDecompression ([#368])
 
 ## Removed
 
@@ -26,6 +27,7 @@ http-range-header to `0.4`
 
 [#418]: https://github.com/tower-rs/tower-http/pull/418
 [#433]: https://github.com/tower-rs/tower-http/pull/433
+[#368]: https://github.com/tower-rs/tower-http/pull/368
 
 # 0.4.2 (July 19, 2023)
 

--- a/tower-http/src/decompression/request/service.rs
+++ b/tower-http/src/decompression/request/service.rs
@@ -42,16 +42,15 @@ where
     S: Service<Request<DecompressionBody<ReqBody>>, Response = Response<ResBody>>,
     ReqBody: Body,
     ResBody: Body<Data = D> + Send + 'static,
-    S::Error: Into<BoxError>,
     <ResBody as Body>::Error: Into<BoxError>,
     D: Buf + 'static,
 {
     type Response = Response<UnsyncBoxBody<D, BoxError>>;
-    type Error = BoxError;
+    type Error = S::Error;
     type Future = ResponseFuture<S::Future, ResBody, S::Error>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx).map_err(Into::into)
+        self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {


### PR DESCRIPTION
There seems to be no reason for `RequestDecompression` to change the service error type to `BoxError`, so it would be nice to preserve the underlying error type. This is especially useful if the inner service is infallible.
 
## Motivation

When I add `RequestDecompressionLayer` to a stack of infallible layers, the resulting service has `BoxError` as an error type, but it never actually fails.

## Solution

Make `RequestDecompression` preserve the error type of the inner service.