### PR TITLE
Implement Default for DecompressionBody

### DIFF
--- a/tower-http/src/decompression/body.rs
+++ b/tower-http/src/decompression/body.rs
@@ -36,6 +36,19 @@ pin_project! {
     }
 }
 
+impl<B> Default for DecompressionBody<B>
+where
+    B: Body + Default,
+{
+    fn default() -> Self {
+        Self {
+            inner: BodyInner::Identity {
+                inner: B::default(),
+            },
+        }
+    }
+}
+
 impl<B> DecompressionBody<B>
 where
     B: Body,


### PR DESCRIPTION
## Motivation

It may be useful to have `Default` implemented for a body type. `DecompressionBody` used by the RequestDecompressionLayer can implement it if the inner body type does. The same `Default` implementation already exists for the `CompressionBody`, and there seems to be no reason why `DecompressionBody` shouldn't.

## Solution

Add a `Default` implementation for `DecompressionBody<B: Default>`
