### PR TITLE
Move examples to its own workspace

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,6 +36,21 @@ jobs:
         RUSTDOCFLAGS: "-D rustdoc::broken_intra_doc_links"
       run: cargo doc --all-features --no-deps
 
+  check-examples:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt
+    - run: cargo fmt --all --check
+      working-directory: examples
+    - uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: "examples -> target"
+    - run: cargo check --workspace --all-features --all-targets
+      working-directory: examples
+
   cargo-hack:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 
 /target/
+/examples/target/
 **/*.rs.bk
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,2 @@
 [workspace]
-members = [
-  "tower-http",
-  "examples/*",
-]
+members = ["tower-http"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = ["*"]
+exclude = ["target"]
+resolver = "2"


### PR DESCRIPTION
## Motivation

- Fixes the ci and makes it more robust.
- Releases examples from `tower-http`'s msrv.

## Solution

Moves examples to its own workspace. As `tower-http` is relatively lower layer library and it's real world examples tend to use a lot of crates as dependencies, the advantages which treating examples and `tower-http` as a single workspace seem small.