### PR TITLE
Update ci config

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: dtolnay/rust-toolchain@nightly
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@v2
     - name: Install cargo-public-api-crates
       run: |
         cargo install --git https://github.com/davidpdrsn/cargo-public-api-crates

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,11 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: dtolnay/rust-toolchain@stable
-    - name: Check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --workspace --all-features --all-targets
+    - run: cargo check --workspace --all-features --all-targets
 
   check-docs:
     runs-on: ubuntu-latest
@@ -55,11 +51,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-    - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --workspace --all-features
+    - run: cargo test --workspace --all-features
 
   test-msrv:
     needs: check
@@ -67,12 +59,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: dtolnay/rust-toolchain@1.60.0
-    - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: -p tower-http --all-features
-        toolchain: 1.60.0
+    - run: cargo test -p tower-http --all-features
 
   style:
     needs: check
@@ -82,11 +69,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt
-    - name: rustfmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+    - run: cargo fmt --all --check
 
   deny-check:
     name: cargo-deny check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,11 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
+    - uses: dtolnay/rust-toolchain@stable
     - name: Check
       uses: actions-rs/cargo@v1
       with:
@@ -26,10 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
+    - uses: dtolnay/rust-toolchain@stable
     - name: cargo doc
       working-directory: ${{ matrix.subcrate }}
       env:
@@ -40,10 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
+    - uses: dtolnay/rust-toolchain@stable
     - name: Install cargo-hack
       run: |
         curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
@@ -62,11 +52,9 @@ jobs:
         rust: [stable, beta, nightly]
     steps:
     - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        profile: minimal
-        override: true
     - name: Run tests
       uses: actions-rs/cargo@v1
       with:
@@ -78,11 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.60.0
-        profile: minimal
-        override: true
+    - uses: dtolnay/rust-toolchain@1.60.0
     - name: Run tests
       uses: actions-rs/cargo@v1
       with:
@@ -95,11 +79,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
         components: rustfmt
-        profile: minimal
     - name: rustfmt
       uses: actions-rs/cargo@v1
       with:
@@ -126,11 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
+    - uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v1
     - name: Install cargo-public-api-crates
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,14 +10,14 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
     - run: cargo check --workspace --all-features --all-targets
 
   check-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
     - name: cargo doc
       working-directory: ${{ matrix.subcrate }}
@@ -28,7 +28,7 @@ jobs:
   cargo-hack:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
     - name: Install cargo-hack
       run: |
@@ -47,7 +47,7 @@ jobs:
       matrix:
         rust: [stable, beta, nightly]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
@@ -57,7 +57,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@1.60.0
     - run: cargo test -p tower-http --all-features
 
@@ -65,7 +65,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt
@@ -81,7 +81,7 @@ jobs:
         - advisories
         - bans licenses sources
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: EmbarkStudios/cargo-deny-action@v1
       with:
         command: check ${{ matrix.checks }}
@@ -90,7 +90,7 @@ jobs:
   cargo-public-api-crates:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v2
     - name: Install cargo-public-api-crates

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,9 +30,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
-    - name: Install cargo-hack
-      run: |
-        curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
+    - uses: taiki-e/install-action@cargo-hack
     - name: cargo hack check
       working-directory: ${{ matrix.subcrate }}
       env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,14 +78,14 @@ jobs:
     strategy:
       matrix:
         checks:
-          - advisories
-          - bans licenses sources
+        - advisories
+        - bans licenses sources
     steps:
-      - uses: actions/checkout@v2
-      - uses: EmbarkStudios/cargo-deny-action@v1
-        with:
-          command: check ${{ matrix.checks }}
-          arguments: --all-features --manifest-path tower-http/Cargo.toml
+    - uses: actions/checkout@v2
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check ${{ matrix.checks }}
+        arguments: --all-features --manifest-path tower-http/Cargo.toml
 
   cargo-public-api-crates:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

Resolves the ci warnings and improves the ci maintainability.

## Solution

### Resolves the ci warnings

- Replaces `actions-rs/toolchain` with `dtolnay/rust-toolchain`.
    - `actions-rs/toolchain` is not maintained (https://github.com/actions-rs/toolchain/issues/216)
    - `dtonlay/rust-toolchain` is widely used in a lot of projects (for example [tokio project](https://github.com/tokio-rs/tokio/blob/tokio-1.28.2/.github/workflows/ci.yml#L90)).
- Replaces `actions-rs/cargo` with `run`.
    - Same as `actions-rs/toolchain`, `actions-rs/cargo` is not maintained.
- Update to `Swatinem/rust-cache@v2` from version 1.

### Other fixes

- YAML indent style.

### Miscellaneous improvements

- Uses the latest stable version 3 of `actions/checkout`.
- Uses `taiki-e/install-action` to install `cargo-hack`.
    - This action is maintained by the same author of `cargo-hack`.
    - It is used in a lot of projects (for example [tokio project](https://github.com/tokio-rs/tokio/blob/tokio-1.28.2/.github/workflows/ci.yml#L97)).