### PR TITLE
trace: Simplify dynamic tracing level application

### DIFF
--- a/tower-http/src/trace/make_span.rs
+++ b/tower-http/src/trace/make_span.rs
@@ -103,21 +103,11 @@ impl<B> MakeSpan<B> for DefaultMakeSpan {
         }
 
         match self.level {
-            Level::ERROR => {
-                make_span!(Level::ERROR)
-            }
-            Level::WARN => {
-                make_span!(Level::WARN)
-            }
-            Level::INFO => {
-                make_span!(Level::INFO)
-            }
-            Level::DEBUG => {
-                make_span!(Level::DEBUG)
-            }
-            Level::TRACE => {
-                make_span!(Level::TRACE)
-            }
+            Level::ERROR => make_span!(Level::ERROR),
+            Level::WARN => make_span!(Level::WARN),
+            Level::INFO => make_span!(Level::INFO),
+            Level::DEBUG => make_span!(Level::DEBUG),
+            Level::TRACE => make_span!(Level::TRACE),
         }
     }
 }

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -383,6 +383,8 @@
 //! [`Body::poll_trailers`]: http_body::Body::poll_trailers
 //! [`Body::poll_data`]: http_body::Body::poll_data
 
+use std::{fmt, time::Duration};
+
 use tracing::Level;
 
 pub use self::{
@@ -397,6 +399,54 @@ pub use self::{
     on_response::{DefaultOnResponse, OnResponse},
     service::Trace,
 };
+use crate::LatencyUnit;
+
+macro_rules! event_dynamic_lvl {
+    ( $(target: $target:expr,)? $(parent: $parent:expr,)? $lvl:expr, $($tt:tt)* ) => {
+        match $lvl {
+            tracing::Level::ERROR => {
+                tracing::event!(
+                    $(target: $target,)?
+                    $(parent: $parent,)?
+                    tracing::Level::ERROR,
+                    $($tt)*
+                );
+            }
+            tracing::Level::WARN => {
+                tracing::event!(
+                    $(target: $target,)?
+                    $(parent: $parent,)?
+                    tracing::Level::WARN,
+                    $($tt)*
+                );
+            }
+            tracing::Level::INFO => {
+                tracing::event!(
+                    $(target: $target,)?
+                    $(parent: $parent,)?
+                    tracing::Level::INFO,
+                    $($tt)*
+                );
+            }
+            tracing::Level::DEBUG => {
+                tracing::event!(
+                    $(target: $target,)?
+                    $(parent: $parent,)?
+                    tracing::Level::DEBUG,
+                    $($tt)*
+                );
+            }
+            tracing::Level::TRACE => {
+                tracing::event!(
+                    $(target: $target,)?
+                    $(parent: $parent,)?
+                    tracing::Level::TRACE,
+                    $($tt)*
+                );
+            }
+        }
+    };
+}
 
 mod body;
 mod future;
@@ -411,6 +461,22 @@ mod service;
 
 const DEFAULT_MESSAGE_LEVEL: Level = Level::DEBUG;
 const DEFAULT_ERROR_LEVEL: Level = Level::ERROR;
+
+struct Latency {
+    unit: LatencyUnit,
+    duration: Duration,
+}
+
+impl fmt::Display for Latency {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.unit {
+            LatencyUnit::Seconds => write!(f, "{} s", self.duration.as_secs_f64()),
+            LatencyUnit::Millis => write!(f, "{} ms", self.duration.as_millis()),
+            LatencyUnit::Micros => write!(f, "{} μs", self.duration.as_micros()),
+            LatencyUnit::Nanos => write!(f, "{} ns", self.duration.as_nanos()),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/tower-http/src/trace/on_request.rs
+++ b/tower-http/src/trace/on_request.rs
@@ -77,22 +77,6 @@ impl DefaultOnRequest {
 
 impl<B> OnRequest<B> for DefaultOnRequest {
     fn on_request(&mut self, _: &Request<B>, _: &Span) {
-        match self.level {
-            Level::ERROR => {
-                tracing::event!(Level::ERROR, "started processing request");
-            }
-            Level::WARN => {
-                tracing::event!(Level::WARN, "started processing request");
-            }
-            Level::INFO => {
-                tracing::event!(Level::INFO, "started processing request");
-            }
-            Level::DEBUG => {
-                tracing::event!(Level::DEBUG, "started processing request");
-            }
-            Level::TRACE => {
-                tracing::event!(Level::TRACE, "started processing request");
-            }
-        }
+        event_dynamic_lvl!(self.level, "started processing request");
     }
 }


### PR DESCRIPTION
## Motivation

I've been looking to refactor the trace layer (really kind of rewrite it, but I wanted to read most of the existing code and ideally transform it piece by piece instead of starting from scratch, which would likely lead to lots of going back and forth as I discover new things that the old code supported that aren't that easy).

As part of that, I found the `log_pattern_match` macros and thought that there *had* to be a better way. And I think I found a better way :)

## Solution

- Don't duplicate `event!` invocations for different `format_args!` strings, instead create a custom type that implements `Display` and create it on-the-fly to then log it
- Don't duplicate `event!` invocations for when a field is supposed to be captured vs. not, instead make the field value an `Option` which has the same effect (not 100% the same I think, the `FieldSet` for the event will always contain the field now, but the `ValueSet` will still behave the same which should be the only practically relevant thing)
- With all other differences gotten rid of, create a *single* macro for logging `event!`s with a non-`const` level