### PR TITLE
Unbreak CI

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -29,14 +29,8 @@ license-files = [
 ]
 
 [bans]
-multiple-versions = "deny"
+multiple-versions = "warn"
 highlight = "all"
-skip = [
-  # tracing-subscriber depends on multiple versions of regex-syntax.
-  # This is not actually depended by tower-http as this is caused by examples.
-  { name = "regex-syntax", version = ">=0.6, <= 0.7" },
-]
-skip-tree = [{ name = "tower", version = ">=0.3, <=0.4" }]
 
 [sources]
 unknown-registry = "warn"


### PR DESCRIPTION
## Motivation

CI is failing in other PRs, with no fault of the PR authors.

## Solution

Stop erroring on duplicate dependencies in the `cargo-deny` check.