### PR TITLE
Http range headers 0.4

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- Msrv 1.60.0 in `tower-http` package metadata
+- None.
 
 ## Changed
 
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
-- Parses range headers with ranges where the end of range goes past the end of the document by bumping 
+- Accepts range headers with ranges where the end of range goes past the end of the document by bumping 
 http-range-header to `0.4`
 
 # 0.4.2 (July 19, 2023)

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- None.
+- Msrv 1.60.0 in `tower-http` package metadata
 
 ## Changed
 
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
-- None.
+- Parses range headers with ranges where the end of range goes past the end of the document by bumping 
+http-range-header to `0.4`
 
 # 0.4.2 (July 19, 2023)
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -12,6 +12,9 @@ categories = ["asynchronous", "network-programming", "web-programming"]
 keywords = ["io", "async", "futures", "service", "http"]
 rust-version = "1.60"
 
+[package.metadata]
+msrv = "1.60.0"
+
 [dependencies]
 bitflags = "2.0.2"
 bytes = "1"

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -26,7 +26,7 @@ tower-service = "0.3"
 # optional dependencies
 async-compression = { version = "0.4", optional = true, features = ["tokio"] }
 base64 = { version = "0.21", optional = true }
-http-range-header = "0.3.0"
+http-range-header = "0.4.0"
 iri-string = { version = "0.7.0", optional = true }
 mime = { version = "0.3.17", optional = true, default_features = false }
 mime_guess = { version = "2", optional = true, default_features = false }

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -12,9 +12,6 @@ categories = ["asynchronous", "network-programming", "web-programming"]
 keywords = ["io", "async", "futures", "service", "http"]
 rust-version = "1.60"
 
-[package.metadata]
-msrv = "1.60.0"
-
 [dependencies]
 bitflags = "2.0.2"
 bytes = "1"

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -8,7 +8,7 @@ use http::{Request, StatusCode};
 use http_body::Body as HttpBody;
 use hyper::Body;
 use std::convert::Infallible;
-use std::io::{Read};
+use std::io::Read;
 use tower::{service_fn, ServiceExt};
 
 #[tokio::test]
@@ -501,7 +501,11 @@ async fn read_partial_accepts_out_of_bounds_range() {
     // Out of bounds range gives all bytes
     assert_eq!(
         res.headers()["content-range"],
-        &format!("bytes 0-{}/{}", file_contents.len() - 1, file_contents.len())
+        &format!(
+            "bytes 0-{}/{}",
+            file_contents.len() - 1,
+            file_contents.len()
+        )
     )
 }
 

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -8,7 +8,7 @@ use http::{Request, StatusCode};
 use http_body::Body as HttpBody;
 use hyper::Body;
 use std::convert::Infallible;
-use std::io::{self, Read};
+use std::io::{Read};
 use tower::{service_fn, ServiceExt};
 
 #[tokio::test]
@@ -480,7 +480,7 @@ async fn read_partial_in_bounds() {
 }
 
 #[tokio::test]
-async fn read_partial_rejects_out_of_bounds_range() {
+async fn read_partial_accepts_out_of_bounds_range() {
     let svc = ServeDir::new("..");
     let bytes_start_incl = 0;
     let bytes_end_excl = 9999999;
@@ -496,11 +496,12 @@ async fn read_partial_rejects_out_of_bounds_range() {
         .unwrap();
     let res = svc.oneshot(req).await.unwrap();
 
-    assert_eq!(res.status(), StatusCode::RANGE_NOT_SATISFIABLE);
+    assert_eq!(res.status(), StatusCode::PARTIAL_CONTENT);
     let file_contents = std::fs::read("../README.md").unwrap();
+    // Out of bounds range gives all bytes
     assert_eq!(
         res.headers()["content-range"],
-        &format!("bytes */{}", file_contents.len())
+        &format!("bytes 0-{}/{}", file_contents.len() - 1, file_contents.len())
     )
 }
 


### PR DESCRIPTION
## Motivation
Fixes https://github.com/tower-rs/tower-http/issues/384

## Solution
Updates http-range-header to `0.4`, it broke a test rejecting a spec-valid header so that's fixed here as well. 
Added a bunch of tests in `0.4` re-ran the fuzzing and made a few optimizations. I think the performance increase was something like 15% across the board. Set the msrv on that project to the same as this one, 1.60.0. Added msrv to the `package.metadata` for `tower-http`, so I could run `cargo msrv verify` on it, it checks out. 

The actual fix came from @jfaust in this PR https://github.com/MarcusGrass/http-range-header/pull/3
