### PR TITLE
cors: Don't overwrite vary header set by the inner service

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Accepts range headers with ranges where the end of range goes past the end of the document by bumping 
 http-range-header to `0.4`
+- cors: Keep Vary headers set by the inner service when setting response headers ([#398])
+
+[#398]:  https://github.com/tower-rs/tower-http/pull/398
 
 # 0.4.2 (July 19, 2023)
 

--- a/tower-http/src/cors/mod.rs
+++ b/tower-http/src/cors/mod.rs
@@ -618,24 +618,10 @@ where
 
         // These headers are applied to both preflight and subsequent regular CORS requests:
         // https://fetch.spec.whatwg.org/#http-responses
-
         headers.extend(self.layer.allow_origin.to_header(origin, &parts));
         headers.extend(self.layer.allow_credentials.to_header(origin, &parts));
         headers.extend(self.layer.allow_private_network.to_header(origin, &parts));
-
-        let mut vary_headers = self.layer.vary.values();
-        if let Some(first) = vary_headers.next() {
-            let mut header = match headers.entry(header::VARY) {
-                header::Entry::Occupied(_) => {
-                    unreachable!("no vary header inserted up to this point")
-                }
-                header::Entry::Vacant(v) => v.insert_entry(first),
-            };
-
-            for val in vary_headers {
-                header.append(val);
-            }
-        }
+        headers.extend(self.layer.vary.to_header());
 
         // Return results immediately upon preflight request
         if parts.method == Method::OPTIONS {

--- a/tower-http/src/cors/mod.rs
+++ b/tower-http/src/cors/mod.rs
@@ -681,6 +681,13 @@ where
         match self.project().inner.project() {
             KindProj::CorsCall { future, headers } => {
                 let mut response: Response<B> = ready!(future.poll(cx))?;
+
+                // vary header can have multiple values, don't overwrite
+                // previously-set value(s).
+                if let Some(vary) = headers.remove(header::VARY) {
+                    headers.append(header::VARY, vary);
+                }
+                // extend will overwrite previous headers of remaining names
                 response.headers_mut().extend(headers.drain());
 
                 Poll::Ready(Ok(response))

--- a/tower-http/src/cors/tests.rs
+++ b/tower-http/src/cors/tests.rs
@@ -1,0 +1,33 @@
+use std::convert::Infallible;
+
+use http::{header, HeaderValue, Request, Response};
+use hyper::Body;
+use tower::{service_fn, util::ServiceExt, Layer};
+
+use crate::cors::CorsLayer;
+
+#[tokio::test]
+#[allow(
+    clippy::declare_interior_mutable_const,
+    clippy::borrow_interior_mutable_const
+)]
+async fn vary_set_by_inner_service() {
+    const CUSTOM_VARY_HEADERS: HeaderValue = HeaderValue::from_static("accept, accept-encoding");
+    const PERMISSIVE_CORS_VARY_HEADERS: HeaderValue = HeaderValue::from_static(
+        "origin, access-control-request-method, access-control-request-headers",
+    );
+
+    async fn inner_svc(_: Request<Body>) -> Result<Response<Body>, Infallible> {
+        Ok(Response::builder()
+            .header(header::VARY, CUSTOM_VARY_HEADERS)
+            .body(Body::empty())
+            .unwrap())
+    }
+
+    let svc = CorsLayer::permissive().layer(service_fn(inner_svc));
+    let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
+    let mut vary_headers = res.headers().get_all(header::VARY).into_iter();
+    assert_eq!(vary_headers.next(), Some(&CUSTOM_VARY_HEADERS));
+    assert_eq!(vary_headers.next(), Some(&PERMISSIVE_CORS_VARY_HEADERS));
+    assert_eq!(vary_headers.next(), None);
+}

--- a/tower-http/src/cors/vary.rs
+++ b/tower-http/src/cors/vary.rs
@@ -1,6 +1,6 @@
 use std::array;
 
-use http::{header::HeaderName, HeaderValue};
+use http::header::{self, HeaderName, HeaderValue};
 
 use super::preflight_request_headers;
 
@@ -26,8 +26,17 @@ impl Vary {
         Self(headers.into_iter().map(Into::into).collect())
     }
 
-    pub(super) fn values(&self) -> impl Iterator<Item = HeaderValue> + '_ {
-        self.0.iter().cloned()
+    pub(super) fn to_header(&self) -> Option<(HeaderName, HeaderValue)> {
+        let values = &self.0;
+        let mut res = values.get(0)?.as_bytes().to_owned();
+        for val in &values[1..] {
+            res.extend_from_slice(b", ");
+            res.extend_from_slice(val.as_bytes());
+        }
+
+        let header_val = HeaderValue::from_bytes(&res)
+            .expect("comma-separated list of HeaderValues is always a valid HeaderValue");
+        Some((header::VARY, header_val))
     }
 }
 


### PR DESCRIPTION
## Motivation

Fixes #397.

## Solution

For GET requests where we call an inner service and compute headers for it (as opposed to assembling the whole response to be sent to the client), append those computed headers instead of overwriting existing headers set by the inner service.

@AlyoshaVasilieva: can you confirm that two `vary` headers in the response are okay for this case? With the first commit of this PR, we will no longer create multiple `vary` headers in the middleware, but with the second commit we will just keep all existing headers from the inner service so the end result in your example will be

```
< vary: accept, accept-encoding
< vary: origin, access-control-request-method, access-control-request-headers
```