### PR TITLE
Vary header in compression

### DIFF
--- a/tower-http/src/compression/future.rs
+++ b/tower-http/src/compression/future.rs
@@ -46,6 +46,12 @@ where
 
         let (mut parts, body) = res.into_parts();
 
+        if should_compress {
+            parts
+                .headers
+                .append(header::VARY, header::ACCEPT_ENCODING.into());
+        }
+
         let body = match (should_compress, self.encoding) {
             // if compression is _not_ support or the client doesn't accept it
             (false, _) | (_, Encoding::Identity) => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

From [the "Compression in HTTP" MDN page](https://developer.mozilla.org/en-US/docs/Web/HTTP/Compression#end-to-end_compression):
> As content negotiation has been used to choose a representation based on its encoding, the server must send a [Vary](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary) header containing at least [Accept-Encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding) alongside this header in the response; that way, caches will be able to cache the different representations of the resource.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

We just append `Accept-Encoding` to the `Vary` header when constructing the compression response.