### PR TITLE
enable clippy for tower-http and fix current issues

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,7 +94,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -90,6 +90,20 @@ jobs:
         components: rustfmt
     - run: cargo fmt --all --check
 
+  clippy:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
+    - name: Install protoc
+      uses: taiki-e/install-action@v2
+      with:
+        tool: protoc@3.20.3
+    - run: cargo clippy --workspace --all-features --all-targets
+
   deny-check:
     name: cargo-deny check
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,7 +102,7 @@ jobs:
       uses: taiki-e/install-action@v2
       with:
         tool: protoc@3.20.3
-    - run: cargo clippy --workspace --all-features --all-targets
+    - run: cargo clippy --workspace --all-features --lib --bins --examples -- -D warnings
 
   deny-check:
     name: cargo-deny check

--- a/tower-http/src/compression/mod.rs
+++ b/tower-http/src/compression/mod.rs
@@ -308,7 +308,7 @@ mod tests {
                 let mut guard = self.0.write().unwrap();
                 let should_compress = *guard % 2 != 0;
                 *guard += 1;
-                dbg!(should_compress)
+                should_compress
             }
         }
 


### PR DESCRIPTION
## Motivation

I maintain a fork of `tower`, including also `tower-http` in <https://github.com/plabayo/tower-async>.
Only now did I notice that tower-http does not yet enable clippy.

Nothing bad was spotted by enabling it, but still,
seems by now that the Rust community agrees that enabling clippy everywhere is useful?
So as such, here my first contribution upstream.

## Solution

N/A