### PR TITLE
Bump MSRV to 1.63

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@1.60.0
+    - uses: dtolnay/rust-toolchain@1.63
     - name: Install protoc
       uses: taiki-e/install-action@v2
       with:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The [examples] folder contains various examples of how to use Tower HTTP:
 
 ## Minimum supported Rust version
 
-tower-http's MSRV is 1.60.
+tower-http's MSRV is 1.63.
 
 ## Getting Help
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- None.
+- Bump Minimum Supported Rust Version to 1.63 ([#418])
 
 ## Removed
 
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Accepts range headers with ranges where the end of range goes past the end of the document by bumping 
 http-range-header to `0.4`
+
+[#418]: https://github.com/tower-rs/tower-http/pull/418
 
 # 0.4.2 (July 19, 2023)
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/tower-rs/tower-http"
 homepage = "https://github.com/tower-rs/tower-http"
 categories = ["asynchronous", "network-programming", "web-programming"]
 keywords = ["io", "async", "futures", "service", "http"]
-rust-version = "1.60"
+rust-version = "1.63"
 
 [dependencies]
 bitflags = "2.0.2"


### PR DESCRIPTION
## Motivation

Multiple dependencies have raised their MSRV to the same.

## Solution

Raise MSRV too, much easier to update CI to check MSRV with lower dependency versions. 1.63 is old enough by now.