### PR TITLE
Do not leak directory info if append_index_html_on_directories = false

### DIFF
--- a/tower-http/src/services/fs/serve_dir/open_file.rs
+++ b/tower-http/src/services/fs/serve_dir/open_file.rs
@@ -257,9 +257,13 @@ async fn maybe_redirect_or_append_path(
 ) -> Option<OpenFileOutput> {
     if !uri.path().ends_with('/') {
         if is_dir(path_to_file).await {
-            let location =
-                HeaderValue::from_str(&append_slash_on_path(uri.clone()).to_string()).unwrap();
-            Some(OpenFileOutput::Redirect { location })
+            if append_index_html_on_directories {
+                let location =
+                    HeaderValue::from_str(&append_slash_on_path(uri.clone()).to_string()).unwrap();
+                Some(OpenFileOutput::Redirect { location })
+            } else {
+                Some(OpenFileOutput::FileNotFound)
+            }
         } else {
             None
         }

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -399,6 +399,23 @@ async fn empty_directory_without_index() {
     assert!(body.is_empty());
 }
 
+#[tokio::test]
+async fn empty_directory_without_index_no_information_leak() {
+    let svc = ServeDir::new("..").append_index_html_on_directories(false);
+
+    let req = Request::builder()
+        .uri("/test-files")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    assert!(res.headers().get(header::CONTENT_TYPE).is_none());
+
+    let body = body_into_text(res.into_body()).await;
+    assert!(body.is_empty());
+}
+
 async fn body_into_text<B>(body: B) -> String
 where
     B: HttpBody<Data = bytes::Bytes> + Unpin,


### PR DESCRIPTION
## Motivation

Currently it is possible to gain information about directories even if `append_index_html_on_directories = false`.

This is caused by the mechanism to redirect to trailing slash for directories (like testcase `redirect_to_trailing_slash_on_dir()`).

This way, an attacker could search for directories by testing URLs without trailing slash and then could continue the
search within such a subdirectory using the same mechanism.

## Solution

This pull request prevents the redirect and directly returns `404 Not Found` if `append_index_html_on_directories = false`.
