### PR TITLE
refactor!: include grpc error message in tracing

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -104,7 +104,7 @@ sensitive-headers = []
 set-header = []
 set-status = []
 timeout = ["dep:http-body", "dep:tokio", "tokio?/time"]
-trace = ["dep:http-body", "tracing"]
+trace = ["dep:http-body", "percent-encoding", "tracing"]
 util = ["tower"]
 validate-request = ["mime"]
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -30,7 +30,7 @@ http-body-util = { version = "0.1.0", optional = true }
 http-range-header = { version = "0.4.0", optional = true }
 mime = { version = "0.3.17", optional = true, default-features = false }
 mime_guess = { version = "2", optional = true, default-features = false }
-percent-encoding = { version = "2.1.0", optional = true }
+percent-encoding = { version = "2.1.0" }
 url = { version = "2.5", optional = true }
 tokio = { version = "1.6", optional = true, default-features = false }
 tokio-util = { version = "0.7", optional = true, default-features = false, features = ["io"] }
@@ -90,7 +90,7 @@ auth = ["base64", "validate-request"]
 catch-panic = ["tracing", "futures-util/std", "dep:http-body", "dep:http-body-util"]
 cors = []
 follow-redirect = ["futures-util", "dep:http-body", "dep:url", "tower/util"]
-fs = ["dep:tokio", "tokio?/fs", "tokio?/io-util", "futures-core", "futures-util", "dep:http-body", "dep:http-body-util", "tokio-util/io", "dep:http-range-header", "mime_guess", "mime", "percent-encoding", "httpdate", "set-status", "futures-util/alloc"]
+fs = ["dep:tokio", "tokio?/fs", "tokio?/io-util", "futures-core", "futures-util", "dep:http-body", "dep:http-body-util", "tokio-util/io", "dep:http-range-header", "mime_guess", "mime", "httpdate", "set-status", "futures-util/alloc"]
 limit = ["dep:http-body", "dep:http-body-util"]
 map-request-body = []
 map-response-body = []
@@ -104,7 +104,7 @@ sensitive-headers = []
 set-header = []
 set-status = []
 timeout = ["dep:http-body", "dep:tokio", "tokio?/time"]
-trace = ["dep:http-body", "percent-encoding", "tracing"]
+trace = ["dep:http-body", "tracing"]
 util = ["tower"]
 validate-request = ["mime"]
 

--- a/tower-http/src/classify/grpc_errors_as_failures.rs
+++ b/tower-http/src/classify/grpc_errors_as_failures.rs
@@ -1,8 +1,9 @@
 use super::{ClassifiedResponse, ClassifyEos, ClassifyResponse, SharedClassifier};
 use bitflags::bitflags;
 use http::{HeaderMap, Response};
+#[cfg(feature = "trace")]
 use percent_encoding::percent_decode;
-use std::fmt;
+use std::{fmt, num::NonZeroI32};
 
 /// gRPC status codes.
 ///
@@ -10,6 +11,8 @@ use std::fmt;
 ///
 /// [gRPC status codes]: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md#status-codes-and-their-use-in-grpc
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i32)]
+#[non_exhaustive]
 pub enum GrpcCode {
     /// The operation completed successfully.
     Ok = 0,
@@ -70,31 +73,25 @@ impl GrpcCode {
         }
     }
 
-    fn from_bytes(bytes: &[u8]) -> Option<GrpcCode> {
-        match bytes.len() {
-            1 => match bytes[0] {
-                b'0' => Some(GrpcCode::Ok),
-                b'1' => Some(GrpcCode::Cancelled),
-                b'2' => Some(GrpcCode::Unknown),
-                b'3' => Some(GrpcCode::InvalidArgument),
-                b'4' => Some(GrpcCode::DeadlineExceeded),
-                b'5' => Some(GrpcCode::NotFound),
-                b'6' => Some(GrpcCode::AlreadyExists),
-                b'7' => Some(GrpcCode::PermissionDenied),
-                b'8' => Some(GrpcCode::ResourceExhausted),
-                b'9' => Some(GrpcCode::FailedPrecondition),
-                _ => None,
-            },
-            2 => match (bytes[0], bytes[1]) {
-                (b'1', b'0') => Some(GrpcCode::Aborted),
-                (b'1', b'1') => Some(GrpcCode::OutOfRange),
-                (b'1', b'2') => Some(GrpcCode::Unimplemented),
-                (b'1', b'3') => Some(GrpcCode::Internal),
-                (b'1', b'4') => Some(GrpcCode::Unavailable),
-                (b'1', b'5') => Some(GrpcCode::DataLoss),
-                (b'1', b'6') => Some(GrpcCode::Unauthenticated),
-                _ => None,
-            },
+    fn from_i32(code: i32) -> Option<GrpcCode> {
+        match code {
+            0 => Some(GrpcCode::Ok),
+            1 => Some(GrpcCode::Cancelled),
+            2 => Some(GrpcCode::Unknown),
+            3 => Some(GrpcCode::InvalidArgument),
+            4 => Some(GrpcCode::DeadlineExceeded),
+            5 => Some(GrpcCode::NotFound),
+            6 => Some(GrpcCode::AlreadyExists),
+            7 => Some(GrpcCode::PermissionDenied),
+            8 => Some(GrpcCode::ResourceExhausted),
+            9 => Some(GrpcCode::FailedPrecondition),
+            10 => Some(GrpcCode::Aborted),
+            11 => Some(GrpcCode::OutOfRange),
+            12 => Some(GrpcCode::Unimplemented),
+            13 => Some(GrpcCode::Internal),
+            14 => Some(GrpcCode::Unavailable),
+            15 => Some(GrpcCode::DataLoss),
+            16 => Some(GrpcCode::Unauthenticated),
             _ => None,
         }
     }
@@ -308,6 +305,7 @@ impl ClassifyEos for GrpcEosErrorsAsFailures {
 
 /// The failure class for [`GrpcErrorsAsFailures`].
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum GrpcFailureClass {
     /// A gRPC response was classified as a failure with the corresponding status.
     Status(GrpcStatus),
@@ -326,6 +324,8 @@ impl fmt::Display for GrpcFailureClass {
     }
 }
 
+impl std::error::Error for GrpcFailureClass {}
+
 pub(crate) fn classify_grpc_metadata(
     headers: &HeaderMap,
     success_codes: GrpcCodeBitmask,
@@ -340,39 +340,68 @@ pub(crate) fn classify_grpc_metadata(
         };
     }
 
-    let code = or_else!(headers.get("grpc-status"), GrpcStatusHeaderMissing);
-    let code = or_else!(GrpcCode::from_bytes(code.as_ref()), HeaderNotGrpcCode);
+    let code_header = or_else!(headers.get("grpc-status"), GrpcStatusHeaderMissing);
+    let code_value: i32 = or_else!(
+        code_header.to_str().ok().and_then(|s| s.parse().ok()),
+        HeaderNotGrpcCode
+    );
+    let grpc_code = GrpcCode::from_i32(code_value);
 
-    if success_codes.contains(GrpcCodeBitmask::from(code)) {
-        ParsedGrpcStatus::Success
-    } else {
-        ParsedGrpcStatus::NonSuccess(GrpcStatus {
-            code,
-            message: headers.get("grpc-message").and_then(|header| {
-                percent_decode(header.as_bytes())
-                    .decode_utf8()
-                    .map(|cow| cow.to_string())
-                    .ok()
-            }),
-        })
+    if let Some(code) = grpc_code {
+        if success_codes.contains(GrpcCodeBitmask::from(code)) {
+            return ParsedGrpcStatus::Success;
+        }
     }
+
+    #[cfg(feature = "trace")]
+    let message = headers.get("grpc-message").map(|header| {
+        percent_decode(header.as_bytes())
+            .decode_utf8_lossy()
+            .into_owned()
+    });
+    #[cfg(not(feature = "trace"))]
+    let message = headers
+        .get("grpc-message")
+        .and_then(|header| header.to_str().ok().map(|s| s.to_owned()));
+
+    ParsedGrpcStatus::NonSuccess(GrpcStatus {
+        code: grpc_code,
+        code_raw: code_value,
+        message,
+    })
 }
 
+/// A gRPC status extracted from response headers/trailers.
 #[derive(Debug, PartialEq, Eq)]
 pub struct GrpcStatus {
-    code: GrpcCode,
+    code: Option<GrpcCode>,
+    code_raw: i32,
     message: Option<String>,
 }
 
 impl GrpcStatus {
-    pub(crate) fn code(&self) -> GrpcCode {
+    /// Returns the status code as a [`GrpcCode`], or `None` if the code is not recognized.
+    pub fn code(&self) -> Option<GrpcCode> {
         self.code
+    }
+
+    /// Returns the raw integer status code.
+    pub fn code_raw(&self) -> i32 {
+        self.code_raw
+    }
+
+    /// Returns the percent-decoded gRPC error message, if present.
+    pub fn message(&self) -> Option<&str> {
+        self.message.as_deref()
     }
 }
 
 impl fmt::Display for GrpcStatus {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self.code)?;
+        match self.code {
+            Some(code) => write!(f, "{:?}", code)?,
+            None => write!(f, "Code({})", self.code_raw)?,
+        }
         if let Some(message) = self.message.as_ref() {
             write!(f, ": {}", message)?;
         }
@@ -440,7 +469,8 @@ mod tests {
         status: "1",
         success_flags: GrpcCodeBitmask::OK,
         expected: ParsedGrpcStatus::NonSuccess(GrpcStatus{
-            code: GrpcCode::Cancelled,
+            code: Some(GrpcCode::Cancelled),
+            code_raw: 1,
             message: None,
         }),
     }
@@ -465,9 +495,75 @@ mod tests {
         message: "mock message",
         success_flags: GrpcCodeBitmask::OK | GrpcCodeBitmask::INVALID_ARGUMENT,
         expected: ParsedGrpcStatus::NonSuccess(GrpcStatus{
-            code: GrpcCode::Unauthenticated,
+            code: Some(GrpcCode::Unauthenticated),
+            code_raw: 16,
             message: Some("mock message".to_string()),
         }),
+    }
+
+    classify_grpc_metadata_test! {
+        name: percent_encoded_message,
+        status: "2",
+        message: "hello%20world",
+        success_flags: GrpcCodeBitmask::OK,
+        expected: ParsedGrpcStatus::NonSuccess(GrpcStatus{
+            code: Some(GrpcCode::Unknown),
+            code_raw: 2,
+            message: Some("hello world".to_string()),
+        }),
+    }
+
+    classify_grpc_metadata_test! {
+        name: invalid_percent_encoding,
+        status: "13",
+        message: "bad%2Gencode",
+        success_flags: GrpcCodeBitmask::OK,
+        expected: ParsedGrpcStatus::NonSuccess(GrpcStatus{
+            code: Some(GrpcCode::Internal),
+            code_raw: 13,
+            message: Some("bad%2Gencode".to_string()),
+        }),
+    }
+
+    classify_grpc_metadata_test! {
+        name: empty_grpc_message,
+        status: "5",
+        message: "",
+        success_flags: GrpcCodeBitmask::OK,
+        expected: ParsedGrpcStatus::NonSuccess(GrpcStatus{
+            code: Some(GrpcCode::NotFound),
+            code_raw: 5,
+            message: None,
+        }),
+    }
+
+    classify_grpc_metadata_test! {
+        name: unknown_status_code_above_16,
+        status: "99",
+        message: "custom error",
+        success_flags: GrpcCodeBitmask::OK,
+        expected: ParsedGrpcStatus::NonSuccess(GrpcStatus{
+            code: None,
+            code_raw: 99,
+            message: Some("custom error".to_string()),
+        }),
+    }
+
+    #[test]
+    fn invalid_utf8_after_percent_decode() {
+        let mut headers = HeaderMap::new();
+        headers.insert("grpc-status", "2".parse().unwrap());
+        // %80 is an invalid UTF-8 start byte; lossy decode replaces it with U+FFFD
+        headers.insert("grpc-message", "bad%80byte".parse().unwrap());
+        let status = classify_grpc_metadata(&headers, GrpcCodeBitmask::OK);
+        assert_eq!(
+            status,
+            ParsedGrpcStatus::NonSuccess(GrpcStatus {
+                code: Some(GrpcCode::Unknown),
+                code_raw: 2,
+                message: Some("bad\u{FFFD}byte".to_string()),
+            })
+        );
     }
 
     #[test]

--- a/tower-http/src/classify/grpc_errors_as_failures.rs
+++ b/tower-http/src/classify/grpc_errors_as_failures.rs
@@ -1,7 +1,6 @@
 use super::{ClassifiedResponse, ClassifyEos, ClassifyResponse, SharedClassifier};
 use bitflags::bitflags;
 use http::{HeaderMap, Response};
-#[cfg(feature = "trace")]
 use percent_encoding::percent_decode;
 use std::{fmt, num::NonZeroI32};
 
@@ -353,16 +352,11 @@ pub(crate) fn classify_grpc_metadata(
         }
     }
 
-    #[cfg(feature = "trace")]
     let message = headers.get("grpc-message").map(|header| {
         percent_decode(header.as_bytes())
             .decode_utf8_lossy()
             .into_owned()
     });
-    #[cfg(not(feature = "trace"))]
-    let message = headers
-        .get("grpc-message")
-        .and_then(|header| header.to_str().ok().map(|s| s.to_owned()));
 
     ParsedGrpcStatus::NonSuccess(GrpcStatus {
         code: grpc_code,
@@ -564,6 +558,37 @@ mod tests {
                 message: Some("bad\u{FFFD}byte".to_string()),
             })
         );
+    }
+
+    #[test]
+    fn valid_utf8_percent_encoded() {
+        let mut headers = HeaderMap::new();
+        headers.insert("grpc-status", "3".parse().unwrap());
+        // %C3%A9 is the percent-encoded form of 'é' (U+00E9) in UTF-8
+        headers.insert("grpc-message", "caf%C3%A9".parse().unwrap());
+        let status = classify_grpc_metadata(&headers, GrpcCodeBitmask::OK);
+        assert_eq!(
+            status,
+            ParsedGrpcStatus::NonSuccess(GrpcStatus {
+                code: Some(GrpcCode::InvalidArgument),
+                code_raw: 3,
+                message: Some("café".to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn grpc_ok_classified_as_success() {
+        use http::Response;
+
+        let res = Response::builder()
+            .header("grpc-status", "0")
+            .body(())
+            .unwrap();
+
+        let classifier = GrpcErrorsAsFailures::new();
+        let result = classifier.classify_response(&res);
+        assert!(matches!(result, ClassifiedResponse::Ready(Ok(()))));
     }
 
     #[test]

--- a/tower-http/src/classify/grpc_errors_as_failures.rs
+++ b/tower-http/src/classify/grpc_errors_as_failures.rs
@@ -1,49 +1,50 @@
 use super::{ClassifiedResponse, ClassifyEos, ClassifyResponse, SharedClassifier};
 use bitflags::bitflags;
 use http::{HeaderMap, Response};
-use std::{fmt, num::NonZeroI32};
+use percent_encoding::percent_decode;
+use std::fmt;
 
 /// gRPC status codes.
 ///
 /// These variants match the [gRPC status codes].
 ///
 /// [gRPC status codes]: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md#status-codes-and-their-use-in-grpc
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum GrpcCode {
     /// The operation completed successfully.
-    Ok,
+    Ok = 0,
     /// The operation was cancelled.
-    Cancelled,
+    Cancelled = 1,
     /// Unknown error.
-    Unknown,
+    Unknown = 2,
     /// Client specified an invalid argument.
-    InvalidArgument,
+    InvalidArgument = 3,
     /// Deadline expired before operation could complete.
-    DeadlineExceeded,
+    DeadlineExceeded = 4,
     /// Some requested entity was not found.
-    NotFound,
+    NotFound = 5,
     /// Some entity that we attempted to create already exists.
-    AlreadyExists,
+    AlreadyExists = 6,
     /// The caller does not have permission to execute the specified operation.
-    PermissionDenied,
+    PermissionDenied = 7,
     /// Some resource has been exhausted.
-    ResourceExhausted,
+    ResourceExhausted = 8,
     /// The system is not in a state required for the operation's execution.
-    FailedPrecondition,
+    FailedPrecondition = 9,
     /// The operation was aborted.
-    Aborted,
+    Aborted = 10,
     /// Operation was attempted past the valid range.
-    OutOfRange,
+    OutOfRange = 11,
     /// Operation is not implemented or not supported.
-    Unimplemented,
+    Unimplemented = 12,
     /// Internal error.
-    Internal,
+    Internal = 13,
     /// The service is currently unavailable.
-    Unavailable,
+    Unavailable = 14,
     /// Unrecoverable data loss or corruption.
-    DataLoss,
+    DataLoss = 15,
     /// The request does not have valid authentication credentials
-    Unauthenticated,
+    Unauthenticated = 16,
 }
 
 impl GrpcCode {
@@ -66,6 +67,35 @@ impl GrpcCode {
             Self::Unavailable => GrpcCodeBitmask::UNAVAILABLE,
             Self::DataLoss => GrpcCodeBitmask::DATA_LOSS,
             Self::Unauthenticated => GrpcCodeBitmask::UNAUTHENTICATED,
+        }
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<GrpcCode> {
+        match bytes.len() {
+            1 => match bytes[0] {
+                b'0' => Some(GrpcCode::Ok),
+                b'1' => Some(GrpcCode::Cancelled),
+                b'2' => Some(GrpcCode::Unknown),
+                b'3' => Some(GrpcCode::InvalidArgument),
+                b'4' => Some(GrpcCode::DeadlineExceeded),
+                b'5' => Some(GrpcCode::NotFound),
+                b'6' => Some(GrpcCode::AlreadyExists),
+                b'7' => Some(GrpcCode::PermissionDenied),
+                b'8' => Some(GrpcCode::ResourceExhausted),
+                b'9' => Some(GrpcCode::FailedPrecondition),
+                _ => None,
+            },
+            2 => match (bytes[0], bytes[1]) {
+                (b'1', b'0') => Some(GrpcCode::Aborted),
+                (b'1', b'1') => Some(GrpcCode::OutOfRange),
+                (b'1', b'2') => Some(GrpcCode::Unimplemented),
+                (b'1', b'3') => Some(GrpcCode::Internal),
+                (b'1', b'4') => Some(GrpcCode::Unavailable),
+                (b'1', b'5') => Some(GrpcCode::DataLoss),
+                (b'1', b'6') => Some(GrpcCode::Unauthenticated),
+                _ => None,
+            },
+            _ => None,
         }
     }
 }
@@ -128,27 +158,26 @@ bitflags! {
     }
 }
 
-impl GrpcCodeBitmask {
-    fn try_from_u32(code: u32) -> Option<Self> {
+impl From<GrpcCode> for GrpcCodeBitmask {
+    fn from(code: GrpcCode) -> Self {
         match code {
-            0 => Some(Self::OK),
-            1 => Some(Self::CANCELLED),
-            2 => Some(Self::UNKNOWN),
-            3 => Some(Self::INVALID_ARGUMENT),
-            4 => Some(Self::DEADLINE_EXCEEDED),
-            5 => Some(Self::NOT_FOUND),
-            6 => Some(Self::ALREADY_EXISTS),
-            7 => Some(Self::PERMISSION_DENIED),
-            8 => Some(Self::RESOURCE_EXHAUSTED),
-            9 => Some(Self::FAILED_PRECONDITION),
-            10 => Some(Self::ABORTED),
-            11 => Some(Self::OUT_OF_RANGE),
-            12 => Some(Self::UNIMPLEMENTED),
-            13 => Some(Self::INTERNAL),
-            14 => Some(Self::UNAVAILABLE),
-            15 => Some(Self::DATA_LOSS),
-            16 => Some(Self::UNAUTHENTICATED),
-            _ => None,
+            GrpcCode::Ok => GrpcCodeBitmask::OK,
+            GrpcCode::Cancelled => GrpcCodeBitmask::CANCELLED,
+            GrpcCode::Unknown => GrpcCodeBitmask::UNKNOWN,
+            GrpcCode::InvalidArgument => GrpcCodeBitmask::INVALID_ARGUMENT,
+            GrpcCode::DeadlineExceeded => GrpcCodeBitmask::DEADLINE_EXCEEDED,
+            GrpcCode::NotFound => GrpcCodeBitmask::NOT_FOUND,
+            GrpcCode::AlreadyExists => GrpcCodeBitmask::ALREADY_EXISTS,
+            GrpcCode::PermissionDenied => GrpcCodeBitmask::PERMISSION_DENIED,
+            GrpcCode::ResourceExhausted => GrpcCodeBitmask::RESOURCE_EXHAUSTED,
+            GrpcCode::FailedPrecondition => GrpcCodeBitmask::FAILED_PRECONDITION,
+            GrpcCode::Aborted => GrpcCodeBitmask::ABORTED,
+            GrpcCode::OutOfRange => GrpcCodeBitmask::OUT_OF_RANGE,
+            GrpcCode::Unimplemented => GrpcCodeBitmask::UNIMPLEMENTED,
+            GrpcCode::Internal => GrpcCodeBitmask::INTERNAL,
+            GrpcCode::Unavailable => GrpcCodeBitmask::UNAVAILABLE,
+            GrpcCode::DataLoss => GrpcCodeBitmask::DATA_LOSS,
+            GrpcCode::Unauthenticated => GrpcCodeBitmask::UNAUTHENTICATED,
         }
     }
 }
@@ -225,11 +254,11 @@ impl ClassifyResponse for GrpcErrorsAsFailures {
         res: &Response<B>,
     ) -> ClassifiedResponse<Self::FailureClass, Self::ClassifyEos> {
         match classify_grpc_metadata(res.headers(), self.success_codes) {
-            ParsedGrpcStatus::Success
-            | ParsedGrpcStatus::HeaderNotString
-            | ParsedGrpcStatus::HeaderNotInt => ClassifiedResponse::Ready(Ok(())),
+            ParsedGrpcStatus::Success | ParsedGrpcStatus::HeaderNotGrpcCode => {
+                ClassifiedResponse::Ready(Ok(()))
+            }
             ParsedGrpcStatus::NonSuccess(status) => {
-                ClassifiedResponse::Ready(Err(GrpcFailureClass::Code(status)))
+                ClassifiedResponse::Ready(Err(GrpcFailureClass::Status(status)))
             }
             ParsedGrpcStatus::GrpcStatusHeaderMissing => {
                 ClassifiedResponse::RequiresEos(GrpcEosErrorsAsFailures {
@@ -261,9 +290,8 @@ impl ClassifyEos for GrpcEosErrorsAsFailures {
             match classify_grpc_metadata(trailers, self.success_codes) {
                 ParsedGrpcStatus::Success
                 | ParsedGrpcStatus::GrpcStatusHeaderMissing
-                | ParsedGrpcStatus::HeaderNotString
-                | ParsedGrpcStatus::HeaderNotInt => Ok(()),
-                ParsedGrpcStatus::NonSuccess(status) => Err(GrpcFailureClass::Code(status)),
+                | ParsedGrpcStatus::HeaderNotGrpcCode => Ok(()),
+                ParsedGrpcStatus::NonSuccess(status) => Err(GrpcFailureClass::Status(status)),
             }
         } else {
             Ok(())
@@ -282,7 +310,7 @@ impl ClassifyEos for GrpcEosErrorsAsFailures {
 #[derive(Debug)]
 pub enum GrpcFailureClass {
     /// A gRPC response was classified as a failure with the corresponding status.
-    Code(std::num::NonZeroI32),
+    Status(GrpcStatus),
     /// A gRPC response was classified as an error with the corresponding error description.
     Error(String),
 }
@@ -290,7 +318,9 @@ pub enum GrpcFailureClass {
 impl fmt::Display for GrpcFailureClass {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Code(code) => write!(f, "Code: {}", code),
+            Self::Status(status) => {
+                write!(f, "Status: {}", status)
+            }
             Self::Error(error) => write!(f, "Error: {}", error),
         }
     }
@@ -310,28 +340,53 @@ pub(crate) fn classify_grpc_metadata(
         };
     }
 
-    let status = or_else!(headers.get("grpc-status"), GrpcStatusHeaderMissing);
-    let status = or_else!(status.to_str().ok(), HeaderNotString);
-    let status = or_else!(status.parse::<i32>().ok(), HeaderNotInt);
+    let code = or_else!(headers.get("grpc-status"), GrpcStatusHeaderMissing);
+    let code = or_else!(GrpcCode::from_bytes(code.as_ref()), HeaderNotGrpcCode);
 
-    if GrpcCodeBitmask::try_from_u32(status as _)
-        .filter(|code| success_codes.contains(*code))
-        .is_some()
-    {
+    if success_codes.contains(GrpcCodeBitmask::from(code)) {
         ParsedGrpcStatus::Success
     } else {
-        ParsedGrpcStatus::NonSuccess(NonZeroI32::new(status).unwrap())
+        ParsedGrpcStatus::NonSuccess(GrpcStatus {
+            code,
+            message: headers.get("grpc-message").and_then(|header| {
+                percent_decode(header.as_bytes())
+                    .decode_utf8()
+                    .map(|cow| cow.to_string())
+                    .ok()
+            }),
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct GrpcStatus {
+    code: GrpcCode,
+    message: Option<String>,
+}
+
+impl GrpcStatus {
+    pub(crate) fn code(&self) -> GrpcCode {
+        self.code
+    }
+}
+
+impl fmt::Display for GrpcStatus {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.code)?;
+        if let Some(message) = self.message.as_ref() {
+            write!(f, ": {}", message)?;
+        }
+        Ok(())
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum ParsedGrpcStatus {
     Success,
-    NonSuccess(NonZeroI32),
+    NonSuccess(GrpcStatus),
     GrpcStatusHeaderMissing,
-    // these two are treated as `Success` but kept separate for clarity
-    HeaderNotString,
-    HeaderNotInt,
+    // this is treated as `Success` but kept separate for clarity
+    HeaderNotGrpcCode,
 }
 
 #[cfg(test)]
@@ -345,10 +400,28 @@ mod tests {
             success_flags: $success_flags:expr,
             expected: $expected:expr,
         ) => {
+            classify_grpc_metadata_test!(
+                name: $name,
+                status: $status,
+                message: "",
+                success_flags: $success_flags,
+                expected: $expected,
+            );
+        };
+        (
+            name: $name:ident,
+            status: $status:expr,
+            message: $message:expr,
+            success_flags: $success_flags:expr,
+            expected: $expected:expr,
+        ) => {
             #[test]
             fn $name() {
                 let mut headers = HeaderMap::new();
                 headers.insert("grpc-status", $status.parse().unwrap());
+                if !$message.is_empty() {
+                    headers.insert("grpc-message", $message.parse().unwrap());
+                }
                 let status = classify_grpc_metadata(&headers, $success_flags);
                 assert_eq!(status, $expected);
             }
@@ -366,7 +439,10 @@ mod tests {
         name: basic_error,
         status: "1",
         success_flags: GrpcCodeBitmask::OK,
-        expected: ParsedGrpcStatus::NonSuccess(NonZeroI32::new(1).unwrap()),
+        expected: ParsedGrpcStatus::NonSuccess(GrpcStatus{
+            code: GrpcCode::Cancelled,
+            message: None,
+        }),
     }
 
     classify_grpc_metadata_test! {
@@ -386,8 +462,12 @@ mod tests {
     classify_grpc_metadata_test! {
         name: two_success_codes_none_matches,
         status: "16",
+        message: "mock message",
         success_flags: GrpcCodeBitmask::OK | GrpcCodeBitmask::INVALID_ARGUMENT,
-        expected: ParsedGrpcStatus::NonSuccess(NonZeroI32::new(16).unwrap()),
+        expected: ParsedGrpcStatus::NonSuccess(GrpcStatus{
+            code: GrpcCode::Unauthenticated,
+            message: Some("mock message".to_string()),
+        }),
     }
 
     #[test]

--- a/tower-http/src/classify/mod.rs
+++ b/tower-http/src/classify/mod.rs
@@ -9,7 +9,7 @@ mod status_in_range_is_error;
 
 pub use self::{
     grpc_errors_as_failures::{
-        GrpcCode, GrpcEosErrorsAsFailures, GrpcErrorsAsFailures, GrpcFailureClass,
+        GrpcCode, GrpcEosErrorsAsFailures, GrpcErrorsAsFailures, GrpcFailureClass, GrpcStatus,
     },
     map_failure_class::MapFailureClass,
     status_in_range_is_error::{StatusInRangeAsFailures, StatusInRangeFailureClass},

--- a/tower-http/src/trace/on_eos.rs
+++ b/tower-http/src/trace/on_eos.rs
@@ -94,10 +94,8 @@ impl OnEos for DefaultOnEos {
                 trailers,
                 crate::classify::GrpcCode::Ok.into_bitmask(),
             ) {
-                ParsedGrpcStatus::Success
-                | ParsedGrpcStatus::HeaderNotString
-                | ParsedGrpcStatus::HeaderNotInt => Some(0),
-                ParsedGrpcStatus::NonSuccess(status) => Some(status.get()),
+                ParsedGrpcStatus::Success | ParsedGrpcStatus::HeaderNotGrpcCode => Some(0),
+                ParsedGrpcStatus::NonSuccess(status) => Some(status.code() as i32),
                 ParsedGrpcStatus::GrpcStatusHeaderMissing => None,
             }
         });

--- a/tower-http/src/trace/on_eos.rs
+++ b/tower-http/src/trace/on_eos.rs
@@ -95,7 +95,7 @@ impl OnEos for DefaultOnEos {
                 crate::classify::GrpcCode::Ok.into_bitmask(),
             ) {
                 ParsedGrpcStatus::Success | ParsedGrpcStatus::HeaderNotGrpcCode => Some(0),
-                ParsedGrpcStatus::NonSuccess(status) => Some(status.code() as i32),
+                ParsedGrpcStatus::NonSuccess(status) => Some(status.code_raw()),
                 ParsedGrpcStatus::GrpcStatusHeaderMissing => None,
             }
         });

--- a/tower-http/src/trace/on_response.rs
+++ b/tower-http/src/trace/on_response.rs
@@ -147,10 +147,8 @@ fn status<B>(res: &Response<B>) -> Option<i32> {
             res.headers(),
             crate::classify::GrpcCode::Ok.into_bitmask(),
         ) {
-            ParsedGrpcStatus::Success
-            | ParsedGrpcStatus::HeaderNotString
-            | ParsedGrpcStatus::HeaderNotInt => Some(0),
-            ParsedGrpcStatus::NonSuccess(status) => Some(status.get()),
+            ParsedGrpcStatus::Success | ParsedGrpcStatus::HeaderNotGrpcCode => Some(0),
+            ParsedGrpcStatus::NonSuccess(status) => Some(status.code() as i32),
             // if `grpc-status` is missing then its a streaming response and there is no status
             // _yet_, so its neither success nor error
             ParsedGrpcStatus::GrpcStatusHeaderMissing => None,

--- a/tower-http/src/trace/on_response.rs
+++ b/tower-http/src/trace/on_response.rs
@@ -148,7 +148,7 @@ fn status<B>(res: &Response<B>) -> Option<i32> {
             crate::classify::GrpcCode::Ok.into_bitmask(),
         ) {
             ParsedGrpcStatus::Success | ParsedGrpcStatus::HeaderNotGrpcCode => Some(0),
-            ParsedGrpcStatus::NonSuccess(status) => Some(status.code() as i32),
+            ParsedGrpcStatus::NonSuccess(status) => Some(status.code_raw()),
             // if `grpc-status` is missing then its a streaming response and there is no status
             // _yet_, so its neither success nor error
             ParsedGrpcStatus::GrpcStatusHeaderMissing => None,


### PR DESCRIPTION
## Motivation

Currently the tracing middleware only captures the gRPC status code when extracting the error out of a http response. Besides the code, gRPC also requires a human-readable message for error handling, and it'll be useful if this message is extracted from the response as well.

## Solution

Per [gRPC over HTTP/2 Protocol](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#responses), a percent-encoded message is included in the `grpc-message` field in the response header/trailer. This PR extracts this value and includes it in a new `GrpcStatus` struct within `GrpcFailureClass`, such that downstream usages can use this message for tracing.

Breaking changes:
- `GrpcFailureClass::Code(NonZeroI32)` → `GrpcFailureClass::Status(GrpcStatus)`
- `GrpcCode` and `GrpcFailureClass` are now `#[non_exhaustive]`
- `GrpcCode` is now `#[repr(i32)]`
- `GrpcFailureClass` implements `std::error::Error`