### PR TITLE
Refactor use of futures crate

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -15,8 +15,6 @@ rust-version = "1.66"
 [dependencies]
 bitflags = "2.0.2"
 bytes = "1"
-futures-core = "0.3"
-futures-util = { version = "0.3.14", default_features = false, features = [] }
 http = "0.2.7"
 http-body = "0.4.5"
 pin-project-lite = "0.2.7"
@@ -26,6 +24,7 @@ tower-service = "0.3"
 # optional dependencies
 async-compression = { version = "0.4", optional = true, features = ["tokio"] }
 base64 = { version = "0.21", optional = true }
+futures-util = { version = "0.3.14", optional = true, default_features = false }
 http-range-header = { version = "0.4.0", optional = true }
 iri-string = { version = "0.7.0", optional = true }
 mime = { version = "0.3.17", optional = true, default_features = false }
@@ -42,7 +41,6 @@ uuid = { version = "1.0", features = ["v4"], optional = true }
 bytes = "1"
 flate2 = "1.0"
 brotli = "3"
-futures = "0.3"
 hyper = { version = "0.14", features = ["full"] }
 once_cell = "1"
 tokio = { version = "1", features = ["full"] }
@@ -81,11 +79,11 @@ full = [
 ]
 
 add-extension = []
-auth = ["base64", "validate-request"]
+auth = ["base64", "futures-util", "validate-request"]
 catch-panic = ["tracing", "futures-util/std"]
 cors = []
-follow-redirect = ["iri-string", "tower/util"]
-fs = ["tokio/fs", "tokio-util/io", "tokio/io-util", "dep:http-range-header", "mime_guess", "mime", "percent-encoding", "httpdate", "set-status", "futures-util/alloc", "tracing"]
+follow-redirect = ["futures-util", "iri-string", "tower/util"]
+fs = ["futures-util", "tokio/fs", "tokio-util/io", "tokio/io-util", "dep:http-range-header", "mime_guess", "mime", "percent-encoding", "httpdate", "set-status", "futures-util/alloc", "tracing"]
 limit = []
 map-request-body = []
 map-response-body = []
@@ -98,21 +96,21 @@ sensitive-headers = []
 set-header = []
 set-status = []
 timeout = ["tokio/time"]
-trace = ["tracing"]
+trace = ["futures-util", "tracing"]
 util = ["tower"]
 validate-request = ["mime"]
 
-compression-br = ["async-compression/brotli", "tokio-util", "tokio"]
-compression-deflate = ["async-compression/zlib", "tokio-util", "tokio"]
+compression-br = ["async-compression/brotli", "futures-util", "tokio-util", "tokio"]
+compression-deflate = ["async-compression/zlib", "futures-util", "tokio-util", "tokio"]
 compression-full = ["compression-br", "compression-deflate", "compression-gzip", "compression-zstd"]
-compression-gzip = ["async-compression/gzip", "tokio-util", "tokio"]
-compression-zstd = ["async-compression/zstd", "tokio-util", "tokio"]
+compression-gzip = ["async-compression/gzip", "futures-util", "tokio-util", "tokio"]
+compression-zstd = ["async-compression/zstd", "futures-util", "tokio-util", "tokio"]
 
-decompression-br = ["async-compression/brotli", "tokio-util", "tokio"]
-decompression-deflate = ["async-compression/zlib", "tokio-util", "tokio"]
+decompression-br = ["async-compression/brotli", "futures-util", "tokio-util", "tokio"]
+decompression-deflate = ["async-compression/zlib", "futures-util", "tokio-util", "tokio"]
 decompression-full = ["decompression-br", "decompression-deflate", "decompression-gzip", "decompression-zstd"]
-decompression-gzip = ["async-compression/gzip", "tokio-util", "tokio"]
-decompression-zstd = ["async-compression/zstd", "tokio-util", "tokio"]
+decompression-gzip = ["async-compression/gzip", "futures-util", "tokio-util", "tokio"]
+decompression-zstd = ["async-compression/zstd", "futures-util", "tokio-util", "tokio"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tower-http/src/auth/async_require_authorization.rs
+++ b/tower-http/src/auth/async_require_authorization.rs
@@ -115,13 +115,12 @@
 //! # }
 //! ```
 
-use futures_core::ready;
 use http::{Request, Response};
 use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 use tower_layer::Layer;
 use tower_service::Service;

--- a/tower-http/src/catch_panic.rs
+++ b/tower-http/src/catch_panic.rs
@@ -83,7 +83,6 @@
 //! ```
 
 use bytes::Bytes;
-use futures_core::ready;
 use futures_util::future::{CatchUnwind, FutureExt};
 use http::{HeaderValue, Request, Response, StatusCode};
 use http_body::{combinators::UnsyncBoxBody, Body, Full};
@@ -93,7 +92,7 @@ use std::{
     future::Future,
     panic::AssertUnwindSafe,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 use tower_layer::Layer;
 use tower_service::Service;

--- a/tower-http/src/classify/mod.rs
+++ b/tower-http/src/classify/mod.rs
@@ -397,7 +397,7 @@ mod usable_for_retries {
         Request<ReqB>: Clone,
         E: std::error::Error + 'static,
     {
-        type Future = futures::future::Ready<RetryBasedOnClassification<C>>;
+        type Future = std::future::Ready<RetryBasedOnClassification<C>>;
 
         fn retry(
             &self,
@@ -410,7 +410,7 @@ mod usable_for_retries {
                         self.classifier.clone().classify_response(res)
                     {
                         if class.err()?.is_retryable() {
-                            return Some(futures::future::ready(self.clone()));
+                            return Some(std::future::ready(self.clone()));
                         }
                     }
 
@@ -421,7 +421,7 @@ mod usable_for_retries {
                     .clone()
                     .classify_error(err)
                     .is_retryable()
-                    .then(|| futures::future::ready(self.clone())),
+                    .then(|| std::future::ready(self.clone())),
             }
         }
 

--- a/tower-http/src/compression/body.rs
+++ b/tower-http/src/compression/body.rs
@@ -15,7 +15,6 @@ use async_compression::tokio::bufread::ZlibEncoder;
 use async_compression::tokio::bufread::ZstdEncoder;
 
 use bytes::{Buf, Bytes};
-use futures_util::ready;
 use http::HeaderMap;
 use http_body::Body;
 use pin_project_lite::pin_project;
@@ -23,7 +22,7 @@ use std::{
     io,
     marker::PhantomData,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 use tokio_util::io::StreamReader;
 

--- a/tower-http/src/compression/future.rs
+++ b/tower-http/src/compression/future.rs
@@ -5,14 +5,13 @@ use crate::compression::predicate::Predicate;
 use crate::compression::CompressionLevel;
 use crate::compression_utils::WrapBody;
 use crate::content_encoding::Encoding;
-use futures_util::ready;
 use http::{header, HeaderMap, HeaderValue, Response};
 use http_body::Body;
 use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 pin_project! {

--- a/tower-http/src/compression/mod.rs
+++ b/tower-http/src/compression/mod.rs
@@ -399,7 +399,7 @@ mod tests {
         let compressed_with_level = {
             use async_compression::tokio::bufread::BrotliEncoder;
 
-            let stream = Box::pin(futures::stream::once(async move {
+            let stream = Box::pin(futures_util::stream::once(async move {
                 Ok::<_, std::io::Error>(DATA.as_bytes())
             }));
             let reader = StreamReader::new(stream);

--- a/tower-http/src/compression_utils.rs
+++ b/tower-http/src/compression_utils.rs
@@ -2,15 +2,14 @@
 
 use crate::{content_encoding::SupportedEncodings, BoxError};
 use bytes::{Bytes, BytesMut};
-use futures_core::Stream;
-use futures_util::ready;
+use futures_util::Stream;
 use http::HeaderValue;
 use http_body::Body;
 use pin_project_lite::pin_project;
 use std::{
     io,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 use tokio::io::AsyncRead;
 use tokio_util::io::{poll_read_buf, StreamReader};

--- a/tower-http/src/cors/mod.rs
+++ b/tower-http/src/cors/mod.rs
@@ -49,7 +49,6 @@
 #![allow(clippy::enum_variant_names)]
 
 use bytes::{BufMut, BytesMut};
-use futures_core::ready;
 use http::{
     header::{self, HeaderName},
     HeaderMap, HeaderValue, Method, Request, Response,
@@ -60,7 +59,7 @@ use std::{
     future::Future,
     mem,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 use tower_layer::Layer;
 use tower_service::Service;

--- a/tower-http/src/decompression/body.rs
+++ b/tower-http/src/decompression/body.rs
@@ -14,12 +14,16 @@ use async_compression::tokio::bufread::ZlibDecoder;
 #[cfg(feature = "decompression-zstd")]
 use async_compression::tokio::bufread::ZstdDecoder;
 use bytes::{Buf, Bytes};
-use futures_util::ready;
 use http::HeaderMap;
 use http_body::Body;
 use pin_project_lite::pin_project;
 use std::task::Context;
-use std::{io, marker::PhantomData, pin::Pin, task::Poll};
+use std::{
+    io,
+    marker::PhantomData,
+    pin::Pin,
+    task::{ready, Poll},
+};
 use tokio_util::io::StreamReader;
 
 pin_project! {

--- a/tower-http/src/decompression/future.rs
+++ b/tower-http/src/decompression/future.rs
@@ -3,14 +3,13 @@
 use super::{body::BodyInner, DecompressionBody};
 use crate::compression_utils::{AcceptEncoding, CompressionLevel, WrapBody};
 use crate::content_encoding::SupportedEncodings;
-use futures_util::ready;
 use http::{header, Response};
 use http_body::Body;
 use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 pin_project! {

--- a/tower-http/src/follow_redirect/mod.rs
+++ b/tower-http/src/follow_redirect/mod.rs
@@ -93,7 +93,6 @@
 pub mod policy;
 
 use self::policy::{Action, Attempt, Policy, Standard};
-use futures_core::ready;
 use futures_util::future::Either;
 use http::{
     header::LOCATION, HeaderMap, HeaderValue, Method, Request, Response, StatusCode, Uri, Version,
@@ -107,7 +106,7 @@ use std::{
     mem,
     pin::Pin,
     str,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 use tower::util::Oneshot;
 use tower_layer::Layer;

--- a/tower-http/src/limit/future.rs
+++ b/tower-http/src/limit/future.rs
@@ -1,12 +1,11 @@
 use super::body::create_error_response;
 use super::ResponseBody;
-use futures_core::ready;
 use http::Response;
 use http_body::Body;
 use pin_project_lite::pin_project;
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pin_project! {
     /// Response future for [`RequestBodyLimit`].

--- a/tower-http/src/map_request_body.rs
+++ b/tower-http/src/map_request_body.rs
@@ -7,10 +7,9 @@
 //! use http::{Request, Response};
 //! use hyper::Body;
 //! use std::convert::Infallible;
-//! use std::{pin::Pin, task::{Context, Poll}};
+//! use std::{pin::Pin, task::{ready, Context, Poll}};
 //! use tower::{ServiceBuilder, service_fn, ServiceExt, Service};
 //! use tower_http::map_request_body::MapRequestBodyLayer;
-//! use futures::ready;
 //!
 //! // A wrapper for a `hyper::Body` that prints the size of data chunks
 //! struct PrintChunkSizesBody {

--- a/tower-http/src/map_response_body.rs
+++ b/tower-http/src/map_response_body.rs
@@ -7,10 +7,9 @@
 //! use http::{Request, Response};
 //! use hyper::Body;
 //! use std::convert::Infallible;
-//! use std::{pin::Pin, task::{Context, Poll}};
+//! use std::{pin::Pin, task::{ready, Context, Poll}};
 //! use tower::{ServiceBuilder, service_fn, ServiceExt, Service};
 //! use tower_http::map_response_body::MapResponseBodyLayer;
-//! use futures::ready;
 //!
 //! // A wrapper for a `hyper::Body` that prints the size of data chunks
 //! struct PrintChunkSizesBody {
@@ -75,14 +74,13 @@
 //! # }
 //! ```
 
-use futures_core::ready;
 use http::{Request, Response};
 use pin_project_lite::pin_project;
 use std::future::Future;
 use std::{
     fmt,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 use tower_layer::Layer;
 use tower_service::Service;

--- a/tower-http/src/metrics/in_flight_requests.rs
+++ b/tower-http/src/metrics/in_flight_requests.rs
@@ -50,7 +50,6 @@
 //! # }
 //! ```
 
-use futures_util::ready;
 use http::{Request, Response};
 use http_body::Body;
 use pin_project_lite::pin_project;
@@ -61,7 +60,7 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Arc,
     },
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
     time::Duration,
 };
 use tower_layer::Layer;
@@ -311,7 +310,7 @@ mod tests {
         assert_eq!(counter.get(), 0);
 
         // driving service to ready shouldn't increment the counter
-        futures::future::poll_fn(|cx| service.poll_ready(cx))
+        std::future::poll_fn(|cx| service.poll_ready(cx))
             .await
             .unwrap();
         assert_eq!(counter.get(), 0);

--- a/tower-http/src/propagate_header.rs
+++ b/tower-http/src/propagate_header.rs
@@ -34,13 +34,12 @@
 //! # }
 //! ```
 
-use futures_util::ready;
 use http::{header::HeaderName, HeaderValue, Request, Response};
 use pin_project_lite::pin_project;
 use std::future::Future;
 use std::{
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 use tower_layer::Layer;
 use tower_service::Service;

--- a/tower-http/src/request_id.rs
+++ b/tower-http/src/request_id.rs
@@ -172,7 +172,7 @@ use http::{
     Request, Response,
 };
 use pin_project_lite::pin_project;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 use std::{future::Future, pin::Pin};
 use tower_layer::Layer;
 use tower_service::Service;
@@ -450,7 +450,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-        let mut response = futures_core::ready!(this.inner.poll(cx))?;
+        let mut response = ready!(this.inner.poll(cx))?;
 
         if let Some(current_id) = response.headers().get(&*this.header_name) {
             if response.extensions().get::<RequestId>().is_none() {

--- a/tower-http/src/sensitive_headers.rs
+++ b/tower-http/src/sensitive_headers.rs
@@ -82,14 +82,13 @@
 //!
 //! [`TraceLayer`]: crate::trace::TraceLayer
 
-use futures_util::ready;
 use http::{header::HeaderName, Request, Response};
 use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
     sync::Arc,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 use tower_layer::Layer;
 use tower_service::Service;

--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -4,10 +4,7 @@ use super::{
 };
 use crate::{content_encoding::Encoding, services::fs::AsyncReadBody, BoxError};
 use bytes::Bytes;
-use futures_util::{
-    future::{BoxFuture, FutureExt, TryFutureExt},
-    ready,
-};
+use futures_util::future::{BoxFuture, FutureExt, TryFutureExt};
 use http::{
     header::{self, ALLOW},
     HeaderValue, Request, Response, StatusCode,
@@ -19,7 +16,7 @@ use std::{
     future::Future,
     io,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 use tower_service::Service;
 

--- a/tower-http/src/set_header/response.rs
+++ b/tower-http/src/set_header/response.rs
@@ -93,14 +93,13 @@
 //! ```
 
 use super::{InsertHeaderMode, MakeHeaderValue};
-use futures_util::ready;
 use http::{header::HeaderName, Request, Response};
 use pin_project_lite::pin_project;
 use std::{
     fmt,
     future::Future,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 use tower_layer::Layer;
 use tower_service::Service;

--- a/tower-http/src/set_status.rs
+++ b/tower-http/src/set_status.rs
@@ -37,7 +37,7 @@ use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 use tower_layer::Layer;
 use tower_service::Service;
@@ -129,7 +129,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-        let mut response = futures_core::ready!(this.inner.poll(cx)?);
+        let mut response = ready!(this.inner.poll(cx)?);
         *response.status_mut() = this.status.take().expect("future polled after completion");
         Poll::Ready(Ok(response))
     }

--- a/tower-http/src/timeout/body.rs
+++ b/tower-http/src/timeout/body.rs
@@ -1,10 +1,10 @@
 use crate::BoxError;
-use futures_core::{ready, Future};
 use http_body::Body;
 use pin_project_lite::pin_project;
 use std::{
+    future::Future,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
     time::Duration,
 };
 use tokio::time::{sleep, Sleep};

--- a/tower-http/src/timeout/service.rs
+++ b/tower-http/src/timeout/service.rs
@@ -1,11 +1,10 @@
 use crate::timeout::body::TimeoutBody;
-use futures_core::ready;
 use http::{Request, Response, StatusCode};
 use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
     time::Duration,
 };
 use tokio::time::Sleep;

--- a/tower-http/src/trace/body.rs
+++ b/tower-http/src/trace/body.rs
@@ -1,13 +1,12 @@
 use super::{OnBodyChunk, OnEos, OnFailure};
 use crate::classify::ClassifyEos;
-use futures_core::ready;
 use http::HeaderMap;
 use http_body::Body;
 use pin_project_lite::pin_project;
 use std::{
     fmt,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
     time::Instant,
 };
 use tracing::Span;

--- a/tower-http/src/trace/future.rs
+++ b/tower-http/src/trace/future.rs
@@ -6,7 +6,7 @@ use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
     time::Instant,
 };
 use tracing::Span;
@@ -49,7 +49,7 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
         let _guard = this.span.enter();
-        let result = futures_util::ready!(this.inner.poll(cx));
+        let result = ready!(this.inner.poll(cx));
         let latency = this.start.elapsed();
 
         let classifier = this.classifier.take().unwrap();

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -606,7 +606,7 @@ mod tests {
     }
 
     async fn streaming_body(_req: Request<Body>) -> Result<Response<Body>, BoxError> {
-        use futures::stream::iter;
+        use futures_util::stream::iter;
 
         let stream = iter(vec![
             Ok::<_, BoxError>(Bytes::from("one")),


### PR DESCRIPTION
## Motivation

Refactoring.

## Solution

- Replaces `futures_{util,core}` with `std`'s APIs when possible.
- Uses `futures_core`'s API via `futures_util` as already used at the other places.
- Replaces `futures` with `futures_util`.
- Makes `futures_util` dependency optional.