### PR TITLE
Replace futures with futures-util in examples dependency

### DIFF
--- a/examples/tonic-key-value-store/Cargo.toml
+++ b/examples/tonic-key-value-store/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "1"
 hyper = { version = "0.14.4", features = ["full"] }
 prost = "0.11"
 tokio = { version = "1.2.0", features = ["full"] }
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
 tokio-stream = { version = "0.1", features = ["sync", "net"] }
 tonic = "0.9"
 tower = { version = "0.4.5", features = ["full"] }

--- a/examples/tonic-key-value-store/src/main.rs
+++ b/examples/tonic-key-value-store/src/main.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use clap::Parser;
-use futures::StreamExt;
+use futures_util::StreamExt;
 use hyper::{
     body::HttpBody,
     header::{self, HeaderValue},


### PR DESCRIPTION
## Motivation

Simplifies examples dependency.

## Solution

Replaces `futures` with `futures-util` in the examples dependency.
