### PR TITLE
[trace] Add default generic parameters to ResponseBody and ResponseFuture

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- None.
+- **trace:** Add default generic parameters for `ResponseBody` and `ResponseFuture` ([#455])
+- **trace:** Add type aliases `HttpMakeClassifier` and `GrpcMakeClassifier` ([#455])
 
 ## Changed
 
@@ -22,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 - None.
+
+[#455]: https://github.com/tower-rs/tower-http/pull/455
 
 # 0.5.0 (November 21, 2023)
 

--- a/tower-http/src/builder.rs
+++ b/tower-http/src/builder.rs
@@ -1,8 +1,5 @@
 use tower::ServiceBuilder;
 
-#[cfg(feature = "trace")]
-use crate::classify::{GrpcErrorsAsFailures, ServerErrorsAsFailures, SharedClassifier};
-
 #[allow(unused_imports)]
 use http::header::HeaderName;
 #[allow(unused_imports)]
@@ -126,7 +123,7 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     #[cfg(feature = "trace")]
     fn trace_for_http(
         self,
-    ) -> ServiceBuilder<Stack<crate::trace::TraceLayer<SharedClassifier<ServerErrorsAsFailures>>, L>>;
+    ) -> ServiceBuilder<Stack<crate::trace::TraceLayer<crate::trace::HttpMakeClassifier>, L>>;
 
     /// High level tracing that classifies responses using gRPC headers.
     ///
@@ -140,7 +137,7 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     #[cfg(feature = "trace")]
     fn trace_for_grpc(
         self,
-    ) -> ServiceBuilder<Stack<crate::trace::TraceLayer<SharedClassifier<GrpcErrorsAsFailures>>, L>>;
+    ) -> ServiceBuilder<Stack<crate::trace::TraceLayer<crate::trace::GrpcMakeClassifier>, L>>;
 
     /// Follow redirect resposes using the [`Standard`] policy.
     ///
@@ -427,16 +424,14 @@ impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
     #[cfg(feature = "trace")]
     fn trace_for_http(
         self,
-    ) -> ServiceBuilder<Stack<crate::trace::TraceLayer<SharedClassifier<ServerErrorsAsFailures>>, L>>
-    {
+    ) -> ServiceBuilder<Stack<crate::trace::TraceLayer<crate::trace::HttpMakeClassifier>, L>> {
         self.layer(crate::trace::TraceLayer::new_for_http())
     }
 
     #[cfg(feature = "trace")]
     fn trace_for_grpc(
         self,
-    ) -> ServiceBuilder<Stack<crate::trace::TraceLayer<SharedClassifier<GrpcErrorsAsFailures>>, L>>
-    {
+    ) -> ServiceBuilder<Stack<crate::trace::TraceLayer<crate::trace::GrpcMakeClassifier>, L>> {
         self.layer(crate::trace::TraceLayer::new_for_grpc())
     }
 

--- a/tower-http/src/trace/body.rs
+++ b/tower-http/src/trace/body.rs
@@ -1,4 +1,4 @@
-use super::{OnBodyChunk, OnEos, OnFailure};
+use super::{DefaultOnBodyChunk, DefaultOnEos, DefaultOnFailure, OnBodyChunk, OnEos, OnFailure};
 use crate::classify::ClassifyEos;
 use http_body::{Body, Frame};
 use pin_project_lite::pin_project;
@@ -14,7 +14,7 @@ pin_project! {
     /// Response body for [`Trace`].
     ///
     /// [`Trace`]: super::Trace
-    pub struct ResponseBody<B, C, OnBodyChunk, OnEos, OnFailure> {
+    pub struct ResponseBody<B, C, OnBodyChunk = DefaultOnBodyChunk, OnEos = DefaultOnEos, OnFailure = DefaultOnFailure> {
         #[pin]
         pub(crate) inner: B,
         pub(crate) classify_eos: Option<C>,

--- a/tower-http/src/trace/future.rs
+++ b/tower-http/src/trace/future.rs
@@ -1,4 +1,7 @@
-use super::{OnBodyChunk, OnEos, OnFailure, OnResponse, ResponseBody};
+use super::{
+    DefaultOnBodyChunk, DefaultOnEos, DefaultOnFailure, DefaultOnResponse, OnBodyChunk, OnEos,
+    OnFailure, OnResponse, ResponseBody,
+};
 use crate::classify::{ClassifiedResponse, ClassifyResponse};
 use http::Response;
 use http_body::Body;
@@ -15,7 +18,7 @@ pin_project! {
     /// Response future for [`Trace`].
     ///
     /// [`Trace`]: super::Trace
-    pub struct ResponseFuture<F, C, OnResponse, OnBodyChunk, OnEos, OnFailure> {
+    pub struct ResponseFuture<F, C, OnResponse = DefaultOnResponse, OnBodyChunk = DefaultOnBodyChunk, OnEos = DefaultOnEos, OnFailure = DefaultOnFailure> {
         #[pin]
         pub(crate) inner: F,
         pub(crate) span: Span,

--- a/tower-http/src/trace/layer.rs
+++ b/tower-http/src/trace/layer.rs
@@ -1,6 +1,6 @@
 use super::{
     DefaultMakeSpan, DefaultOnBodyChunk, DefaultOnEos, DefaultOnFailure, DefaultOnRequest,
-    DefaultOnResponse, Trace,
+    DefaultOnResponse, GrpcMakeClassifier, HttpMakeClassifier, Trace,
 };
 use crate::classify::{
     GrpcErrorsAsFailures, MakeClassifier, ServerErrorsAsFailures, SharedClassifier,
@@ -176,7 +176,7 @@ impl<M, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
     }
 }
 
-impl TraceLayer<SharedClassifier<ServerErrorsAsFailures>> {
+impl TraceLayer<HttpMakeClassifier> {
     /// Create a new [`TraceLayer`] using [`ServerErrorsAsFailures`] which supports classifying
     /// regular HTTP responses based on the status code.
     pub fn new_for_http() -> Self {
@@ -192,7 +192,7 @@ impl TraceLayer<SharedClassifier<ServerErrorsAsFailures>> {
     }
 }
 
-impl TraceLayer<SharedClassifier<GrpcErrorsAsFailures>> {
+impl TraceLayer<GrpcMakeClassifier> {
     /// Create a new [`TraceLayer`] using [`GrpcErrorsAsFailures`] which supports classifying
     /// gRPC responses and streams based on the `grpc-status` header.
     pub fn new_for_grpc() -> Self {

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -400,7 +400,16 @@ pub use self::{
     on_response::{DefaultOnResponse, OnResponse},
     service::Trace,
 };
-use crate::LatencyUnit;
+use crate::{
+    classify::{GrpcErrorsAsFailures, ServerErrorsAsFailures, SharedClassifier},
+    LatencyUnit,
+};
+
+/// MakeClassifier for HTTP requests.
+pub type HttpMakeClassifier = SharedClassifier<ServerErrorsAsFailures>;
+
+/// MakeClassifier for gRPC requests.
+pub type GrpcMakeClassifier = SharedClassifier<GrpcErrorsAsFailures>;
 
 macro_rules! event_dynamic_lvl {
     ( $(target: $target:expr,)? $(parent: $parent:expr,)? $lvl:expr, $($tt:tt)* ) => {

--- a/tower-http/src/trace/service.rs
+++ b/tower-http/src/trace/service.rs
@@ -1,7 +1,7 @@
 use super::{
     DefaultMakeSpan, DefaultOnBodyChunk, DefaultOnEos, DefaultOnFailure, DefaultOnRequest,
-    DefaultOnResponse, MakeSpan, OnBodyChunk, OnEos, OnFailure, OnRequest, OnResponse,
-    ResponseBody, ResponseFuture, TraceLayer,
+    DefaultOnResponse, GrpcMakeClassifier, HttpMakeClassifier, MakeSpan, OnBodyChunk, OnEos,
+    OnFailure, OnRequest, OnResponse, ResponseBody, ResponseFuture, TraceLayer,
 };
 use crate::classify::{
     GrpcErrorsAsFailures, MakeClassifier, ServerErrorsAsFailures, SharedClassifier,
@@ -207,7 +207,7 @@ impl<S, M, MakeSpan, OnRequest, OnResponse, OnBodyChunk, OnEos, OnFailure>
 impl<S>
     Trace<
         S,
-        SharedClassifier<ServerErrorsAsFailures>,
+        HttpMakeClassifier,
         DefaultMakeSpan,
         DefaultOnRequest,
         DefaultOnResponse,
@@ -235,7 +235,7 @@ impl<S>
 impl<S>
     Trace<
         S,
-        SharedClassifier<GrpcErrorsAsFailures>,
+        GrpcMakeClassifier,
         DefaultMakeSpan,
         DefaultOnRequest,
         DefaultOnResponse,


### PR DESCRIPTION
## Motivation

Fixes issue: #233 

## Solution

This PR adds default generic parameters to trace::{ResponseBody, ResponseFuture}, allowing users to use these respective types while omitting several generics that can be defaulted, decreasing verbosity.

Additionally, this PR also adds two type aliases: HttpMakeClassifier and GrpcMakeClassifier, as requested in the issue mentioned.
