### PR TITLE
Fix Deny Action failures in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -106,8 +106,8 @@ jobs:
     - uses: actions/checkout@v3
     - uses: EmbarkStudios/cargo-deny-action@v1
       with:
+        manifest-path: tower-http/Cargo.toml
         command: check ${{ matrix.checks }}
-        arguments: --all-features --manifest-path tower-http/Cargo.toml
 
   cargo-public-api-crates:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Fixes deny action CI failures like in PR #467.

## Motivation
Fixes deny action CI failures like in PR #467.

## Solution
- Specify manifest-path as a separate input property instead of in `arguments`
- Removes `arguments` because the new value [is the default](https://github.com/EmbarkStudios/cargo-deny-action/blob/68cd9c5e3e16328a430a37c743167572e3243e7e/action.yml#L17)