### PR TITLE
Optimize encoding selection for compression middleware

### DIFF
--- a/tower-http/src/content_encoding.rs
+++ b/tower-http/src/content_encoding.rs
@@ -100,7 +100,7 @@ impl Encoding {
         headers: &http::HeaderMap,
         supported_encoding: impl SupportedEncodings,
     ) -> Self {
-        Encoding::preferred_encoding(&encodings(headers, supported_encoding))
+        Encoding::preferred_encoding(encodings(headers, supported_encoding))
             .unwrap_or(Encoding::Identity)
     }
 
@@ -111,12 +111,13 @@ impl Encoding {
         feature = "compression-deflate",
         feature = "fs",
     ))]
-    pub(crate) fn preferred_encoding(accepted_encodings: &[(Encoding, QValue)]) -> Option<Self> {
+    pub(crate) fn preferred_encoding(
+        accepted_encodings: impl Iterator<Item = (Encoding, QValue)>,
+    ) -> Option<Self> {
         accepted_encodings
-            .iter()
             .filter(|(_, qvalue)| qvalue.0 > 0)
-            .max_by_key(|(encoding, qvalue)| (qvalue, encoding))
-            .map(|(encoding, _)| *encoding)
+            .max_by_key(|&(encoding, qvalue)| (qvalue, encoding))
+            .map(|(encoding, _)| encoding)
     }
 }
 
@@ -212,16 +213,16 @@ impl QValue {
     feature = "fs",
 ))]
 // based on https://github.com/http-rs/accept-encoding
-pub(crate) fn encodings(
-    headers: &http::HeaderMap,
-    supported_encoding: impl SupportedEncodings,
-) -> Vec<(Encoding, QValue)> {
+pub(crate) fn encodings<'a>(
+    headers: &'a http::HeaderMap,
+    supported_encoding: impl SupportedEncodings + 'a,
+) -> impl Iterator<Item = (Encoding, QValue)> + 'a {
     headers
         .get_all(http::header::ACCEPT_ENCODING)
         .iter()
         .filter_map(|hval| hval.to_str().ok())
         .flat_map(|s| s.split(','))
-        .filter_map(|v| {
+        .filter_map(move |v| {
             let mut v = v.splitn(2, ';');
 
             let encoding = match Encoding::parse(v.next().unwrap().trim(), supported_encoding) {
@@ -237,7 +238,6 @@ pub(crate) fn encodings(
 
             Some((encoding, qval))
         })
-        .collect::<Vec<(Encoding, QValue)>>()
 }
 
 #[cfg(all(

--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -365,10 +365,11 @@ impl<F> ServeDir<F> {
             .and_then(|value| value.to_str().ok())
             .map(|s| s.to_owned());
 
-        let negotiated_encodings = encodings(
+        let negotiated_encodings: Vec<_> = encodings(
             req.headers(),
             self.precompressed_variants.unwrap_or_default(),
-        );
+        )
+        .collect();
 
         let variant = self.variant.clone();
 

--- a/tower-http/src/services/fs/serve_dir/open_file.rs
+++ b/tower-http/src/services/fs/serve_dir/open_file.rs
@@ -176,7 +176,7 @@ fn preferred_encoding(
     path: &mut PathBuf,
     negotiated_encoding: &[(Encoding, QValue)],
 ) -> Option<Encoding> {
-    let preferred_encoding = Encoding::preferred_encoding(negotiated_encoding);
+    let preferred_encoding = Encoding::preferred_encoding(negotiated_encoding.iter().copied());
 
     if let Some(file_extension) =
         preferred_encoding.and_then(|encoding| encoding.to_file_extension())


### PR DESCRIPTION
## Motivation

I noticed that `Encoding::from_headers` unnecessarily allocates a `Vec` for all the supported encodings it finds before selecting the most suitable one of them.

## Solution

Change `encodings` to return an iterator and only collect that iterator where it makes sense.