### PR TITLE
Small documentation improvements for compression middleware

### DIFF
--- a/tower-http/src/compression/layer.rs
+++ b/tower-http/src/compression/layer.rs
@@ -34,7 +34,7 @@ where
 }
 
 impl CompressionLayer {
-    /// Create a new [`CompressionLayer`]
+    /// Creates a new [`CompressionLayer`].
     pub fn new() -> Self {
         Self::default()
     }

--- a/tower-http/src/compression_utils.rs
+++ b/tower-http/src/compression_utils.rs
@@ -404,12 +404,16 @@ pub enum CompressionLevel {
     Fastest,
     /// Best quality of compression, usually produces the smallest size.
     Best,
-    /// Default quality of compression defined by the selected compression algorithm.
+    /// Default quality of compression defined by the selected compression
+    /// algorithm.
     #[default]
     Default,
     /// Precise quality based on the underlying compression algorithms'
-    /// qualities. The interpretation of this depends on the algorithm chosen
-    /// and the specific implementation backing it.
+    /// qualities.
+    ///
+    /// The interpretation of this depends on the algorithm chosen and the
+    /// specific implementation backing it.
+    ///
     /// Qualities are implicitly clamped to the algorithm's maximum.
     Precise(i32),
 }


### PR DESCRIPTION
- Rewrap doc comments on CompressionLevel variants
- Normalize wording for CompressionLayer::new