### PR TITLE
enable cors/tests.rs and make it pass

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 - **compression:** Skip compression for range requests ([#446])
-- **cors:** don't overwrite previously-set (Vary) value ([#473])
+- **cors:** *Actually* keep Vary headers set by the inner service when setting response headers ([#473])
+  - Version 0.5.1 intended to ship this, but the implementation was buggy and didn't actually do anything
 
 [#399]: https://github.com/tower-rs/tower-http/pull/399
 [#446]: https://github.com/tower-rs/tower-http/pull/446

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 - **compression:** Skip compression for range requests ([#446])
+- **cors:** don't overwrite previously-set (Vary) value ([#473])
 
 [#399]: https://github.com/tower-rs/tower-http/pull/399
 [#446]: https://github.com/tower-rs/tower-http/pull/446
+[#473]: https://github.com/tower-rs/tower-http/pull/473
 
 # 0.5.1 (January 14, 2024)
 

--- a/tower-http/src/cors/mod.rs
+++ b/tower-http/src/cors/mod.rs
@@ -74,6 +74,9 @@ mod expose_headers;
 mod max_age;
 mod vary;
 
+#[cfg(test)]
+mod tests;
+
 pub use self::{
     allow_credentials::AllowCredentials, allow_headers::AllowHeaders, allow_methods::AllowMethods,
     allow_origin::AllowOrigin, allow_private_network::AllowPrivateNetwork,
@@ -682,13 +685,15 @@ where
             KindProj::CorsCall { future, headers } => {
                 let mut response: Response<B> = ready!(future.poll(cx))?;
 
+                let response_headers = response.headers_mut();
+
                 // vary header can have multiple values, don't overwrite
                 // previously-set value(s).
-                if let Some(vary) = headers.remove(header::VARY) {
+                if let Some(vary) = response_headers.remove(header::VARY) {
                     headers.append(header::VARY, vary);
                 }
                 // extend will overwrite previous headers of remaining names
-                response.headers_mut().extend(headers.drain());
+                response_headers.extend(headers.drain());
 
                 Poll::Ready(Ok(response))
             }

--- a/tower-http/src/cors/mod.rs
+++ b/tower-http/src/cors/mod.rs
@@ -689,8 +689,8 @@ where
 
                 // vary header can have multiple values, don't overwrite
                 // previously-set value(s).
-                if let Some(vary) = response_headers.remove(header::VARY) {
-                    headers.append(header::VARY, vary);
+                if let Some(vary) = headers.remove(header::VARY) {
+                    response_headers.append(header::VARY, vary);
                 }
                 // extend will overwrite previous headers of remaining names
                 response_headers.extend(headers.drain());

--- a/tower-http/src/cors/tests.rs
+++ b/tower-http/src/cors/tests.rs
@@ -27,7 +27,7 @@ async fn vary_set_by_inner_service() {
     let svc = CorsLayer::permissive().layer(service_fn(inner_svc));
     let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
     let mut vary_headers = res.headers().get_all(header::VARY).into_iter();
-    assert_eq!(vary_headers.next(), Some(&PERMISSIVE_CORS_VARY_HEADERS));
     assert_eq!(vary_headers.next(), Some(&CUSTOM_VARY_HEADERS));
+    assert_eq!(vary_headers.next(), Some(&PERMISSIVE_CORS_VARY_HEADERS));
     assert_eq!(vary_headers.next(), None);
 }

--- a/tower-http/src/cors/tests.rs
+++ b/tower-http/src/cors/tests.rs
@@ -1,7 +1,7 @@
 use std::convert::Infallible;
 
+use crate::test_helpers::Body;
 use http::{header, HeaderValue, Request, Response};
-use hyper::Body;
 use tower::{service_fn, util::ServiceExt, Layer};
 
 use crate::cors::CorsLayer;
@@ -27,7 +27,7 @@ async fn vary_set_by_inner_service() {
     let svc = CorsLayer::permissive().layer(service_fn(inner_svc));
     let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
     let mut vary_headers = res.headers().get_all(header::VARY).into_iter();
-    assert_eq!(vary_headers.next(), Some(&CUSTOM_VARY_HEADERS));
     assert_eq!(vary_headers.next(), Some(&PERMISSIVE_CORS_VARY_HEADERS));
+    assert_eq!(vary_headers.next(), Some(&CUSTOM_VARY_HEADERS));
     assert_eq!(vary_headers.next(), None);
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

`cors/tests.rs` was added somewhere between now and the `0.5` release.
However the file wasn't enabled, and this seemed to also hide a bug,
where we did not in fact preserve the already set `Vary` (http response) header.

Found while porting over the updated/added logic since 0.5 to <https://github.com/plabayo/rama>

(as that codebase uses ported code from `tower-async`, which is ported from `tower`, 
  since then I have abandoned `tower-async` as it did its job to proof that it was possible, but more drastic changes
  were desired on my side for `rama`. I do keep however `rama` in sync with improvements made to codebases such as `tower-http`, which is one of many reasons why I love to contribute to `tower` where I can and where it is desired)


## Solution

1. enable the test by adding the mod to `cors/mod.rs`
2. fix the bug in `cors/mod.rs` where we remove from `headers` instead of  `response_headers`

As flagged on Discord it does also mean we need a third change where the order is not preserved,
and instead the custom (already set) Vary header will be at the end.
