### PR TITLE
Make http-body and http-body-util dependencies optional

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# Unreleased
+
+## Changed:
+
+- `body` module is disabled except for `catch-panic`, `decompression-*`, `fs`, or `limit` features (BREAKING) ([#477])
+
+[#477]: https://github.com/tower-rs/tower-http/pull/477
+
 # 0.5.2
 
 ## Added:
@@ -54,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
-- Accepts range headers with ranges where the end of range goes past the end of the document by bumping 
+- Accepts range headers with ranges where the end of range goes past the end of the document by bumping
 http-range-header to `0.4`
 
 [#418]: https://github.com/tower-rs/tower-http/pull/418

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -16,8 +16,6 @@ rust-version = "1.66"
 bitflags = "2.0.2"
 bytes = "1"
 http = "1.0"
-http-body = "1.0.0"
-http-body-util = "0.1.0"
 pin-project-lite = "0.2.7"
 tower-layer = "0.3"
 tower-service = "0.3"
@@ -27,6 +25,8 @@ async-compression = { version = "0.4", optional = true, features = ["tokio"] }
 base64 = { version = "0.21", optional = true }
 futures-core = { version = "0.3", optional = true, default_features = false }
 futures-util = { version = "0.3.14", optional = true, default_features = false }
+http-body = { version = "1.0.0", optional = true }
+http-body-util = { version = "0.1.0", optional = true }
 http-range-header = { version = "0.4.0", optional = true }
 iri-string = { version = "0.7.0", optional = true }
 mime = { version = "0.3.17", optional = true, default_features = false }
@@ -45,6 +45,8 @@ brotli = "3"
 bytes = "1"
 flate2 = "1.0"
 futures-util = "0.3.14"
+http-body = "1.0.0"
+http-body-util = "0.1.0"
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "tokio"] }
 once_cell = "1"
 serde_json = "1.0"
@@ -84,15 +86,15 @@ full = [
 ]
 
 add-extension = []
-auth = ["base64", "validate-request"]
-catch-panic = ["tracing", "futures-util/std"]
+auth = ["base64", "dep:http-body", "validate-request"]
+catch-panic = ["tracing", "futures-util/std", "dep:http-body", "dep:http-body-util"]
 cors = []
-follow-redirect = ["futures-util", "iri-string", "tower/util"]
-fs = ["futures-util", "tokio/fs", "tokio-util/io", "tokio/io-util", "dep:http-range-header", "mime_guess", "mime", "percent-encoding", "httpdate", "set-status", "futures-util/alloc", "tracing"]
-limit = []
+follow-redirect = ["futures-util", "dep:http-body", "iri-string", "tower/util"]
+fs = ["futures-util", "dep:http-body", "dep:http-body-util", "tokio/fs", "tokio-util/io", "tokio/io-util", "dep:http-range-header", "mime_guess", "mime", "percent-encoding", "httpdate", "set-status", "futures-util/alloc", "tracing"]
+limit = ["dep:http-body", "dep:http-body-util"]
 map-request-body = []
 map-response-body = []
-metrics = ["tokio/time"]
+metrics = ["dep:http-body", "tokio/time"]
 normalize-path = []
 propagate-header = []
 redirect = []
@@ -100,22 +102,22 @@ request-id = ["uuid"]
 sensitive-headers = []
 set-header = []
 set-status = []
-timeout = ["tokio/time"]
-trace = ["tracing"]
+timeout = ["dep:http-body", "tokio/time"]
+trace = ["dep:http-body", "tracing"]
 util = ["tower"]
-validate-request = ["mime"]
+validate-request = ["dep:http-body", "mime"]
 
-compression-br = ["async-compression/brotli", "futures-core", "tokio-util", "tokio"]
-compression-deflate = ["async-compression/zlib", "futures-core", "tokio-util", "tokio"]
+compression-br = ["async-compression/brotli", "futures-core", "dep:http-body", "tokio-util", "tokio"]
+compression-deflate = ["async-compression/zlib", "futures-core", "dep:http-body", "tokio-util", "tokio"]
 compression-full = ["compression-br", "compression-deflate", "compression-gzip", "compression-zstd"]
-compression-gzip = ["async-compression/gzip", "futures-core", "tokio-util", "tokio"]
-compression-zstd = ["async-compression/zstd", "futures-core", "tokio-util", "tokio"]
+compression-gzip = ["async-compression/gzip", "futures-core", "dep:http-body", "tokio-util", "tokio"]
+compression-zstd = ["async-compression/zstd", "futures-core", "dep:http-body", "tokio-util", "tokio"]
 
-decompression-br = ["async-compression/brotli", "futures-core", "tokio-util", "tokio"]
-decompression-deflate = ["async-compression/zlib", "futures-core", "tokio-util", "tokio"]
+decompression-br = ["async-compression/brotli", "futures-core", "dep:http-body", "dep:http-body-util", "tokio-util", "tokio"]
+decompression-deflate = ["async-compression/zlib", "futures-core", "dep:http-body", "dep:http-body-util", "tokio-util", "tokio"]
 decompression-full = ["decompression-br", "decompression-deflate", "decompression-gzip", "decompression-zstd"]
-decompression-gzip = ["async-compression/gzip", "futures-core", "tokio-util", "tokio"]
-decompression-zstd = ["async-compression/zstd", "futures-core", "tokio-util", "tokio"]
+decompression-gzip = ["async-compression/gzip", "futures-core", "dep:http-body", "dep:http-body-util", "tokio-util", "tokio"]
+decompression-zstd = ["async-compression/zstd", "futures-core", "dep:http-body", "dep:http-body-util", "tokio-util", "tokio"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -343,6 +343,15 @@ pub use self::builder::ServiceBuilderExt;
 #[cfg(feature = "validate-request")]
 pub mod validate_request;
 
+#[cfg(any(
+    feature = "catch-panic",
+    feature = "decompression-br",
+    feature = "decompression-deflate",
+    feature = "decompression-gzip",
+    feature = "decompression-zstd",
+    feature = "fs",
+    feature = "limit",
+))]
 pub mod body;
 
 /// The latency unit used to report latencies by middleware.


### PR DESCRIPTION
## Motivation

Some features do not seem to use `http-body` crate, and some of them also not using `http-body-util` crate as the dependencies.

## Solution

Makes `http-body` and `http-body-util` dependencies optional.

This is a breaking change as this disables `body` module conditionally, 