### PR TITLE
Relax body trait bound

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -105,7 +105,7 @@ set-status = []
 timeout = ["dep:http-body", "tokio/time"]
 trace = ["dep:http-body", "tracing"]
 util = ["tower"]
-validate-request = ["dep:http-body", "mime"]
+validate-request = ["mime"]
 
 compression-br = ["async-compression/brotli", "futures-core", "dep:http-body", "tokio-util", "tokio"]
 compression-deflate = ["async-compression/zlib", "futures-core", "dep:http-body", "tokio-util", "tokio"]

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -86,7 +86,7 @@ full = [
 ]
 
 add-extension = []
-auth = ["base64", "dep:http-body", "validate-request"]
+auth = ["base64", "validate-request"]
 catch-panic = ["tracing", "futures-util/std", "dep:http-body", "dep:http-body-util"]
 cors = []
 follow-redirect = ["futures-util", "dep:http-body", "iri-string", "tower/util"]

--- a/tower-http/src/auth/require_authorization.rs
+++ b/tower-http/src/auth/require_authorization.rs
@@ -60,7 +60,6 @@ use http::{
     header::{self, HeaderValue},
     Request, Response, StatusCode,
 };
-use http_body::Body;
 use std::{fmt, marker::PhantomData};
 
 const BASE64: base64::engine::GeneralPurpose = base64::engine::general_purpose::STANDARD;
@@ -75,7 +74,7 @@ impl<S, ResBody> ValidateRequestHeader<S, Basic<ResBody>> {
     /// with this method. However use of HTTPS/TLS is not enforced by this middleware.
     pub fn basic(inner: S, username: &str, value: &str) -> Self
     where
-        ResBody: Body + Default,
+        ResBody: Default,
     {
         Self::custom(inner, Basic::new(username, value))
     }
@@ -91,7 +90,7 @@ impl<ResBody> ValidateRequestHeaderLayer<Basic<ResBody>> {
     /// with this method. However use of HTTPS/TLS is not enforced by this middleware.
     pub fn basic(username: &str, password: &str) -> Self
     where
-        ResBody: Body + Default,
+        ResBody: Default,
     {
         Self::custom(Basic::new(username, password))
     }
@@ -107,7 +106,7 @@ impl<S, ResBody> ValidateRequestHeader<S, Bearer<ResBody>> {
     /// Panics if the token is not a valid [`HeaderValue`].
     pub fn bearer(inner: S, token: &str) -> Self
     where
-        ResBody: Body + Default,
+        ResBody: Default,
     {
         Self::custom(inner, Bearer::new(token))
     }
@@ -123,7 +122,7 @@ impl<ResBody> ValidateRequestHeaderLayer<Bearer<ResBody>> {
     /// Panics if the token is not a valid [`HeaderValue`].
     pub fn bearer(token: &str) -> Self
     where
-        ResBody: Body + Default,
+        ResBody: Default,
     {
         Self::custom(Bearer::new(token))
     }
@@ -140,7 +139,7 @@ pub struct Bearer<ResBody> {
 impl<ResBody> Bearer<ResBody> {
     fn new(token: &str) -> Self
     where
-        ResBody: Body + Default,
+        ResBody: Default,
     {
         Self {
             header_value: format!("Bearer {}", token)
@@ -170,7 +169,7 @@ impl<ResBody> fmt::Debug for Bearer<ResBody> {
 
 impl<B, ResBody> ValidateRequest<B> for Bearer<ResBody>
 where
-    ResBody: Body + Default,
+    ResBody: Default,
 {
     type ResponseBody = ResBody;
 
@@ -197,7 +196,7 @@ pub struct Basic<ResBody> {
 impl<ResBody> Basic<ResBody> {
     fn new(username: &str, password: &str) -> Self
     where
-        ResBody: Body + Default,
+        ResBody: Default,
     {
         let encoded = BASE64.encode(format!("{}:{}", username, password));
         let header_value = format!("Basic {}", encoded).parse().unwrap();
@@ -227,7 +226,7 @@ impl<ResBody> fmt::Debug for Basic<ResBody> {
 
 impl<B, ResBody> ValidateRequest<B> for Basic<ResBody>
 where
-    ResBody: Body + Default,
+    ResBody: Default,
 {
     type ResponseBody = ResBody;
 

--- a/tower-http/src/validate_request.rs
+++ b/tower-http/src/validate_request.rs
@@ -117,7 +117,6 @@
 //! ```
 
 use http::{header, Request, Response, StatusCode};
-use http_body::Body;
 use mime::{Mime, MimeIter};
 use pin_project_lite::pin_project;
 use std::{
@@ -163,7 +162,7 @@ impl<ResBody> ValidateRequestHeaderLayer<AcceptHeader<ResBody>> {
     /// [`Accept`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
     pub fn accept(value: &str) -> Self
     where
-        ResBody: Body + Default,
+        ResBody: Default,
     {
         Self::custom(AcceptHeader::new(value))
     }
@@ -215,7 +214,7 @@ impl<S, ResBody> ValidateRequestHeader<S, AcceptHeader<ResBody>> {
     /// See `AcceptHeader::new` for when this method panics.
     pub fn accept(inner: S, value: &str) -> Self
     where
-        ResBody: Body + Default,
+        ResBody: Default,
     {
         Self::custom(inner, AcceptHeader::new(value))
     }
@@ -339,7 +338,7 @@ impl<ResBody> AcceptHeader<ResBody> {
     /// Panics if `header_value` is not in the form: `type/subtype`, such as `application/json`
     fn new(header_value: &str) -> Self
     where
-        ResBody: Body + Default,
+        ResBody: Default,
     {
         Self {
             header_value: Arc::new(
@@ -371,7 +370,7 @@ impl<ResBody> fmt::Debug for AcceptHeader<ResBody> {
 
 impl<B, ResBody> ValidateRequest<B> for AcceptHeader<ResBody>
 where
-    ResBody: Body + Default,
+    ResBody: Default,
 {
     type ResponseBody = ResBody;
 


### PR DESCRIPTION
## Motivation

`Body` trait bound does not seem to be needed in these response body type.

## Solution

Removes `Body` trait requirement from these type parameters.
