### PR TITLE
trace: adds back call to classify_eos on trailers

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The implicit `async-compression` feature is removed (BREAKING) ([#642])
 - The implicit `tokio` feature is removed (BREAKING) ([#628])
 
+## Fixed
+
+- `trace`: restore failure classification at end-of-stream ([#483])
+
+[#483]: https://github.com/tower-rs/tower-http/pull/483
 [#628]: https://github.com/tower-rs/tower-http/pull/628
 [#642]: https://github.com/tower-rs/tower-http/pull/642
 

--- a/tower-http/src/trace/body.rs
+++ b/tower-http/src/trace/body.rs
@@ -62,6 +62,13 @@ where
 
                 let frame = match frame.into_trailers() {
                     Ok(trailers) => {
+                        if let Some((classify_eos, mut on_failure)) =
+                            this.classify_eos.take().zip(this.on_failure.take())
+                        {
+                            if let Err(failure_class) = classify_eos.classify_eos(Some(&trailers)) {
+                                on_failure.on_failure(failure_class, latency, this.span);
+                            }
+                        }
                         if let Some((on_eos, stream_start)) = this.on_eos.take() {
                             on_eos.on_eos(Some(&trailers), stream_start.elapsed(), this.span);
                         }

--- a/tower-http/src/trace/body.rs
+++ b/tower-http/src/trace/body.rs
@@ -90,6 +90,13 @@ where
                 Poll::Ready(Some(Err(err)))
             }
             None => {
+                if let Some((classify_eos, mut on_failure)) =
+                    this.classify_eos.take().zip(this.on_failure.take())
+                {
+                    if let Err(failure_class) = classify_eos.classify_eos(None) {
+                        on_failure.on_failure(failure_class, latency, this.span);
+                    }
+                }
                 if let Some((on_eos, stream_start)) = this.on_eos.take() {
                     on_eos.on_eos(None, stream_start.elapsed(), this.span);
                 }

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -683,6 +683,40 @@ mod tests {
         assert_eq!(1, ON_FAILURE.load(Ordering::SeqCst), "failure");
     }
 
+    #[tokio::test]
+    async fn classify_eos_on_empty_stream() {
+        static ON_EOS: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+        static ON_FAILURE: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+
+        let trace_layer = TraceLayer::new(TestClassify::new(true))
+            .on_eos(
+                |_trailers: Option<&HeaderMap>, _latency: Duration, _span: &Span| {
+                    ON_EOS.fetch_add(1, Ordering::SeqCst);
+                },
+            )
+            .on_failure(|_class: &'static str, _latency: Duration, _span: &Span| {
+                ON_FAILURE.fetch_add(1, Ordering::SeqCst);
+            });
+
+        let mut svc = ServiceBuilder::new()
+            .layer(trace_layer)
+            .service_fn(streaming_body);
+
+        let res = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(Request::new(Body::empty()))
+            .await
+            .unwrap();
+
+        crate::test_helpers::to_bytes(res.into_body())
+            .await
+            .unwrap();
+        assert_eq!(1, ON_EOS.load(Ordering::SeqCst), "eos");
+        assert_eq!(1, ON_FAILURE.load(Ordering::SeqCst), "failure");
+    }
+
     async fn echo(req: Request<Body>) -> Result<Response<Body>, BoxError> {
         Ok(Response::new(req.into_body()))
     }

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -615,6 +615,74 @@ mod tests {
         assert_eq!(0, ON_FAILURE.load(Ordering::SeqCst), "failure");
     }
 
+    #[tokio::test]
+    async fn classify_eos_on_trailers_success() {
+        static ON_EOS: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+        static ON_FAILURE: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+
+        let trace_layer = TraceLayer::new(TestClassify::new(false))
+            .on_eos(
+                |_trailers: Option<&HeaderMap>, _latency: Duration, _span: &Span| {
+                    ON_EOS.fetch_add(1, Ordering::SeqCst);
+                },
+            )
+            .on_failure(|_class: &'static str, _latency: Duration, _span: &Span| {
+                ON_FAILURE.fetch_add(1, Ordering::SeqCst);
+            });
+
+        let mut svc = ServiceBuilder::new()
+            .layer(trace_layer)
+            .service_fn(body_with_trailers);
+
+        let res = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(Request::new(Body::empty()))
+            .await
+            .unwrap();
+
+        crate::test_helpers::to_bytes(res.into_body())
+            .await
+            .unwrap();
+        assert_eq!(1, ON_EOS.load(Ordering::SeqCst), "eos");
+        assert_eq!(0, ON_FAILURE.load(Ordering::SeqCst), "failure");
+    }
+
+    #[tokio::test]
+    async fn classify_eos_on_trailers_failure() {
+        static ON_EOS: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+        static ON_FAILURE: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+
+        let trace_layer = TraceLayer::new(TestClassify::new(true))
+            .on_eos(
+                |_trailers: Option<&HeaderMap>, _latency: Duration, _span: &Span| {
+                    ON_EOS.fetch_add(1, Ordering::SeqCst);
+                },
+            )
+            .on_failure(|_class: &'static str, _latency: Duration, _span: &Span| {
+                ON_FAILURE.fetch_add(1, Ordering::SeqCst);
+            });
+
+        let mut svc = ServiceBuilder::new()
+            .layer(trace_layer)
+            .service_fn(body_with_trailers);
+
+        let res = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(Request::new(Body::empty()))
+            .await
+            .unwrap();
+
+        crate::test_helpers::to_bytes(res.into_body())
+            .await
+            .unwrap();
+        assert_eq!(1, ON_EOS.load(Ordering::SeqCst), "eos");
+        assert_eq!(1, ON_FAILURE.load(Ordering::SeqCst), "failure");
+    }
+
     async fn echo(req: Request<Body>) -> Result<Response<Body>, BoxError> {
         Ok(Response::new(req.into_body()))
     }
@@ -631,5 +699,85 @@ mod tests {
         let body = Body::from_stream(stream);
 
         Ok(Response::new(body))
+    }
+
+    async fn body_with_trailers(_req: Request<Body>) -> Result<Response<Body>, BoxError> {
+        let mut trailers = HeaderMap::new();
+        trailers.insert("x-test-trailer", "value".parse().unwrap());
+        let body = Body::new(Body::from(Bytes::from("data")).with_trailers(trailers));
+        Ok(Response::new(body))
+    }
+
+    #[derive(Clone)]
+    struct TestClassify {
+        reject: bool,
+    }
+
+    impl TestClassify {
+        fn new(reject: bool) -> Self {
+            Self { reject }
+        }
+    }
+
+    impl crate::classify::MakeClassifier for TestClassify {
+        type FailureClass = &'static str;
+        type ClassifyEos = TestClassifyEos;
+        type Classifier = TestClassifyResponse;
+
+        fn make_classifier<B>(&self, _req: &Request<B>) -> Self::Classifier {
+            TestClassifyResponse {
+                reject: self.reject,
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestClassifyResponse {
+        reject: bool,
+    }
+
+    impl crate::classify::ClassifyResponse for TestClassifyResponse {
+        type FailureClass = &'static str;
+        type ClassifyEos = TestClassifyEos;
+
+        fn classify_response<B>(
+            self,
+            _res: &Response<B>,
+        ) -> crate::classify::ClassifiedResponse<Self::FailureClass, Self::ClassifyEos> {
+            crate::classify::ClassifiedResponse::RequiresEos(TestClassifyEos {
+                reject: self.reject,
+            })
+        }
+
+        fn classify_error<E>(self, _error: &E) -> Self::FailureClass
+        where
+            E: std::fmt::Display + 'static,
+        {
+            "error"
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestClassifyEos {
+        reject: bool,
+    }
+
+    impl crate::classify::ClassifyEos for TestClassifyEos {
+        type FailureClass = &'static str;
+
+        fn classify_eos(self, _trailers: Option<&HeaderMap>) -> Result<(), Self::FailureClass> {
+            if self.reject {
+                Err("classified as failure")
+            } else {
+                Ok(())
+            }
+        }
+
+        fn classify_error<E>(self, _error: &E) -> Self::FailureClass
+        where
+            E: std::fmt::Display + 'static,
+        {
+            "error"
+        }
     }
 }


### PR DESCRIPTION
- was dropped in the http-body 1.0 upgrade

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

We have some tracing middleware that started as a copy of <https://github.com/EmbarkStudios/server-framework/blob/main/src/middleware/trace.rs>

After upgrading to tower-http 0.5.X one of the tests is failing -

https://github.com/EmbarkStudios/server-framework/blob/1bae7fe7a417443b365d2452007adfe46910037b/src/middleware/trace.rs#L205-L215

```
json atoms at path ".span.otel.status_code" are not equal:
    expected:
        "ERROR"
    actual:
        "OK"
```

## Solution

Adds back call to classify_eos on trailers. 

I've proven with this change the downstream tests pass once more. Notably I haven't attempted to write any tests in this repo - there was a historic desire to rewrite this middleware expessed in <https://github.com/tower-rs/tower-http/issues/365> - I would be amenable to spend some time to upstream some of the tests from <https://github.com/EmbarkStudios/server-framework/blob/main/src/middleware/trace.rs> if considered worthwhile by the maintainers.

