### PR TITLE
chore: bump `sync_wrapper` to v1

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -50,7 +50,7 @@ http-body-util = "0.1.0"
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "tokio"] }
 once_cell = "1"
 serde_json = "1.0"
-sync_wrapper = "0.1.1"
+sync_wrapper = "1"
 tokio = { version = "1", features = ["full"] }
 tower = { version = "0.4.10", features = ["buffer", "util", "retry", "make", "timeout"] }
 tracing-subscriber = "0.3"


### PR DESCRIPTION
## Motivation

Duplicate `sync_wrapper` dependency versions with an `axum` + `tower-http` project

## Solution

Upgrade `sync_wrapper` from version 0.1 to version 1.

Changes (they just promoted to v1): https://github.com/Actyx/sync_wrapper/compare/v0.1.2...v1.0.1
