### PR TITLE
Add `redirect_path_prefix` option

### DIFF
--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -52,6 +52,7 @@ const DEFAULT_CAPACITY: usize = 65536;
 #[derive(Clone, Debug)]
 pub struct ServeDir<F = DefaultServeDirFallback> {
     base: PathBuf,
+    redirect_path_prefix: String,
     buf_chunk_size: usize,
     precompressed_variants: Option<PrecompressedVariants>,
     // This is used to specialize implementation for
@@ -72,6 +73,7 @@ impl ServeDir<DefaultServeDirFallback> {
 
         Self {
             base,
+            redirect_path_prefix: String::new(),
             buf_chunk_size: DEFAULT_CAPACITY,
             precompressed_variants: None,
             variant: ServeVariant::Directory {
@@ -89,6 +91,7 @@ impl ServeDir<DefaultServeDirFallback> {
     {
         Self {
             base: path.as_ref().to_owned(),
+            redirect_path_prefix: String::new(),
             buf_chunk_size: DEFAULT_CAPACITY,
             precompressed_variants: None,
             variant: ServeVariant::SingleFile { mime },
@@ -131,6 +134,23 @@ impl<F> ServeDir<F> {
             }
             ServeVariant::SingleFile { mime: _ } => self,
         }
+    }
+
+    /// Sets a path to be prepended when performing a trailing slash redirect.
+    ///
+    /// This is useful when you want to serve the files at another location than `/`, for example
+    /// when you are using multiple services and want this instance to handle `/static/<path>`.
+    /// In that example, you should pass in `/static` so that a trailing slash redirect does not
+    /// redirect to `/<path>/` but instead to `/static/<path>/`
+    ///
+    /// The default is the empty string.
+    ///
+    /// A trailing slash is removed from the prefix.
+    pub fn redirect_path_prefix(mut self, prefix: impl Into<String>) -> Self {
+        let mut prefix = prefix.into();
+        prefix = prefix.trim_end_matches('/').to_owned();
+        self.redirect_path_prefix = prefix;
+        self
     }
 
     /// Set a specific read buffer chunk size.
@@ -229,6 +249,7 @@ impl<F> ServeDir<F> {
     /// ```
     pub fn fallback<F2>(self, new_fallback: F2) -> ServeDir<F2> {
         ServeDir {
+            redirect_path_prefix: self.redirect_path_prefix,
             base: self.base,
             buf_chunk_size: self.buf_chunk_size,
             precompressed_variants: self.precompressed_variants,
@@ -377,6 +398,8 @@ impl<F> ServeDir<F> {
             }
         };
 
+        let redirect_path_prefix = self.redirect_path_prefix.clone();
+
         let buf_chunk_size = self.buf_chunk_size;
         let range_header = req
             .headers()
@@ -391,16 +414,19 @@ impl<F> ServeDir<F> {
         )
         .collect();
 
-        let variant = self.variant.clone();
+        let open_file_config = open_file::OpenFileConfig {
+            variant: self.variant.clone(),
+            redirect_path_prefix,
+            buf_chunk_size,
+            precompression_configured,
+        };
 
         let open_file_future = Box::pin(open_file::open_file(
-            variant,
+            open_file_config,
             path_to_file,
             req,
             negotiated_encodings,
             range_header,
-            buf_chunk_size,
-            precompression_configured,
         ));
 
         ResponseFuture::open_file_future(open_file_future, fallback_and_request)

--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -144,12 +144,8 @@ impl<F> ServeDir<F> {
     /// redirect to `/<path>/` but instead to `/static/<path>/`
     ///
     /// The default is the empty string.
-    ///
-    /// A trailing slash is removed from the prefix.
     pub fn redirect_path_prefix(mut self, prefix: impl Into<String>) -> Self {
-        let mut prefix = prefix.into();
-        prefix = prefix.trim_end_matches('/').to_owned();
-        self.redirect_path_prefix = prefix;
+        self.redirect_path_prefix = prefix.into();
         self
     }
 

--- a/tower-http/src/services/fs/serve_dir/open_file.rs
+++ b/tower-http/src/services/fs/serve_dir/open_file.rs
@@ -47,15 +47,27 @@ pub(super) enum FileRequestExtent {
     Head(Metadata),
 }
 
+pub(super) struct OpenFileConfig {
+    pub(super) variant: ServeVariant,
+    pub(super) redirect_path_prefix: String,
+    pub(super) buf_chunk_size: usize,
+    pub(super) precompression_configured: bool,
+}
+
 pub(super) async fn open_file(
-    variant: ServeVariant,
+    config: OpenFileConfig,
     mut path_to_file: PathBuf,
     req: Request<Empty<Bytes>>,
     negotiated_encodings: Vec<(Encoding, QValue)>,
     range_header: Option<String>,
-    buf_chunk_size: usize,
-    precompression_configured: bool,
 ) -> io::Result<OpenFileOutput> {
+    let OpenFileConfig {
+        variant,
+        redirect_path_prefix,
+        buf_chunk_size,
+        precompression_configured,
+    } = config;
+
     let preconditions = Preconditions {
         if_match: req
             .headers()
@@ -84,6 +96,7 @@ pub(super) async fn open_file(
             // returned which corresponds to a Some(output). Otherwise the path might be
             // modified and proceed to the open file/metadata future.
             if let Some(output) = maybe_redirect_or_append_path(
+                &redirect_path_prefix,
                 &mut path_to_file,
                 req.uri(),
                 append_index_html_on_directories,
@@ -377,6 +390,7 @@ async fn file_metadata_with_fallback(
 }
 
 async fn maybe_redirect_or_append_path(
+    redirect_path_prefix: &str,
     path_to_file: &mut PathBuf,
     uri: &Uri,
     append_index_html_on_directories: bool,
@@ -408,7 +422,7 @@ async fn maybe_redirect_or_append_path(
         path_to_file.push("index.html");
         None
     } else {
-        let uri = match append_slash_on_path(uri.clone()) {
+        let uri = match append_slash_on_path(uri.clone(), redirect_path_prefix) {
             Ok(uri) => uri,
             Err(err) => return Some(err),
         };
@@ -434,7 +448,7 @@ async fn is_dir(path_to_file: &Path) -> Option<bool> {
         .map(|meta_data| meta_data.is_dir())
 }
 
-fn append_slash_on_path(uri: Uri) -> Result<Uri, OpenFileOutput> {
+fn append_slash_on_path(uri: Uri, redirect_path_prefix: &str) -> Result<Uri, OpenFileOutput> {
     let http::uri::Parts {
         scheme,
         authority,
@@ -454,12 +468,16 @@ fn append_slash_on_path(uri: Uri) -> Result<Uri, OpenFileOutput> {
 
     let uri_builder = if let Some(path_and_query) = path_and_query {
         if let Some(query) = path_and_query.query() {
-            uri_builder.path_and_query(format!("{}/?{}", path_and_query.path(), query))
+            uri_builder.path_and_query(format!(
+                "{redirect_path_prefix}{}/?{}",
+                path_and_query.path(),
+                query
+            ))
         } else {
-            uri_builder.path_and_query(format!("{}/", path_and_query.path()))
+            uri_builder.path_and_query(format!("{redirect_path_prefix}{}/", path_and_query.path()))
         }
     } else {
-        uri_builder.path_and_query("/")
+        uri_builder.path_and_query(format!("{redirect_path_prefix}/"))
     };
 
     uri_builder.build().map_err(|_err| {

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -448,6 +448,48 @@ async fn redirect_to_trailing_slash_on_dir() {
 }
 
 #[tokio::test]
+async fn redirect_to_trailing_slash_with_redirect_path_prefix() {
+    let cases = [
+        ("/foo", "/src", "/foo/src/"),
+        ("/foo/", "/src", "/foo/src/"),
+        ("", "/src", "/src/"),
+        ("/foo", "/src?key=value", "/foo/src/?key=value"),
+        ("/foo", "/s%72c", "/foo/s%72c/"),
+    ];
+
+    for (prefix, uri, expected_location) in cases {
+        let svc = ServeDir::new(".").redirect_path_prefix(prefix);
+
+        let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::TEMPORARY_REDIRECT);
+
+        let location = &res.headers()[http::header::LOCATION];
+        assert_eq!(location, expected_location);
+    }
+}
+
+#[tokio::test]
+async fn redirect_path_prefix_preserved_through_fallback() {
+    async fn fallback<B>(_: Request<B>) -> Result<Response<Body>, Infallible> {
+        Ok(Response::new(Body::empty()))
+    }
+
+    let svc = ServeDir::new(".")
+        .redirect_path_prefix("/foo")
+        .fallback(tower::service_fn(fallback));
+
+    let req = Request::builder().uri("/src").body(Body::empty()).unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::TEMPORARY_REDIRECT);
+
+    let location = &res.headers()[http::header::LOCATION];
+    assert_eq!(location, "/foo/src/");
+}
+
+#[tokio::test]
 async fn empty_directory_without_index() {
     let svc = ServeDir::new(".").append_index_html_on_directories(false);
 

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -451,7 +451,7 @@ async fn redirect_to_trailing_slash_on_dir() {
 async fn redirect_to_trailing_slash_with_redirect_path_prefix() {
     let cases = [
         ("/foo", "/src", "/foo/src/"),
-        ("/foo/", "/src", "/foo/src/"),
+        ("/foo/", "/src", "/foo//src/"),
         ("", "/src", "/src/"),
         ("/foo", "/src?key=value", "/foo/src/?key=value"),
         ("/foo", "/s%72c", "/foo/s%72c/"),


### PR DESCRIPTION
## Motivation

Currently `ServeDir` assumes that the files are served from `/`, which breaks trailing slash redirects in some configurations like a reverse proxy that redirects `/somePath/*` to the `ServeDir` server or a scenario where `axum::Router::nest_service` is used.

## Solution

This allows the user to pass in a string that is prepended to the redirect path.

edit(jplatte): Closes #413