### PR TITLE
Limit zstd window size to web-safe value

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -55,7 +55,7 @@ tokio = { version = "1", features = ["full"] }
 tower = { version = "0.4.10", features = ["buffer", "util", "retry", "make", "timeout"] }
 tracing-subscriber = "0.3"
 uuid = { version = "1.0", features = ["v4"] }
-zstd = "0.12"
+zstd = "0.13"
 
 [features]
 default = []


### PR DESCRIPTION
zstd's memory buffer is limited to 8MB by Chromium and Firefox (at least), but the encoder can exceed that at level 20 and above. This ensures it's limited to 8MB.

See [zstd issue 2712](https://togithub.com/facebook/zstd/issues/2713), [RFC 8878](https://datatracker.ietf.org/doc/html/rfc8878#name-window-descriptor), [Chrome bug 41493659](https://issues.chromium.org/issues/41493659).

To verify, try this:

Cargo.toml:

```toml
[package]
name = "bug-repro"
version = "0.1.0"
edition = "2021"

[dependencies]
anyhow = "1.0.86"
tokio = { version = "1.37", features = ["rt", "rt-multi-thread", "macros"] }
axum = "0.7.5"
#tower-http = { version = "0.5.2", features = ["compression-zstd"] }

[dependencies.tower-http]
git = "https://github.com/AlyoshaVasilieva/tower-http.git"
features = ["compression-zstd"]
rev = "a9575c0bf7098204098bc5ea7949342da9134c3f"

[profile.dev]
opt-level = 1
```

main.rs:

```rust
use std::net::{Ipv4Addr, SocketAddr};

use anyhow::Result;
use axum::routing::get;
use axum::Router;
use tower_http::compression::CompressionLayer;
use tower_http::CompressionLevel;

#[tokio::main]
async fn main() -> Result<()> {
    let router = Router::new()
        .route("/zero", get(zeroes))
        .layer(CompressionLayer::new().quality(CompressionLevel::Precise(20)));
    let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 6612);
    let listener = tokio::net::TcpListener::bind(addr).await?;
    axum::serve(listener, router.into_make_service()).await?;
    Ok(())
}

async fn zeroes() -> String {
    let zeroes = vec![b'0'; 33_554_432];
    String::from_utf8(zeroes).unwrap()
}
```

Accessing `http://127.0.0.1:6612/zero` in recent Firefox/Chrome versions will trigger an error with tower-http 0.5.2, but works with this PR.

Probably fixes #488. It should, but I haven't tested the software involved.

The window size is set for levels >=17, rather than >=20, in case `zstd` ever changes to have larger window sizes at lower presets for some reason, in the hopes that this will cover that too. (I don't think it's very likely that zstd will do that, but this shouldn't do anything at all for presets 17..=19, so it's not harmful.)