### PR TITLE
Make Sealed trait pass cargo-hack CI

### DIFF
--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -372,6 +372,6 @@ pub enum LatencyUnit {
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 mod sealed {
-    #[allow(unreachable_pub)]
+    #[allow(unreachable_pub, unused)]
     pub trait Sealed<T> {}
 }


### PR DESCRIPTION
This fixes the cargo-hack CI step by allowing the `Sealed` trait to be unused.

Alternative solution: Feature-gating `mod sealed` to only compile when the feature `util` is enabled.

I did it this way to avoid needing to add more feature gates if other code wants to rely on `Sealed`, but I can change it to `#[cfg(feature = "util")]` if that's preferred.