### PR TITLE
remove unnecessary sync constraint from async_predicate

### DIFF
--- a/tower-http/src/cors/allow_origin.rs
+++ b/tower-http/src/cors/allow_origin.rs
@@ -87,7 +87,7 @@ impl AllowOrigin {
     pub fn async_predicate<F, Fut>(f: F) -> Self
     where
         F: FnOnce(HeaderValue, &RequestParts) -> Fut + Send + Sync + 'static + Clone,
-        Fut: Future<Output = bool> + Send + Sync + 'static,
+        Fut: Future<Output = bool> + Send + 'static,
     {
         Self(OriginInner::AsyncPredicate(Arc::new(move |v, p| {
             Box::pin((f.clone())(v, p))


### PR DESCRIPTION
This `Sync` constraint on the future made it really hard to use for the real use cases. Plus it doesn't seem necessary.
