### PR TITLE
Fix possible typos in comments

### DIFF
--- a/tower-http/src/builder.rs
+++ b/tower-http/src/builder.rs
@@ -169,7 +169,7 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     where
         I: IntoIterator<Item = HeaderName>;
 
-    /// Mark headers as [sensitive] on both requests.
+    /// Mark headers as [sensitive] on requests.
     ///
     /// See [`tower_http::sensitive_headers`] for more details.
     ///
@@ -181,7 +181,7 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
         headers: std::sync::Arc<[HeaderName]>,
     ) -> ServiceBuilder<Stack<crate::sensitive_headers::SetSensitiveRequestHeadersLayer, L>>;
 
-    /// Mark headers as [sensitive] on both responses.
+    /// Mark headers as [sensitive] on responses.
     ///
     /// See [`tower_http::sensitive_headers`] for more details.
     ///


### PR DESCRIPTION
I believe "both" is extraneous in these two comments and it tripped me up a bit the first time I was trying to understand the different layers.

## Motivation

Make the comments more clear.

## Solution

Remove the words.