### PR TITLE
ci: pin tokio for msrv

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,6 +77,7 @@ jobs:
       uses: taiki-e/install-action@v2
       with:
         tool: protoc@3.20.3
+    - run: cargo update -p tokio --precise 1.38.1
     - run: cargo test -p tower-http --all-features
 
   style:


### PR DESCRIPTION
Latest Tokio has a higher MSRV than we require, but we don't need latest Tokio. So this pins Tokio for the MSRV job.