### PR TITLE
Bump tower to v0.5

### DIFF
--- a/examples/axum-key-value-store/Cargo.toml
+++ b/examples/axum-key-value-store/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 
 [dependencies]
 tokio = { version = "1.32.0", features = ["full"] }
-tower = { version = "0.4.13", features = ["full"] }
+tower = { version = "0.5", features = ["full"] }
 tower-http = { path = "../../tower-http", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }

--- a/examples/tonic-key-value-store/Cargo.toml
+++ b/examples/tonic-key-value-store/Cargo.toml
@@ -14,7 +14,7 @@ tokio = { version = "1.2.0", features = ["full"] }
 futures = "0.3"
 tokio-stream = { version = "0.1", features = ["sync", "net"] }
 tonic = "0.9"
-tower = { version = "0.4.5", features = ["full"] }
+tower = { version = "0.5", features = ["full"] }
 tower-http = { path = "../../tower-http", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/warp-key-value-store/Cargo.toml
+++ b/examples/warp-key-value-store/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "1"
 clap = { version = "4.3.16", features = ["derive"] }
 hyper = { version = "0.14.4", features = ["full"] }
 tokio = { version = "1.2.0", features = ["full"] }
-tower = { version = "0.4.5", features = ["full"] }
+tower = { version = "0.5", features = ["full"] }
 tower-http = { path = "../../tower-http", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -5,13 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# Unreleased
+# 0.6.0
 
 ## Changed:
 
 - `body` module is disabled except for `catch-panic`, `decompression-*`, `fs`, or `limit` features (BREAKING) ([#477])
+- Update to `tower` 0.5 ([#503])
 
 [#477]: https://github.com/tower-rs/tower-http/pull/477
+[#503]: https://github.com/tower-rs/tower-http/pull/503
 
 # 0.5.2
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# 0.6.0
+# 0.6.0 (unreleased)
 
 ## Changed:
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -34,7 +34,7 @@ mime_guess = { version = "2", optional = true, default_features = false }
 percent-encoding = { version = "2.1.0", optional = true }
 tokio = { version = "1.6", optional = true, default_features = false }
 tokio-util = { version = "0.7", optional = true, default_features = false, features = ["io"] }
-tower = { version = "0.4.1", optional = true }
+tower = { version = "0.5", optional = true }
 tracing = { version = "0.1", default_features = false, optional = true }
 httpdate = { version = "1.0", optional = true }
 uuid = { version = "1.0", features = ["v4"], optional = true }
@@ -52,7 +52,7 @@ once_cell = "1"
 serde_json = "1.0"
 sync_wrapper = "1"
 tokio = { version = "1", features = ["full"] }
-tower = { version = "0.4.10", features = ["buffer", "util", "retry", "make", "timeout"] }
+tower = { version = "0.5", features = ["buffer", "util", "retry", "make", "timeout"] }
 tracing-subscriber = "0.3"
 uuid = { version = "1.0", features = ["v4"] }
 zstd = "0.13"


### PR DESCRIPTION
I see `tower` 0.5 came out but `tower-http` hadn't upgraded yet. I've fixed all compilation issues and now it seems to work.