### PR TITLE
Fix -Zminimal-versions build

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -17,7 +17,7 @@ bitflags = "2.0.2"
 bytes = "1"
 http = "1.0"
 pin-project-lite = "0.2.7"
-tower-layer = "0.3"
+tower-layer = "0.3.3"
 tower-service = "0.3"
 
 # optional dependencies


### PR DESCRIPTION
## Motivation

Building with `-Zminimal-versions` fails because `tower_layer::Identity::new` is not const.

## Solution

Bumps the minimum version requirement for `tower-layer` to the first version that had it const.
