### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -114,7 +114,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@nightly
+    # Pinned version due to failing `cargo-public-api-crates`.
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2024-06-06
     - uses: Swatinem/rust-cache@v2
     - name: Install cargo-public-api-crates
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -122,5 +122,8 @@ jobs:
     - name: Install cargo-public-api-crates
       run: |
         cargo install --git https://github.com/davidpdrsn/cargo-public-api-crates
+    - name: Build rustdoc
+      run: |
+        cargo rustdoc --all-features --manifest-path tower-http/Cargo.toml -- -Z unstable-options --output-format json
     - name: cargo public-api-crates check
-      run: cargo public-api-crates --manifest-path tower-http/Cargo.toml check
+      run: cargo public-api-crates --manifest-path tower-http/Cargo.toml --skip-build check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - name: Install protoc
       uses: taiki-e/install-action@v2
@@ -21,7 +21,7 @@ jobs:
   check-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - name: Install protoc
       uses: taiki-e/install-action@v2
@@ -36,7 +36,7 @@ jobs:
   cargo-hack:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - uses: taiki-e/install-action@cargo-hack
     - name: Install protoc
@@ -57,7 +57,7 @@ jobs:
       matrix:
         rust: [stable, beta, nightly]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
@@ -71,7 +71,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@1.66
     - name: Install protoc
       uses: taiki-e/install-action@v2
@@ -84,7 +84,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt
@@ -104,7 +104,7 @@ jobs:
         - advisories
         - bans licenses sources
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: EmbarkStudios/cargo-deny-action@v1
       with:
         manifest-path: tower-http/Cargo.toml
@@ -113,7 +113,7 @@ jobs:
   cargo-public-api-crates:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v2
     - name: Install cargo-public-api-crates

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,6 +78,7 @@ jobs:
       with:
         tool: protoc@3.20.3
     - run: cargo update -p tokio --precise 1.38.1
+    - run: cargo update -p tokio-util --precise 0.7.11
     - run: cargo test -p tower-http --all-features
 
   style:


### PR DESCRIPTION
## Motivation

tokio-util v0.7.12 has bumped its MSRV, and CI is failing.
`cargo public-api-crates` is also failing due to rustdoc JSON changes.

## Solution

Have the MSRV job downgrade tokio-util, pin a nightly for public-api-crates. Also upgrade the checkout action, bc. why not.