### PR TITLE
Release tower-http v0.6.0

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# 0.6.0 (unreleased)
+# 0.6.0
 
 ## Changed:
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tower-http"
 description = "Tower middleware and utilities for HTTP clients and servers"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION

## Changed:

- `body` module is disabled except for `catch-panic`, `decompression-*`, `fs`, or `limit` features (BREAKING) ([#477])
- Update to `tower` 0.5 ([#503])
## Fixed
- **fs:** Precompression of static files now supports files without a file extension ([#507])

[#477]: https://github.com/tower-rs/tower-http/pull/477
[#503]: https://github.com/tower-rs/tower-http/pull/503
[#507]: https://github.com/tower-rs/tower-http/pull/507