### PR TITLE
Update brotli dev-dependency from 6 to 7

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -41,7 +41,7 @@ uuid = { version = "1.0", features = ["v4"], optional = true }
 
 [dev-dependencies]
 async-trait = "0.1"
-brotli = "6"
+brotli = "7"
 bytes = "1"
 flate2 = "1.0"
 futures-util = "0.3.14"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Version 7.0.0 of the `brotli` crate was just relased. There were few changes between 6.0.0 and 7.0.0, and it looks like https://github.com/dropbox/rust-brotli/commit/41cadaabb6c650ae518b30509a5fbe43ca8cfab9 was the only breaking one. I see no reason not to keep this dev-dependency up to date.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I adjusted the version of `brotli` from `6` to `7` and confirmed that `cargo test` still passes.