### PR TITLE
Set `size_hint` for identity compession bodies

### DIFF
--- a/tower-http/src/compression/body.rs
+++ b/tower-http/src/compression/body.rs
@@ -269,6 +269,14 @@ where
             },
         }
     }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        if let BodyInner::Identity { inner } = &self.inner {
+            inner.size_hint()
+        } else {
+            http_body::SizeHint::new()
+        }
+    }
 }
 
 #[cfg(feature = "compression-gzip")]


### PR DESCRIPTION
## Motivation

See https://github.com/tokio-rs/axum/issues/3035#issuecomment-2481680119

## Solution

Override the `size_hint` on identity compression bodies.