### PR TITLE
body timeout - remove unnecessary bounds on service error

### DIFF
--- a/tower-http/src/timeout/service.rs
+++ b/tower-http/src/timeout/service.rs
@@ -165,7 +165,6 @@ impl<S> RequestBodyTimeout<S> {
 impl<S, ReqBody> Service<Request<ReqBody>> for RequestBodyTimeout<S>
 where
     S: Service<Request<TimeoutBody<ReqBody>>>,
-    S::Error: Into<Box<dyn std::error::Error>>,
 {
     type Response = S::Response;
     type Error = S::Error;
@@ -212,7 +211,6 @@ pub struct ResponseBodyTimeout<S> {
 impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for ResponseBodyTimeout<S>
 where
     S: Service<Request<ReqBody>, Response = Response<ResBody>>,
-    S::Error: Into<Box<dyn std::error::Error>>,
 {
     type Response = Response<TimeoutBody<ResBody>>;
     type Error = S::Error;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

Removing these bounds `S::Error: Into<Box<dyn std::error::Error>>` allows these layers to be used with e.g. tower-test which supplies `Box<dyn std::error::Error + Send + Sync>` aka `BoxError`

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Drop unnecessary bounds - the service error, whatever that may be, is passed straight through
