### PR TITLE
compression: the identity body should respect is_end_stream

### DIFF
--- a/tower-http/src/compression/body.rs
+++ b/tower-http/src/compression/body.rs
@@ -277,6 +277,14 @@ where
             http_body::SizeHint::new()
         }
     }
+
+    fn is_end_stream(&self) -> bool {
+        if let BodyInner::Identity { inner } = &self.inner {
+            inner.is_end_stream()
+        } else {
+            false
+        }
+    }
 }
 
 #[cfg(feature = "compression-gzip")]


### PR DESCRIPTION
This breaks certain gRPC failure scenarios when not compressing.

I don't have the bandwidth to work on tests right now but will circle back later if I have time.
