### PR TITLE
Add conversions into `UnsyncBoxBody`

### DIFF
--- a/tower-http/src/body.rs
+++ b/tower-http/src/body.rs
@@ -103,6 +103,12 @@ where
     }
 }
 
+impl<D, E> From<UnsyncBoxBody<D, E>> for http_body_util::combinators::UnsyncBoxBody<D, E> {
+    fn from(body: UnsyncBoxBody<D, E>) -> Self {
+        body.inner
+    }
+}
+
 impl<D, E> UnsyncBoxBody<D, E> {
     #[allow(dead_code)]
     pub(crate) fn new(inner: http_body_util::combinators::UnsyncBoxBody<D, E>) -> Self {

--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -493,6 +493,12 @@ opaque_body! {
     pub type ResponseBody = UnsyncBoxBody<Bytes, io::Error>;
 }
 
+impl From<ResponseBody> for http_body_util::combinators::UnsyncBoxBody<Bytes, io::Error> {
+    fn from(body: ResponseBody) -> Self {
+        body.inner.inner
+    }
+}
+
 /// The default fallback service used with [`ServeDir`].
 #[derive(Debug, Clone, Copy)]
 pub struct DefaultServeDirFallback(Infallible);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

I want to return http bodies of different types, for example from multiple match branches. The easiest way to do this is to box the body like:
```rust
use {http_body_util::combinators::UnsyncBoxBody, /**/};

let serve = ServeFile::new(/**/);
let res = match req.uri().path() {
    "s1" => Ok(Response::new(UnsyncBoxBody::new(/**/))),
    "s2" => Ok(Response::new(UnsyncBoxBody::new(/**/))),
    _ => serve
        .oneshot(req)
        .await
        .map(|res| res.map(UnsyncBoxBody::new)),
};
```
But in the case of the body type from the `ServeFile`/`ServeDir` service, I have to box what is already boxed. This requires double allocation and, more critically, double indirection. I would like to avoid these overhead costs.

## Solution

My proposal to add a conversion impl into the [`UnsyncBoxBody`](https://docs.rs/http-body-util/latest/http_body_util/combinators/struct.UnsyncBoxBody.html) type. This eliminates the need for additional boxing:
```diff
- .map(|res| res.map(UnsyncBoxBody::new))
+ .map(|res| res.map(UnsyncBoxBody::from))
```

## Alternatives
- I could use the [`Either`](https://docs.rs/http-body-util/latest/http_body_util/enum.Either.html) type, but it's not convenient with more than two different types. I could do infinite levels of nesting, but I want a more straightforward solution.
- I could use the service's [`fallback`](https://docs.rs/tower-http/latest/tower_http/services/fs/struct.ServeDir.html#method.fallback) method, but I want to resolve routes at a higher level, e.g. preferring a route even if a file with same name exists.
- If exposing implementation details is undesirable, it could be converted directly to the `Pin<Box<dyn Body<Data = D, Error = E> + Send>>` type.

