### PR TITLE
chore(request-id): change X_REQUEST_ID constant HeaderName

### DIFF
--- a/tower-http/src/builder.rs
+++ b/tower-http/src/builder.rs
@@ -302,10 +302,7 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     where
         M: crate::request_id::MakeRequestId,
     {
-        self.set_request_id(
-            HeaderName::from_static(crate::request_id::X_REQUEST_ID),
-            make_request_id,
-        )
+        self.set_request_id(crate::request_id::X_REQUEST_ID, make_request_id)
     }
 
     /// Propgate request ids from requests to responses.
@@ -328,7 +325,7 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     fn propagate_x_request_id(
         self,
     ) -> ServiceBuilder<Stack<crate::request_id::PropagateRequestIdLayer, L>> {
-        self.propagate_request_id(HeaderName::from_static(crate::request_id::X_REQUEST_ID))
+        self.propagate_request_id(crate::request_id::X_REQUEST_ID)
     }
 
     /// Catch panics and convert them into `500 Internal Server` responses.

--- a/tower-http/src/request_id.rs
+++ b/tower-http/src/request_id.rs
@@ -181,7 +181,7 @@ use tower_layer::Layer;
 use tower_service::Service;
 use uuid::Uuid;
 
-pub(crate) const X_REQUEST_ID: &str = "x-request-id";
+pub(crate) const X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
 
 /// Trait for producing [`RequestId`]s.
 ///
@@ -246,7 +246,7 @@ impl<M> SetRequestIdLayer<M> {
     where
         M: MakeRequestId,
     {
-        SetRequestIdLayer::new(HeaderName::from_static(X_REQUEST_ID), make_request_id)
+        SetRequestIdLayer::new(X_REQUEST_ID, make_request_id)
     }
 }
 
@@ -299,11 +299,7 @@ impl<S, M> SetRequestId<S, M> {
     where
         M: MakeRequestId,
     {
-        Self::new(
-            inner,
-            HeaderName::from_static(X_REQUEST_ID),
-            make_request_id,
-        )
+        Self::new(inner, X_REQUEST_ID, make_request_id)
     }
 
     define_inner_service_accessors!();
@@ -365,7 +361,7 @@ impl PropagateRequestIdLayer {
 
     /// Create a new `PropagateRequestIdLayer` that uses `x-request-id` as the header name.
     pub fn x_request_id() -> Self {
-        Self::new(HeaderName::from_static(X_REQUEST_ID))
+        Self::new(X_REQUEST_ID)
     }
 }
 
@@ -397,7 +393,7 @@ impl<S> PropagateRequestId<S> {
 
     /// Create a new `PropagateRequestId` that uses `x-request-id` as the header name.
     pub fn x_request_id(inner: S) -> Self {
-        Self::new(inner, HeaderName::from_static(X_REQUEST_ID))
+        Self::new(inner, X_REQUEST_ID)
     }
 
     define_inner_service_accessors!();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

This constant seems to be used for HeaderName.

## Solution

Changes the constant to HeaderName.