### PR TITLE
feat(redirect): add `new` method for `Attempt`

### DIFF
--- a/tower-http/src/follow_redirect/policy/mod.rs
+++ b/tower-http/src/follow_redirect/policy/mod.rs
@@ -217,6 +217,15 @@ impl<'a> Attempt<'a> {
     pub fn previous(&self) -> &'a Uri {
         self.previous
     }
+
+    /// Creates a new `Attempt`.
+    pub fn new(status: StatusCode, location: &'a Uri, previous: &'a Uri) -> Self {
+        Self {
+            status,
+            location,
+            previous,
+        }
+    }
 }
 
 /// A value returned by [`Policy::redirect`] which indicates the action


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Due to `Attempt` fields are all private, that dissallows producting `Attempt` outside.

My another PR needs a way to construct a `tower-http` Attempt, see https://github.com/seanmonstar/reqwest/pull/2617

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add a `new` method and passing all the needed fileds to produce the `Attempt`.  This way has less expansibility when adding new fields to `Attempt`. 








