### PR TITLE
Return 0 content length for range requests for empty files

### DIFF
--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -269,12 +269,18 @@ fn build_response(output: FileOpened) -> Response<ResponseBody> {
                         empty_body()
                     };
 
+                    let content_length = if size == 0 {
+                        0
+                    } else {
+                        range.end() - range.start() + 1
+                    };
+
                     builder
                         .header(
                             header::CONTENT_RANGE,
                             format!("bytes {}-{}/{}", range.start(), range.end(), size),
                         )
-                        .header(header::CONTENT_LENGTH, range.end() - range.start() + 1)
+                        .header(header::CONTENT_LENGTH, content_length)
                         .status(StatusCode::PARTIAL_CONTENT)
                         .body(body)
                         .unwrap()

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -507,6 +507,25 @@ async fn access_space_percent_encoded_uri_path() {
 }
 
 #[tokio::test]
+async fn read_partial_empty() {
+    let svc = ServeDir::new("../test-files");
+
+    let req = Request::builder()
+        .uri("/empty.txt")
+        .header("Range", "bytes=0-")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::PARTIAL_CONTENT);
+    assert_eq!(res.headers()["content-length"], "0");
+    assert_eq!(res.headers()["content-range"], "bytes 0-0/0");
+
+    let body = to_bytes(res.into_body()).await.ok().unwrap();
+    assert!(body.is_empty());
+}
+
+#[tokio::test]
 async fn read_partial_in_bounds() {
     let svc = ServeDir::new("..");
     let bytes_start_incl = 9;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

Also came up here: https://github.com/seanmonstar/reqwest/issues/1559#issuecomment-2788796161

Currently tower-http's `ServeDir` handles range requests for empty files slightly incorrectly, it returns a correctly empty `Content-Range` but the `Content-Length` is set to `1`. Which causes troubles in `reqwest` (it tries to read 1 byte which never comes).

For example:

```
└─ %  curl http://localhost:49488/files/index.android.bundle -i -H "Range: bytes=0-"
HTTP/1.1 206 Partial Content
content-type: application/octet-stream
accept-ranges: bytes
last-modified: Thu, 09 Jan 2025 08:11:11 GMT
content-range: bytes 0-0/0
content-length: 1
date: Wed, 09 Apr 2025 08:36:05 GMT

curl: (18) transfer closed with 1 bytes remaining to read

┌─── ~ 
└─ %  curl http://localhost:49488/files/index.android.bundle -i                     
HTTP/1.1 200 OK
content-type: application/octet-stream
accept-ranges: bytes
last-modified: Thu, 09 Jan 2025 08:11:11 GMT
content-length: 0
date: Wed, 09 Apr 2025 08:36:11 GMT
```

## Solution

For empty files, return a content length of 1, instead of calculating it from the inclusive range.