### PR TITLE
Update mod.rs

### DIFF
--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -477,7 +477,7 @@ impl ServeVariant {
                                     return None;
                                 }
                             }
-                            
+
                             path_to_file.push(comp);
                         }
                         Component::CurDir => {}

--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -465,14 +465,20 @@ impl ServeVariant {
                     match component {
                         Component::Normal(comp) => {
                             // protect against paths like `/foo/c:/bar/baz` (#204)
-                            if Path::new(&comp)
-                                .components()
-                                .all(|c| matches!(c, Component::Normal(_)))
+                            // does not work on unix like machines
+                            #[cfg(target_os = "windows")]
                             {
-                                path_to_file.push(comp)
-                            } else {
-                                return None;
+                                // if any of the path of the components are not of Component::Normal
+                                // return None
+                                if Path::new(&comp).components().any(|c| match c {
+                                    Component::Normal(_) => false,
+                                    _ => true,
+                                }) {
+                                    return None;
+                                }
                             }
+                            
+                            path_to_file.push(comp);
                         }
                         Component::CurDir => {}
                         Component::Prefix(_) | Component::RootDir | Component::ParentDir => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

The component check only works on windows. If this was run on linux, the code will always push the component to the path_to_file variable, even if it contains c: in the path. 

## Solution

Use #[cfg(target_os = "windows")] to disable it
