### PR TITLE
follow_redirect: expose previous and next request methods

### DIFF
--- a/tower-http/src/follow_redirect/mod.rs
+++ b/tower-http/src/follow_redirect/mod.rs
@@ -310,7 +310,7 @@ where
 
         let attempt = Attempt {
             status: res.status(),
-            next_method: &this.method,
+            method: this.method,
             location: &location,
             previous_method,
             previous: this.uri,
@@ -446,6 +446,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stops_post_redirect_get() {
+        let policy = policy::redirect_fn(|attempt| -> Result<_, Infallible> {
+            if attempt.previous_method() == Method::POST && attempt.method() == Method::GET {
+                Ok(Action::Stop)
+            } else {
+                Ok(Action::Follow)
+            }
+        });
+        let svc = ServiceBuilder::new()
+            .layer(FollowRedirectLayer::with_policy(policy))
+            .service_fn(handle);
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("http://example.com/42")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.oneshot(req).await.unwrap();
+        assert_eq!(*res.body(), 42);
+        assert_eq!(
+            res.extensions().get::<RequestUri>().unwrap().0,
+            "http://example.com/42"
+        );
+    }
+
+    #[tokio::test]
     async fn limited() {
         let svc = ServiceBuilder::new()
             .layer(FollowRedirectLayer::with_policy(Limited::new(10)))
@@ -463,7 +488,7 @@ mod tests {
         );
     }
 
-    /// A server with an endpoint `GET /{n}` which redirects to `/{n-1}` unless `n` equals zero,
+    /// A server with an endpoint `/{n}` which redirects to `/{n-1}` unless `n` equals zero,
     /// returning `n` as the response body.
     async fn handle<B>(req: Request<B>) -> Result<Response<u64>, Infallible> {
         let n: u64 = req.uri().path()[1..].parse().unwrap();

--- a/tower-http/src/follow_redirect/mod.rs
+++ b/tower-http/src/follow_redirect/mod.rs
@@ -259,6 +259,7 @@ where
         let mut res = ready!(this.future.as_mut().poll(cx)?);
         res.extensions_mut().insert(RequestUri(this.uri.clone()));
 
+        let previous_method = &this.method.clone();
         let drop_payload_headers = |headers: &mut HeaderMap| {
             for header in &[
                 CONTENT_TYPE,
@@ -309,7 +310,9 @@ where
 
         let attempt = Attempt {
             status: res.status(),
+            next_method: &this.method,
             location: &location,
+            previous_method,
             previous: this.uri,
         };
         match this.policy.redirect(&attempt)? {

--- a/tower-http/src/follow_redirect/mod.rs
+++ b/tower-http/src/follow_redirect/mod.rs
@@ -259,7 +259,7 @@ where
         let mut res = ready!(this.future.as_mut().poll(cx)?);
         res.extensions_mut().insert(RequestUri(this.uri.clone()));
 
-        let previous_method = &this.method.clone();
+        let previous_method = this.method.clone();
         let drop_payload_headers = |headers: &mut HeaderMap| {
             for header in &[
                 CONTENT_TYPE,
@@ -312,7 +312,7 @@ where
             status: res.status(),
             method: this.method,
             location: &location,
-            previous_method,
+            previous_method: &previous_method,
             previous: this.uri,
         };
         match this.policy.redirect(&attempt)? {
@@ -446,31 +446,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stops_post_redirect_get() {
-        let policy = policy::redirect_fn(|attempt| -> Result<_, Infallible> {
-            if attempt.previous_method() == Method::POST && attempt.method() == Method::GET {
-                Ok(Action::Stop)
-            } else {
-                Ok(Action::Follow)
-            }
-        });
-        let svc = ServiceBuilder::new()
-            .layer(FollowRedirectLayer::with_policy(policy))
-            .service_fn(handle);
-        let req = Request::builder()
-            .method(Method::POST)
-            .uri("http://example.com/42")
-            .body(Body::empty())
-            .unwrap();
-        let res = svc.oneshot(req).await.unwrap();
-        assert_eq!(*res.body(), 42);
-        assert_eq!(
-            res.extensions().get::<RequestUri>().unwrap().0,
-            "http://example.com/42"
-        );
-    }
-
-    #[tokio::test]
     async fn limited() {
         let svc = ServiceBuilder::new()
             .layer(FollowRedirectLayer::with_policy(Limited::new(10)))
@@ -499,6 +474,264 @@ mod tests {
                 .header(LOCATION, format!("/{}", n - 1));
         }
         Ok::<_, Infallible>(res.body(n).unwrap())
+    }
+
+    #[tokio::test]
+    async fn test_301_redirects() {
+        let policy = policy::redirect_fn(|attempt| -> Result<_, Infallible> {
+            if attempt.previous_method() == Method::POST && attempt.method() == Method::GET {
+                Ok(Action::Stop)
+            } else {
+                Ok(Action::Follow)
+            }
+        });
+        let svc = ServiceBuilder::new()
+            .layer(FollowRedirectLayer::with_policy(policy))
+            .service_fn(redirections);
+
+        // A POST request with a 301 redirection should turn into a GET
+        // request, and the policy should stop the redirection.
+        {
+            let req = Request::builder()
+                .method(Method::POST)
+                .uri("http://example.com/301")
+                .body(Body::empty())
+                .unwrap();
+            let res = svc.clone().oneshot(req).await.unwrap();
+            assert_eq!(*res.body(), "/target/301");
+            assert_eq!(
+                res.extensions().get::<RequestUri>().unwrap().0,
+                "http://example.com/301"
+            );
+        }
+
+        // A GET request with a 301 redirection should remain a GET
+        // request, and the policy should allow the redirection.
+        {
+            let req = Request::builder()
+                .method(Method::GET)
+                .uri("http://example.com/301")
+                .body(Body::empty())
+                .unwrap();
+            let res = svc.clone().oneshot(req).await.unwrap();
+            assert_eq!(*res.body(), "/target/301/final");
+            assert_eq!(
+                res.extensions().get::<RequestUri>().unwrap().0,
+                "http://example.com/target/301"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_302_redirects() {
+        let policy = policy::redirect_fn(|attempt| -> Result<_, Infallible> {
+            if attempt.previous_method() != attempt.method() {
+                Ok(Action::Stop)
+            } else {
+                Ok(Action::Follow)
+            }
+        });
+        let svc = ServiceBuilder::new()
+            .layer(FollowRedirectLayer::with_policy(policy))
+            .service_fn(redirections);
+
+        // A POST request with a 302 redirection should turn into a GET
+        // request, and the policy should stop the redirection.
+        {
+            let req = Request::builder()
+                .method(Method::POST)
+                .uri("http://example.com/302")
+                .body(Body::empty())
+                .unwrap();
+            let res = svc.clone().oneshot(req).await.unwrap();
+            assert_eq!(*res.body(), "/target/302");
+            assert_eq!(
+                res.extensions().get::<RequestUri>().unwrap().0,
+                "http://example.com/302"
+            );
+        }
+
+        // A PUT request with a 302 redirection should remain a PUT
+        // request, and the policy should allow the redirection.
+        {
+            let req = Request::builder()
+                .method(Method::PUT)
+                .uri("http://example.com/302")
+                .body(Body::empty())
+                .unwrap();
+            let res = svc.clone().oneshot(req).await.unwrap();
+            assert_eq!(*res.body(), "/target/302/final");
+            assert_eq!(
+                res.extensions().get::<RequestUri>().unwrap().0,
+                "http://example.com/target/302"
+            );
+        }
+
+        // A HEAD request with a 302 redirection should remain a HEAD
+        // request, and the policy should allow the redirection.
+        {
+            let req = Request::builder()
+                .method(Method::HEAD)
+                .uri("http://example.com/302")
+                .body(Body::empty())
+                .unwrap();
+            let res = svc.clone().oneshot(req).await.unwrap();
+            assert_eq!(*res.body(), "/target/302/final");
+            assert_eq!(
+                res.extensions().get::<RequestUri>().unwrap().0,
+                "http://example.com/target/302"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_303_redirects() {
+        let policy = policy::redirect_fn(|attempt| -> Result<_, Infallible> {
+            if attempt.previous_method() != attempt.method() {
+                Ok(Action::Stop)
+            } else {
+                Ok(Action::Follow)
+            }
+        });
+        let svc = ServiceBuilder::new()
+            .layer(FollowRedirectLayer::with_policy(policy))
+            .service_fn(redirections);
+
+        // A POST request with a 303 redirection should turn into a GET
+        // request, and the policy should stop the redirection.
+        {
+            let req = Request::builder()
+                .method(Method::POST)
+                .uri("http://example.com/303")
+                .body(Body::empty())
+                .unwrap();
+            let res = svc.clone().oneshot(req).await.unwrap();
+            assert_eq!(*res.body(), "/target/303");
+            assert_eq!(
+                res.extensions().get::<RequestUri>().unwrap().0,
+                "http://example.com/303"
+            );
+        }
+
+        // A PUT request with a 303 redirection should turn into a GET
+        // request, and the policy should stop the redirection.
+        {
+            let req = Request::builder()
+                .method(Method::PUT)
+                .uri("http://example.com/303")
+                .body(Body::empty())
+                .unwrap();
+            let res = svc.clone().oneshot(req).await.unwrap();
+            assert_eq!(*res.body(), "/target/303");
+            assert_eq!(
+                res.extensions().get::<RequestUri>().unwrap().0,
+                "http://example.com/303"
+            );
+        }
+
+        // A HEAD request with a 303 redirection should remain a HEAD
+        // request, and the policy should allow the redirection.
+        {
+            let req = Request::builder()
+                .method(Method::HEAD)
+                .uri("http://example.com/303")
+                .body(Body::empty())
+                .unwrap();
+            let res = svc.clone().oneshot(req).await.unwrap();
+            assert_eq!(*res.body(), "/target/303/final");
+            assert_eq!(
+                res.extensions().get::<RequestUri>().unwrap().0,
+                "http://example.com/target/303"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_307_308_redirects() {
+        let policy = policy::redirect_fn(|attempt| -> Result<_, Infallible> {
+            if attempt.previous_method() != Method::POST || attempt.method() != Method::POST {
+                Ok(Action::Stop)
+            } else {
+                Ok(Action::Follow)
+            }
+        });
+        let svc = ServiceBuilder::new()
+            .layer(FollowRedirectLayer::with_policy(policy))
+            .service_fn(redirections);
+
+        // A POST request with a 307 redirection should remain a POST
+        // request, and the policy should allow the redirection.
+        {
+            let req = Request::builder()
+                .method(Method::POST)
+                .uri("http://example.com/307")
+                .body(Body::empty())
+                .unwrap();
+            let res = svc.clone().oneshot(req).await.unwrap();
+            assert_eq!(*res.body(), "/target/307/final");
+            assert_eq!(
+                res.extensions().get::<RequestUri>().unwrap().0,
+                "http://example.com/target/307"
+            );
+        }
+
+        // A POST request with a 308 redirection should remain a POST
+        // request, and the policy should allow the redirection.
+        {
+            let req = Request::builder()
+                .method(Method::POST)
+                .uri("http://example.com/308")
+                .body(Body::empty())
+                .unwrap();
+            let res = svc.clone().oneshot(req).await.unwrap();
+            assert_eq!(*res.body(), "/target/308/final");
+            assert_eq!(
+                res.extensions().get::<RequestUri>().unwrap().0,
+                "http://example.com/target/308"
+            );
+        }
+    }
+
+    /// Returns different 3xx redirections based on the request's URI.
+    async fn redirections<B>(req: Request<B>) -> Result<Response<String>, Infallible> {
+        let path = req.uri().path();
+        let mut res = Response::builder();
+        let body_str;
+        res = match path {
+            "/301" => {
+                let case = "/target/301";
+                body_str = case.to_string();
+                res.status(StatusCode::MOVED_PERMANENTLY)
+                    .header(LOCATION, case)
+            }
+            "/302" => {
+                let case = "/target/302";
+                body_str = case.to_string();
+                res.status(StatusCode::FOUND).header(LOCATION, case)
+            }
+            "/303" => {
+                let case = "/target/303";
+                body_str = case.to_string();
+                res.status(StatusCode::SEE_OTHER).header(LOCATION, case)
+            }
+            "/307" => {
+                let case = "/target/307";
+                body_str = case.to_string();
+                res.status(StatusCode::TEMPORARY_REDIRECT)
+                    .header(LOCATION, case)
+            }
+            "/308" => {
+                let case = "/target/308";
+                body_str = case.to_string();
+                res.status(StatusCode::PERMANENT_REDIRECT)
+                    .header(LOCATION, case)
+            }
+            v => {
+                body_str = format!("{v}/final");
+                res.status(StatusCode::OK)
+            }
+        };
+        Ok::<_, Infallible>(res.body(body_str).unwrap())
     }
 
     #[tokio::test]

--- a/tower-http/src/follow_redirect/policy/and.rs
+++ b/tower-http/src/follow_redirect/policy/and.rs
@@ -45,7 +45,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use http::Uri;
+    use http::{Method, Uri};
 
     struct Taint<P> {
         policy: P,
@@ -75,7 +75,9 @@ mod tests {
     fn redirect() {
         let attempt = Attempt {
             status: Default::default(),
+            next_method: &Method::GET,
             location: &Uri::from_static("*"),
+            previous_method: &Method::GET,
             previous: &Uri::from_static("*"),
         };
 

--- a/tower-http/src/follow_redirect/policy/and.rs
+++ b/tower-http/src/follow_redirect/policy/and.rs
@@ -75,7 +75,7 @@ mod tests {
     fn redirect() {
         let attempt = Attempt {
             status: Default::default(),
-            next_method: &Method::GET,
+            method: &Method::GET,
             location: &Uri::from_static("*"),
             previous_method: &Method::GET,
             previous: &Uri::from_static("*"),

--- a/tower-http/src/follow_redirect/policy/filter_credentials.rs
+++ b/tower-http/src/follow_redirect/policy/filter_credentials.rs
@@ -106,7 +106,7 @@ impl<B, E> Policy<B, E> for FilterCredentials {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use http::Uri;
+    use http::{Method, Uri};
 
     #[test]
     fn works() {
@@ -126,7 +126,9 @@ mod tests {
 
         let attempt = Attempt {
             status: Default::default(),
+            next_method: &Method::GET,
             location: &same_origin,
+            previous_method: &Method::GET,
             previous: request.uri(),
         };
         assert!(Policy::<(), ()>::redirect(&mut policy, &attempt)
@@ -143,7 +145,9 @@ mod tests {
 
         let attempt = Attempt {
             status: Default::default(),
+            next_method: &Method::GET,
             location: &cross_origin,
+            previous_method: &Method::GET,
             previous: request.uri(),
         };
         assert!(Policy::<(), ()>::redirect(&mut policy, &attempt)

--- a/tower-http/src/follow_redirect/policy/filter_credentials.rs
+++ b/tower-http/src/follow_redirect/policy/filter_credentials.rs
@@ -126,7 +126,7 @@ mod tests {
 
         let attempt = Attempt {
             status: Default::default(),
-            next_method: &Method::GET,
+            method: &Method::GET,
             location: &same_origin,
             previous_method: &Method::GET,
             previous: request.uri(),
@@ -145,7 +145,7 @@ mod tests {
 
         let attempt = Attempt {
             status: Default::default(),
-            next_method: &Method::GET,
+            method: &Method::GET,
             location: &cross_origin,
             previous_method: &Method::GET,
             previous: request.uri(),

--- a/tower-http/src/follow_redirect/policy/limited.rs
+++ b/tower-http/src/follow_redirect/policy/limited.rs
@@ -36,7 +36,7 @@ impl<B, E> Policy<B, E> for Limited {
 
 #[cfg(test)]
 mod tests {
-    use http::{Request, Uri};
+    use http::{Method, Request, Uri};
 
     use super::*;
 
@@ -51,7 +51,9 @@ mod tests {
 
             let attempt = Attempt {
                 status: Default::default(),
+                next_method: &Method::GET,
                 location: &uri,
+                previous_method: &Method::GET,
                 previous: &uri,
             };
             assert!(Policy::<(), ()>::redirect(&mut policy, &attempt)
@@ -64,7 +66,9 @@ mod tests {
 
         let attempt = Attempt {
             status: Default::default(),
+            next_method: &Method::GET,
             location: &uri,
+            previous_method: &Method::GET,
             previous: &uri,
         };
         assert!(Policy::<(), ()>::redirect(&mut policy, &attempt)

--- a/tower-http/src/follow_redirect/policy/limited.rs
+++ b/tower-http/src/follow_redirect/policy/limited.rs
@@ -51,7 +51,7 @@ mod tests {
 
             let attempt = Attempt {
                 status: Default::default(),
-                next_method: &Method::GET,
+                method: &Method::GET,
                 location: &uri,
                 previous_method: &Method::GET,
                 previous: &uri,
@@ -66,7 +66,7 @@ mod tests {
 
         let attempt = Attempt {
             status: Default::default(),
-            next_method: &Method::GET,
+            method: &Method::GET,
             location: &uri,
             previous_method: &Method::GET,
             previous: &uri,

--- a/tower-http/src/follow_redirect/policy/mod.rs
+++ b/tower-http/src/follow_redirect/policy/mod.rs
@@ -18,7 +18,7 @@ pub use self::{
     same_origin::SameOrigin,
 };
 
-use http::{uri::Scheme, Request, StatusCode, Uri};
+use http::{uri::Scheme, Method, Request, StatusCode, Uri};
 
 /// Trait for the policy on handling redirection responses.
 ///
@@ -198,7 +198,9 @@ pub type Standard = And<Limited, FilterCredentials>;
 /// A type that holds information on a redirection attempt.
 pub struct Attempt<'a> {
     pub(crate) status: StatusCode,
+    pub(crate) next_method: &'a Method,
     pub(crate) location: &'a Uri,
+    pub(crate) previous_method: &'a Method,
     pub(crate) previous: &'a Uri,
 }
 
@@ -208,9 +210,19 @@ impl<'a> Attempt<'a> {
         self.status
     }
 
+    /// Returns the method for the next request, after applying redirection logic.
+    pub fn next_method(&self) -> &Method {
+        self.next_method
+    }
+
     /// Returns the destination URI of the redirection.
     pub fn location(&self) -> &'a Uri {
         self.location
+    }
+
+    /// Returns the method for the previous request, before redirection.
+    pub fn previous_method(&self) -> &Method {
+        self.previous_method
     }
 
     /// Returns the URI of the original request.

--- a/tower-http/src/follow_redirect/policy/mod.rs
+++ b/tower-http/src/follow_redirect/policy/mod.rs
@@ -210,7 +210,7 @@ impl<'a> Attempt<'a> {
         self.status
     }
 
-    /// Returns the method for the next request, after applying redirection logic.
+    /// Returns the destination method of the redirection.
     pub fn method(&self) -> &'a Method {
         self.method
     }

--- a/tower-http/src/follow_redirect/policy/mod.rs
+++ b/tower-http/src/follow_redirect/policy/mod.rs
@@ -27,21 +27,21 @@ use http::{uri::Scheme, Method, Request, StatusCode, Uri};
 /// Detecting a cyclic redirection:
 ///
 /// ```
-/// use http::{Request, Uri};
+/// use http::{Method, Request, Uri};
 /// use std::collections::HashSet;
 /// use tower_http::follow_redirect::policy::{Action, Attempt, Policy};
 ///
 /// #[derive(Clone)]
 /// pub struct DetectCycle {
-///     uris: HashSet<Uri>,
+///     uris: HashSet<(Method, Uri)>,
 /// }
 ///
 /// impl<B, E> Policy<B, E> for DetectCycle {
 ///     fn redirect(&mut self, attempt: &Attempt<'_>) -> Result<Action, E> {
-///         if self.uris.contains(attempt.location()) {
+///         if self.uris.contains(&(attempt.method().clone(), attempt.location().clone())) {
 ///             Ok(Action::Stop)
 ///         } else {
-///             self.uris.insert(attempt.previous().clone());
+///             self.uris.insert((attempt.previous_method().clone(), attempt.previous().clone()));
 ///             Ok(Action::Follow)
 ///         }
 ///     }
@@ -198,7 +198,7 @@ pub type Standard = And<Limited, FilterCredentials>;
 /// A type that holds information on a redirection attempt.
 pub struct Attempt<'a> {
     pub(crate) status: StatusCode,
-    pub(crate) next_method: &'a Method,
+    pub(crate) method: &'a Method,
     pub(crate) location: &'a Uri,
     pub(crate) previous_method: &'a Method,
     pub(crate) previous: &'a Uri,
@@ -211,8 +211,8 @@ impl<'a> Attempt<'a> {
     }
 
     /// Returns the method for the next request, after applying redirection logic.
-    pub fn next_method(&self) -> &Method {
-        self.next_method
+    pub fn method(&self) -> &'a Method {
+        self.method
     }
 
     /// Returns the destination URI of the redirection.
@@ -221,7 +221,7 @@ impl<'a> Attempt<'a> {
     }
 
     /// Returns the method for the previous request, before redirection.
-    pub fn previous_method(&self) -> &Method {
+    pub fn previous_method(&self) -> &'a Method {
         self.previous_method
     }
 

--- a/tower-http/src/follow_redirect/policy/or.rs
+++ b/tower-http/src/follow_redirect/policy/or.rs
@@ -45,7 +45,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use http::Uri;
+    use http::{Method, Uri};
 
     struct Taint<P> {
         policy: P,
@@ -75,7 +75,9 @@ mod tests {
     fn redirect() {
         let attempt = Attempt {
             status: Default::default(),
+            next_method: &Method::GET,
             location: &Uri::from_static("*"),
+            previous_method: &Method::GET,
             previous: &Uri::from_static("*"),
         };
 

--- a/tower-http/src/follow_redirect/policy/or.rs
+++ b/tower-http/src/follow_redirect/policy/or.rs
@@ -75,7 +75,7 @@ mod tests {
     fn redirect() {
         let attempt = Attempt {
             status: Default::default(),
-            next_method: &Method::GET,
+            method: &Method::GET,
             location: &Uri::from_static("*"),
             previous_method: &Method::GET,
             previous: &Uri::from_static("*"),

--- a/tower-http/src/follow_redirect/policy/same_origin.rs
+++ b/tower-http/src/follow_redirect/policy/same_origin.rs
@@ -33,7 +33,7 @@ impl<B, E> Policy<B, E> for SameOrigin {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use http::{Request, Uri};
+    use http::{Method, Request, Uri};
 
     #[test]
     fn works() {
@@ -48,7 +48,9 @@ mod tests {
 
         let attempt = Attempt {
             status: Default::default(),
+            next_method: &Method::GET,
             location: &same_origin,
+            previous_method: &Method::GET,
             previous: request.uri(),
         };
         assert!(Policy::<(), ()>::redirect(&mut policy, &attempt)
@@ -60,7 +62,9 @@ mod tests {
 
         let attempt = Attempt {
             status: Default::default(),
+            next_method: &Method::GET,
             location: &cross_origin,
+            previous_method: &Method::GET,
             previous: request.uri(),
         };
         assert!(Policy::<(), ()>::redirect(&mut policy, &attempt)

--- a/tower-http/src/follow_redirect/policy/same_origin.rs
+++ b/tower-http/src/follow_redirect/policy/same_origin.rs
@@ -48,7 +48,7 @@ mod tests {
 
         let attempt = Attempt {
             status: Default::default(),
-            next_method: &Method::GET,
+            method: &Method::GET,
             location: &same_origin,
             previous_method: &Method::GET,
             previous: request.uri(),
@@ -62,7 +62,7 @@ mod tests {
 
         let attempt = Attempt {
             status: Default::default(),
-            next_method: &Method::GET,
+            method: &Method::GET,
             location: &cross_origin,
             previous_method: &Method::GET,
             previous: request.uri(),


### PR DESCRIPTION
This augments follow-redirect `Attempt` in order to expose two relevant HTTP methods during redirects:
 - the method for the original/previous request
 - the method to be performed on the next request upon following a redirection

This allows consumers to write policies based on both previous and next requests methods.