### PR TITLE
fix: use mem::swap on cloned inner service

### DIFF
--- a/tower-http/src/auth/async_require_authorization.rs
+++ b/tower-http/src/auth/async_require_authorization.rs
@@ -121,6 +121,7 @@ use http::{Request, Response};
 use pin_project_lite::pin_project;
 use std::{
     future::Future,
+    mem,
     pin::Pin,
     task::{ready, Context, Poll},
 };
@@ -202,8 +203,10 @@ where
     }
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        let inner = self.inner.clone();
+        let mut inner = self.inner.clone();
         let authorize = self.auth.authorize(req);
+        // mem::swap due to https://docs.rs/tower/latest/tower/trait.Service.html#be-careful-when-cloning-inner-services
+        mem::swap(&mut self.inner, &mut inner);
 
         ResponseFuture {
             state: State::Authorize { authorize },


### PR DESCRIPTION
## Motivation

Without this change the inner service may `panic!` since the cloned service may not be the ready service as described in 
[the tower docs](https://docs.rs/tower/latest/tower/trait.Service.html#be-careful-when-cloning-inner-services)

## Solution

Use `std::mem::replace` to swap the ready and cloned services
