### PR TITLE
Some cleanup

### DIFF
--- a/tower-http/src/auth/async_require_authorization.rs
+++ b/tower-http/src/auth/async_require_authorization.rs
@@ -332,10 +332,8 @@ mod tests {
                 let authorized = request
                     .headers()
                     .get(header::AUTHORIZATION)
-                    .and_then(|it| it.to_str().ok())
-                    .and_then(|it| it.strip_prefix("Bearer "))
-                    .map(|it| it == "69420")
-                    .unwrap_or(false);
+                    .and_then(|auth| auth.to_str().ok()?.strip_prefix("Bearer "))
+                    == Some("69420");
 
                 if authorized {
                     Ok(request)

--- a/tower-http/src/auth/async_require_authorization.rs
+++ b/tower-http/src/auth/async_require_authorization.rs
@@ -327,7 +327,7 @@ mod tests {
         type ResponseBody = Body;
         type Future = BoxFuture<'static, Result<Request<B>, Response<Self::ResponseBody>>>;
 
-        fn authorize(&mut self, mut request: Request<B>) -> Self::Future {
+        fn authorize(&mut self, request: Request<B>) -> Self::Future {
             Box::pin(async move {
                 let authorized = request
                     .headers()
@@ -338,8 +338,6 @@ mod tests {
                     .unwrap_or(false);
 
                 if authorized {
-                    let user_id = UserId("6969".to_owned());
-                    request.extensions_mut().insert(user_id);
                     Ok(request)
                 } else {
                     Err(Response::builder()
@@ -350,9 +348,6 @@ mod tests {
             })
         }
     }
-
-    #[derive(Clone, Debug)]
-    struct UserId(String);
 
     #[tokio::test]
     async fn require_async_auth_works() {

--- a/tower-http/src/builder.rs
+++ b/tower-http/src/builder.rs
@@ -5,6 +5,11 @@ use http::header::HeaderName;
 #[allow(unused_imports)]
 use tower_layer::Stack;
 
+mod sealed {
+    #[allow(unreachable_pub, unused)]
+    pub trait Sealed<T> {}
+}
+
 /// Extension trait that adds methods to [`tower::ServiceBuilder`] for adding middleware from
 /// tower-http.
 ///
@@ -39,7 +44,7 @@ use tower_layer::Stack;
 /// ```
 #[cfg(feature = "util")]
 // ^ work around rustdoc not inferring doc(cfg)s for cfg's from surrounding scopes
-pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
+pub trait ServiceBuilderExt<L>: sealed::Sealed<L> + Sized {
     /// Propagate a header from the request to the response.
     ///
     /// See [`tower_http::propagate_header`] for more details.
@@ -363,7 +368,7 @@ pub trait ServiceBuilderExt<L>: crate::sealed::Sealed<L> + Sized {
     ) -> ServiceBuilder<Stack<crate::normalize_path::NormalizePathLayer, L>>;
 }
 
-impl<L> crate::sealed::Sealed<L> for ServiceBuilder<L> {}
+impl<L> sealed::Sealed<L> for ServiceBuilder<L> {}
 
 impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
     #[cfg(feature = "propagate-header")]

--- a/tower-http/src/classify/grpc_errors_as_failures.rs
+++ b/tower-http/src/classify/grpc_errors_as_failures.rs
@@ -126,7 +126,6 @@ impl GrpcCodeBitmask {
 /// Responses are considered successful if
 ///
 /// - `grpc-status` header value contains a success value.
-/// default).
 /// - `grpc-status` header is missing.
 /// - `grpc-status` header value isn't a valid `String`.
 /// - `grpc-status` header value can't parsed into an `i32`.

--- a/tower-http/src/classify/mod.rs
+++ b/tower-http/src/classify/mod.rs
@@ -362,7 +362,7 @@ pub enum ServerErrorsFailureClass {
 }
 
 impl fmt::Display for ServerErrorsFailureClass {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::StatusCode(code) => write!(f, "Status code: {}", code),
             Self::Error(error) => write!(f, "Error: {}", error),
@@ -373,10 +373,14 @@ impl fmt::Display for ServerErrorsFailureClass {
 // Just verify that we can actually use this response classifier to determine retries as well
 #[cfg(test)]
 mod usable_for_retries {
-    #[allow(unused_imports)]
-    use super::*;
+    #![allow(dead_code)]
+
+    use std::fmt;
+
     use http::{Request, Response};
     use tower::retry::Policy;
+
+    use super::{ClassifiedResponse, ClassifyResponse};
 
     trait IsRetryable {
         fn is_retryable(&self) -> bool;

--- a/tower-http/src/classify/status_in_range_is_error.rs
+++ b/tower-http/src/classify/status_in_range_is_error.rs
@@ -112,7 +112,7 @@ pub enum StatusInRangeFailureClass {
 }
 
 impl fmt::Display for StatusInRangeFailureClass {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::StatusCode(code) => write!(f, "Status code: {}", code),
             Self::Error(error) => write!(f, "Error: {}", error),
@@ -131,23 +131,23 @@ mod tests {
         let classifier = StatusInRangeAsFailures::new(400..=599);
 
         assert!(matches!(
-            dbg!(classifier
+            classifier
                 .clone()
-                .classify_response(&response_with_status(200))),
+                .classify_response(&response_with_status(200)),
             ClassifiedResponse::Ready(Ok(())),
         ));
 
         assert!(matches!(
-            dbg!(classifier
+            classifier
                 .clone()
-                .classify_response(&response_with_status(400))),
+                .classify_response(&response_with_status(400)),
             ClassifiedResponse::Ready(Err(StatusInRangeFailureClass::StatusCode(
                 StatusCode::BAD_REQUEST
             ))),
         ));
 
         assert!(matches!(
-            dbg!(classifier.classify_response(&response_with_status(500))),
+            classifier.classify_response(&response_with_status(500)),
             ClassifiedResponse::Ready(Err(StatusInRangeFailureClass::StatusCode(
                 StatusCode::INTERNAL_SERVER_ERROR
             ))),

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -189,7 +189,6 @@
     clippy::needless_borrow,
     clippy::match_wildcard_for_single_variants,
     clippy::if_let_mutex,
-    clippy::mismatched_target_os,
     clippy::await_holding_lock,
     clippy::match_on_vec_items,
     clippy::imprecise_flops,

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -370,8 +370,3 @@ pub enum LatencyUnit {
 
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
-
-mod sealed {
-    #[allow(unreachable_pub, unused)]
-    pub trait Sealed<T> {}
-}

--- a/tower-http/src/services/fs/serve_dir/open_file.rs
+++ b/tower-http/src/services/fs/serve_dir/open_file.rs
@@ -216,10 +216,9 @@ async fn open_file_with_fallback(
                 // Remove the encoding from the negotiated_encodings since the file doesn't exist
                 negotiated_encoding
                     .retain(|(negotiated_encoding, _)| *negotiated_encoding != encoding);
-                continue;
             }
             (Err(err), _) => return Err(err),
-        };
+        }
     };
     Ok((file, encoding))
 }
@@ -243,10 +242,9 @@ async fn file_metadata_with_fallback(
                 // Remove the encoding from the negotiated_encodings since the file doesn't exist
                 negotiated_encoding
                     .retain(|(negotiated_encoding, _)| *negotiated_encoding != encoding);
-                continue;
             }
             (Err(err), _) => return Err(err),
-        };
+        }
     };
     Ok((file, encoding))
 }

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -369,9 +369,9 @@
 //! [`TraceLayer`] comes with convenience methods for using common classifiers:
 //!
 //! - [`TraceLayer::new_for_http`] classifies based on the status code. It doesn't consider
-//! streaming responses.
+//!   streaming responses.
 //! - [`TraceLayer::new_for_grpc`] classifies based on the gRPC protocol and supports streaming
-//! responses.
+//!   responses.
 //!
 //! [tracing]: https://crates.io/crates/tracing
 //! [`Service`]: tower_service::Service
@@ -516,7 +516,7 @@ mod tests {
                 tracing::info_span!("test-span", foo = tracing::field::Empty)
             })
             .on_request(|_req: &Request<Body>, span: &Span| {
-                span.record("foo", &42);
+                span.record("foo", 42);
                 ON_REQUEST_COUNT.fetch_add(1, Ordering::SeqCst);
             })
             .on_response(|_res: &Response<Body>, _latency: Duration, _span: &Span| {


### PR DESCRIPTION
## Motivation

Wanted to add a `ServiceExt` (gonna be the next PR) and noticed that the existing `Sealed` trait for `ServiceBuilderExt` was weirdly at the crate root (when every sealed trait should have its own `Sealed` trait). Also had a bunch of clippy errors locally (from nightly clippy, I think).

## Solution

See individual commit messages.