### PR TITLE
msrv: reduce to 1.64, only run check in ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@1.66
+    - uses: dtolnay/rust-toolchain@1.64
     - name: Install protoc
       uses: taiki-e/install-action@v2
       with:
@@ -81,7 +81,7 @@ jobs:
     - run: cargo update -p tokio-util --precise 0.7.11
     - run: cargo update -p flate2 --precise 1.0.35
     - run: cargo update -p once_cell --precise 1.20.3
-    - run: cargo test -p tower-http --all-features
+    - run: cargo check -p tower-http --all-features
 
   style:
     needs: check

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/tower-rs/tower-http"
 homepage = "https://github.com/tower-rs/tower-http"
 categories = ["asynchronous", "network-programming", "web-programming"]
 keywords = ["io", "async", "futures", "service", "http"]
-rust-version = "1.66"
+rust-version = "1.64"
 
 [dependencies]
 bitflags = "2.0.2"


### PR DESCRIPTION
Reduce the MSRV to 1.64, by only running `cargo check` instead of `cargo test` in CI.