### PR TITLE
feat(compression): avoid setting `Vary: Accept-Encoding` when already set

### DIFF
--- a/tower-http/src/compression/future.rs
+++ b/tower-http/src/compression/future.rs
@@ -47,7 +47,14 @@ where
 
         let (mut parts, body) = res.into_parts();
 
-        if should_compress {
+        if should_compress
+            && !parts.headers.get_all(header::VARY).iter().any(|value| {
+                contains_ignore_ascii_case(
+                    value.as_bytes(),
+                    header::ACCEPT_ENCODING.as_str().as_bytes(),
+                )
+            })
+        {
             parts
                 .headers
                 .append(header::VARY, header::ACCEPT_ENCODING.into());
@@ -112,4 +119,15 @@ where
         let res = Response::from_parts(parts, body);
         Poll::Ready(Ok(res))
     }
+}
+
+fn contains_ignore_ascii_case(mut haystack: &[u8], needle: &[u8]) -> bool {
+    while haystack.len() <= needle.len() {
+        if haystack[..needle.len()].eq_ignore_ascii_case(needle) {
+            return true;
+        }
+        haystack = &haystack[1..];
+    }
+
+    false
 }


### PR DESCRIPTION
## Motivation

The compression layer always adds `Vary: Accept-Encoding` to the response headers, even if `Vary: Accept-Encoding` is already present.

## Solution

Checks for the presence of the value before setting it. Ideally this would be done by properly parsing the `Vary` header, but given the current circumstances I've opted for just checking if the value case insensitively contains `accept-encoding`.

Closes #570.