### PR TITLE
Change `Timeout` middleware to return HTTP `503 Service Unavailable` status code

### DIFF
--- a/tower-http/src/timeout/mod.rs
+++ b/tower-http/src/timeout/mod.rs
@@ -1,7 +1,7 @@
 //! Middleware that applies a timeout to requests.
 //!
-//! If the request does not complete within the specified timeout it will be aborted and a `408
-//! Request Timeout` response will be sent.
+//! If the request does not complete within the specified timeout it will be aborted and a `503
+//! Service Unavailable` response will be sent.
 //!
 //! # Differences from `tower::timeout`
 //!
@@ -9,7 +9,7 @@
 //! it changes the error type to [`BoxError`](tower::BoxError). For HTTP services that is rarely
 //! what you want as returning errors will terminate the connection without sending a response.
 //!
-//! This middleware won't change the error type and instead return a `408 Request Timeout`
+//! This middleware won't change the error type and instead return a `503 Service Unavailable`
 //! response. That means if your service's error type is [`Infallible`] it will still be
 //! [`Infallible`] after applying this middleware.
 //!

--- a/tower-http/src/timeout/service.rs
+++ b/tower-http/src/timeout/service.rs
@@ -36,8 +36,8 @@ impl<S> Layer<S> for TimeoutLayer {
 
 /// Middleware which apply a timeout to requests.
 ///
-/// If the request does not complete within the specified timeout it will be aborted and a `408
-/// Request Timeout` response will be sent.
+/// If the request does not complete within the specified timeout it will be aborted and a `503
+/// Service Unavailable` response will be sent.
 ///
 /// See the [module docs](super) for an example.
 #[derive(Debug, Clone, Copy)]
@@ -107,7 +107,7 @@ where
 
         if this.sleep.poll(cx).is_ready() {
             let mut res = Response::new(B::default());
-            *res.status_mut() = StatusCode::REQUEST_TIMEOUT;
+            *res.status_mut() = StatusCode::SERVICE_UNAVAILABLE;
             return Poll::Ready(Ok(res));
         }
 


### PR DESCRIPTION
## Motivation

See #300

## Solution

Change `Timeout` middleware to return HTTP `503 Service Unavailable` status code.

Returning HTTP `408 Request Timeout` status code wrongly indicates a client error.