### PR TITLE
ci: MSRV job pin async-compression

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,6 +82,7 @@ jobs:
     - run: cargo update -p flate2 --precise 1.0.35
     - run: cargo update -p once_cell --precise 1.20.3
     - run: cargo update -p tracing-core --precise 0.1.33
+    - run: cargo update -p async-compression --precise 0.4.23
     - run: cargo check -p tower-http --all-features
 
   style:


### PR DESCRIPTION
async-compression v0.4.24 uses `io::Error::other()`, requiring Rust 1.73. (It seems they don't have any MSRV policy... 🤷 )

Anyways, pin for the MSRV job.