### PR TITLE
Fix serve_dir method not allowed handling when no fallback is configured

### DIFF
--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -320,9 +320,9 @@ impl<F> ServeDir<F> {
                         inner: future::call_fallback(fallback, req),
                     };
                 }
-            } else {
-                return ResponseFuture::method_not_allowed();
             }
+
+            return ResponseFuture::method_not_allowed();
         }
 
         // `ServeDir` doesn't care about the request body but the fallback might. So move out the

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -792,6 +792,21 @@ async fn calling_fallback_on_not_allowed() {
 }
 
 #[tokio::test]
+async fn method_not_allowed_without_fallback() {
+    let svc = ServeDir::new("..").call_fallback_on_method_not_allowed(true);
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/README.md")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
+    assert_eq!(res.headers()[ALLOW], "GET,HEAD");
+}
+
+#[tokio::test]
 async fn with_fallback_svc_and_not_append_index_html_on_directories() {
     async fn fallback<B>(req: Request<B>) -> Result<Response<Body>, Infallible> {
         Ok(Response::new(Body::from(format!(


### PR DESCRIPTION
Fixes a bug in `ServeDir` where non-GET/HEAD requests were incorrectly processed when `call_fallback_on_method_not_allowed` is enabled but no fallback service is provided.

**Problem**
When configured with `call_fallback_on_method_not_allowed(true)` but no fallback service, non-GET/HEAD requests would proceed through normal file serving logic instead of returning `405 Method Not Allowed`.