### PR TITLE
remove unnecessary to_string

### DIFF
--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -314,7 +314,7 @@ fn build_response(output: FileOpened) -> Response<ResponseBody> {
             };
 
             builder
-                .header(header::CONTENT_LENGTH, size.to_string())
+                .header(header::CONTENT_LENGTH, size)
                 .body(body)
                 .unwrap()
         }


### PR DESCRIPTION
Not sure this merits a PR, but just something I found.