### PR TITLE
added a new_absolute function to ServeDir

### DIFF
--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -82,6 +82,22 @@ impl ServeDir<DefaultServeDirFallback> {
         }
     }
 
+    pub fn new_absolute<P>(path: P) -> Self
+    where
+        P: AsRef<Path>,
+    {
+        Self {
+            base: PathBuf::from(path.as_ref()),
+            buf_chunk_size: DEFAULT_CAPACITY,
+            precompressed_variants: None,
+            variant: ServeVariant::Directory {
+                append_index_html_on_directories: true,
+            },
+            fallback: None,
+            call_fallback_on_method_not_allowed: false,
+        }
+    }
+
     pub(crate) fn new_single_file<P>(path: P, mime: HeaderValue) -> Self
     where
         P: AsRef<Path>,


### PR DESCRIPTION
## Motivation

By tower-http forces the path of the directory to be relative to the working directory, and there is no way to change this behavior

## Solution

Added a new `new_absolute` function to ServeDir, which skips the conversion to a relative path