### PR TITLE
docs: Remove Sync requirement for B as in the tests

### DIFF
--- a/tower-http/src/auth/async_require_authorization.rs
+++ b/tower-http/src/auth/async_require_authorization.rs
@@ -17,7 +17,7 @@
 //!
 //! impl<B> AsyncAuthorizeRequest<B> for MyAuth
 //! where
-//!     B: Send + Sync + 'static,
+//!     B: Send + 'static,
 //! {
 //!     type RequestBody = B;
 //!     type ResponseBody = Full<Bytes>;


### PR DESCRIPTION
## Motivation

Copying the `async_require_authorization` example from the docs does not compile at the moment, because it requires `B` to by `Sync`. This was fixed in the tests but overlooked in the docs.

## Solution

Straightforward, see commits.
