### PR TITLE
examples: Drop protoc dependency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,10 +12,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
-    - name: Install protoc
-      uses: taiki-e/install-action@v2
-      with:
-        tool: protoc@3.20.3
     - run: cargo check --workspace --all-features --all-targets
 
   check-docs:
@@ -23,10 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
-    - name: Install protoc
-      uses: taiki-e/install-action@v2
-      with:
-        tool: protoc@3.20.3
     - name: cargo doc
       working-directory: ${{ matrix.subcrate }}
       env:
@@ -39,10 +31,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - uses: taiki-e/install-action@cargo-hack
-    - name: Install protoc
-      uses: taiki-e/install-action@v2
-      with:
-        tool: protoc@3.20.3
     - name: cargo hack check
       working-directory: ${{ matrix.subcrate }}
       env:
@@ -61,10 +49,6 @@ jobs:
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-    - name: Install protoc
-      uses: taiki-e/install-action@v2
-      with:
-        tool: protoc@3.20.3
     - run: cargo test --workspace --all-features
 
   test-msrv:
@@ -73,10 +57,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@1.64
-    - name: Install protoc
-      uses: taiki-e/install-action@v2
-      with:
-        tool: protoc@3.20.3
     - run: cargo update -p tokio --precise 1.38.1
     - run: cargo update -p tokio-util --precise 0.7.11
     - run: cargo update -p flate2 --precise 1.0.35
@@ -93,10 +73,6 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt
-    - name: Install protoc
-      uses: taiki-e/install-action@v2
-      with:
-        tool: protoc@3.20.3
     - run: cargo fmt --all --check
 
   deny-check:

--- a/examples/tonic-key-value-store/Cargo.toml
+++ b/examples/tonic-key-value-store/Cargo.toml
@@ -23,4 +23,5 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { version = "4.3.16", features = ["derive"] }
 
 [build-dependencies]
+protox = "0.9"
 tonic-prost-build = "0.14"

--- a/examples/tonic-key-value-store/build.rs
+++ b/examples/tonic-key-value-store/build.rs
@@ -1,5 +1,4 @@
 fn main() {
-    tonic_prost_build::configure()
-        .compile_protos(&["key_value_store.proto"], &["proto"])
-        .unwrap();
+    let fds = protox::compile(["key_value_store.proto"], ["proto"]).unwrap();
+    tonic_prost_build::compile_fds(fds).unwrap();
 }


### PR DESCRIPTION
## Motivation

Removes protoc dependency to simplify CI.

## Solution

Uses protox to build proto.
