### PR TITLE
ci: Re-enable ci on default branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-    - master
+    - main
   pull_request: {}
 
 jobs:


### PR DESCRIPTION
## Motivation

Re-enables the CI on the default branch.

## Solution

Updates the branch name in the CI config.
