### PR TITLE
doc: Replace doc_auto_cfg with doc_cfg

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@nightly
     - name: cargo doc
       working-directory: ${{ matrix.subcrate }}
       env:
-        RUSTDOCFLAGS: "-D rustdoc::broken_intra_doc_links"
+        RUSTDOCFLAGS: "-D rustdoc::broken_intra_doc_links --cfg docsrs"
       run: cargo doc --all-features --no-deps
 
   cargo-hack:

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -216,7 +216,7 @@
     clippy::type_complexity
 )]
 #![forbid(unsafe_code)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 
 #[macro_use]


### PR DESCRIPTION
## Motivation

`doc_auto_cfg` was merged into `doc_cfg` in https://github.com/rust-lang/rust/pull/138907.

## Solution

Replaces `doc_auto_cfg` with `doc_cfg`.
