### PR TITLE
ci: Switch cargo-public-api-crates to cargo-check-external-types

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,20 +95,17 @@ jobs:
         manifest-path: tower-http/Cargo.toml
         command: check ${{ matrix.checks }}
 
-  cargo-public-api-crates:
+  external-types:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    # Pinned version due to failing `cargo-public-api-crates`.
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2025-11-23
+        toolchain: nightly-2025-08-06
+    - name: Install cargo-check-external-types
+      uses: taiki-e/cache-cargo-install-action@v2
+      with:
+        tool: cargo-check-external-types@0.3.0
     - uses: Swatinem/rust-cache@v2
-    - name: Install cargo-public-api-crates
-      run: |
-        cargo install --git https://github.com/jplatte/cargo-public-api-crates
-    - name: Build rustdoc
-      run: |
-        cargo rustdoc --all-features --manifest-path tower-http/Cargo.toml -- -Z unstable-options --output-format json
-    - name: cargo public-api-crates check
-      run: cargo public-api-crates --manifest-path tower-http/Cargo.toml --skip-build check
+    - run: cargo check-external-types --all-features
+      working-directory: tower-http

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -124,17 +124,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 [package.metadata.playground]
 features = ["full"]
 
-[package.metadata.cargo-public-api-crates]
-allowed = [
-    "bytes",
-    "http",
-    "http_body",
-    "mime",
-    "pin-project-lite",
-    "tokio",
-    "tower",
-    "tower_layer",
-    "tower_service",
-    "tracing",
-    "tracing_core",
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+    "bytes::*",
+    "http::*",
+    "http_body::*",
+    "mime::*",
+    "tokio::*",
+    "tower::*",
+    "tower_layer::*",
+    "tower_service::*",
+    "tracing::*",
+    "tracing_core::*",
 ]


### PR DESCRIPTION
## Motivation

`cargo-public-api-crates` seems to have version conflict at the dependencies.

```
error: failed to compile `cargo-public-api-crates v0.2.0 (https://github.com/davidpdrsn/cargo-public-api-crates#13bf827a)`, intermediate artifacts can be found at `/tmp/cargo-installDFx8K1`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  rustc 1.80.0-nightly is not supported by the following package:
    indexmap@2.12.0 requires rustc 1.82
  Either upgrade rustc or select compatible dependency versions with
  `cargo update <name>@<current-ver> --precise <compatible-ver>`
  where `<compatible-ver>` is the latest version supporting rustc 1.80.0-nightly
```

https://github.com/tower-rs/tower-http/actions/runs/18697143413/job/53317419830

## Solution

Switches `cargo-public-api-crates` to `cargo-check-external-types`.