### PR TITLE
ci: Pin tracing in MSRV job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,6 +62,8 @@ jobs:
     - run: cargo update -p tokio --precise 1.38.1
     - run: cargo update -p tokio-util --precise 0.7.11
     - run: cargo update -p once_cell --precise 1.20.3
+    - run: cargo update -p tracing --precise 0.1.41
+    - run: cargo update -p tracing-subscriber --precise 0.3.19
     - run: cargo update -p tracing-core --precise 0.1.33
     - run: cargo update -p async-compression --precise 0.4.23
     - run: cargo update -p flate2 --precise 1.0.35


### PR DESCRIPTION
CI is failing in main since latest versions of `tracing` and `tracing-subscriber` now require rust 1.65