### PR TITLE
examples: Use axum::body::to_bytes

### DIFF
--- a/examples/axum-key-value-store/Cargo.toml
+++ b/examples/axum-key-value-store/Cargo.toml
@@ -14,6 +14,3 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 axum = "0.8"
 clap = { version = "4.4.4", features = ["derive"] }
-
-[dev-dependencies]
-http-body-util = "0.1"

--- a/examples/axum-key-value-store/src/main.rs
+++ b/examples/axum-key-value-store/src/main.rs
@@ -112,7 +112,6 @@ async fn set_key(Path(path): Path<String>, state: State<AppState>, value: Bytes)
 #[cfg(test)]
 mod tests {
     use axum::{body::Body, http::Request};
-    use http_body_util::BodyExt;
     use tower::ServiceExt;
 
     use super::*;
@@ -137,7 +136,7 @@ mod tests {
             .oneshot(Request::get("/foo").body(Body::empty())?)
             .await?;
         assert_eq!(response.status(), StatusCode::OK);
-        let body = response.into_body().collect().await?.to_bytes();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
         assert_eq!(body.as_ref(), b"Hello, World!");
 
         Ok(())


### PR DESCRIPTION
`axum::body::to_bytes` could be used to collect the response body.