### PR TITLE
fix: reject multipart ranges before validation

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -27,7 +27,7 @@ futures-core = { version = "0.3", optional = true, default-features = false }
 futures-util = { version = "0.3.14", optional = true, default-features = false }
 http-body = { version = "1.0.0", optional = true }
 http-body-util = { version = "0.1.0", optional = true }
-http-range-header = { version = "0.4.0", optional = true }
+http-range-header = { version = "0.4.2", optional = true }
 mime = { version = "0.3.17", optional = true, default-features = false }
 mime_guess = { version = "2", optional = true, default-features = false }
 percent-encoding = { version = "2.1.0" }

--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -13,6 +13,7 @@ use http::{
     HeaderValue, Request, Response, StatusCode,
 };
 use http_body_util::{BodyExt, Empty, Full};
+use http_range_header::RangeUnsatisfiableError;
 use pin_project_lite::pin_project;
 use std::{
     convert::Infallible,
@@ -320,6 +321,14 @@ fn build_response(output: FileOpened) -> Response<ResponseBody> {
                     .unwrap()
             }
         }
+
+        Some(Err(RangeUnsatisfiableError::OverlappingRanges)) => builder
+            .header(header::CONTENT_RANGE, format!("bytes */{}", size))
+            .status(StatusCode::RANGE_NOT_SATISFIABLE)
+            .body(body_from_bytes(Bytes::from(
+                "Cannot serve multipart range requests",
+            )))
+            .unwrap(),
 
         Some(Err(_)) => builder
             .header(header::CONTENT_RANGE, format!("bytes */{}", size))

--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -1,5 +1,5 @@
 use super::{
-    open_file::{FileOpened, FileRequestExtent, OpenFileOutput},
+    open_file::{FileOpened, FileRequestExtent, OpenFileOutput, RangeError},
     DefaultServeDirFallback, ResponseBody,
 };
 use crate::{
@@ -13,7 +13,6 @@ use http::{
     HeaderValue, Request, Response, StatusCode,
 };
 use http_body_util::{BodyExt, Empty, Full};
-use http_range_header::RangeUnsatisfiableError;
 use pin_project_lite::pin_project;
 use std::{
     convert::Infallible,
@@ -322,7 +321,7 @@ fn build_response(output: FileOpened) -> Response<ResponseBody> {
             }
         }
 
-        Some(Err(RangeUnsatisfiableError::OverlappingRanges)) => builder
+        Some(Err(RangeError::MultipleRangesNotSupported)) => builder
             .header(header::CONTENT_RANGE, format!("bytes */{}", size))
             .status(StatusCode::RANGE_NOT_SATISFIABLE)
             .body(body_from_bytes(Bytes::from(
@@ -330,7 +329,7 @@ fn build_response(output: FileOpened) -> Response<ResponseBody> {
             )))
             .unwrap(),
 
-        Some(Err(_)) => builder
+        Some(Err(RangeError::Unsatisfiable)) => builder
             .header(header::CONTENT_RANGE, format!("bytes */{}", size))
             .status(StatusCode::RANGE_NOT_SATISFIABLE)
             .body(empty_body())

--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -269,56 +269,32 @@ fn build_response(output: FileOpened) -> Response<ResponseBody> {
     }
 
     match output.maybe_range {
-        Some(Ok(ranges)) => {
-            if let Some(range) = ranges.first() {
-                if ranges.len() > 1 {
-                    builder
-                        .header(header::CONTENT_RANGE, format!("bytes */{}", size))
-                        .status(StatusCode::RANGE_NOT_SATISFIABLE)
-                        .body(body_from_bytes(Bytes::from(
-                            "Cannot serve multipart range requests",
-                        )))
-                        .unwrap()
-                } else {
-                    let body = if let Some(file) = maybe_file {
-                        let range_size = range.end() - range.start() + 1;
-                        ResponseBody::new(UnsyncBoxBody::from_inner(
-                            AsyncReadBody::with_capacity_limited(
-                                file,
-                                output.chunk_size,
-                                range_size,
-                            )
-                            .boxed_unsync(),
-                        ))
-                    } else {
-                        empty_body()
-                    };
-
-                    let content_length = if size == 0 {
-                        0
-                    } else {
-                        range.end() - range.start() + 1
-                    };
-
-                    builder
-                        .header(
-                            header::CONTENT_RANGE,
-                            format!("bytes {}-{}/{}", range.start(), range.end(), size),
-                        )
-                        .header(header::CONTENT_LENGTH, content_length)
-                        .status(StatusCode::PARTIAL_CONTENT)
-                        .body(body)
-                        .unwrap()
-                }
+        Some(Ok(range)) => {
+            let body = if let Some(file) = maybe_file {
+                let range_size = range.end() - range.start() + 1;
+                ResponseBody::new(UnsyncBoxBody::from_inner(
+                    AsyncReadBody::with_capacity_limited(file, output.chunk_size, range_size)
+                        .boxed_unsync(),
+                ))
             } else {
-                builder
-                    .header(header::CONTENT_RANGE, format!("bytes */{}", size))
-                    .status(StatusCode::RANGE_NOT_SATISFIABLE)
-                    .body(body_from_bytes(Bytes::from(
-                        "No range found after parsing range header, please file an issue",
-                    )))
-                    .unwrap()
-            }
+                empty_body()
+            };
+
+            let content_length = if size == 0 {
+                0
+            } else {
+                range.end() - range.start() + 1
+            };
+
+            builder
+                .header(
+                    header::CONTENT_RANGE,
+                    format!("bytes {}-{}/{}", range.start(), range.end(), size),
+                )
+                .header(header::CONTENT_LENGTH, content_length)
+                .status(StatusCode::PARTIAL_CONTENT)
+                .body(body)
+                .unwrap()
         }
 
         Some(Err(RangeError::MultipleRangesNotSupported)) => builder

--- a/tower-http/src/services/fs/serve_dir/open_file.rs
+++ b/tower-http/src/services/fs/serve_dir/open_file.rs
@@ -446,8 +446,15 @@ fn try_parse_range(
     file_size: u64,
 ) -> Option<Result<Vec<RangeInclusive<u64>>, RangeUnsatisfiableError>> {
     maybe_range_ref.map(|header_value| {
-        http_range_header::parse_range_header(header_value)
-            .and_then(|first_pass| first_pass.validate(file_size))
+        let parsed = http_range_header::parse_range_header(header_value)?;
+
+        if parsed.ranges.len() > 1 {
+            // ServeDir/ServeFile do not support multipart responses, so reject
+            // multi-range requests before validate() runs overlap checks.
+            return Err(RangeUnsatisfiableError::OverlappingRanges);
+        }
+
+        parsed.validate(file_size)
     })
 }
 

--- a/tower-http/src/services/fs/serve_dir/open_file.rs
+++ b/tower-http/src/services/fs/serve_dir/open_file.rs
@@ -7,7 +7,6 @@ use crate::content_encoding::{Encoding, QValue};
 use bytes::Bytes;
 use http::{header, HeaderValue, Method, Request, Uri};
 use http_body_util::Empty;
-use http_range_header::RangeUnsatisfiableError;
 use std::{
     ffi::OsStr,
     io::{self, ErrorKind, SeekFrom},
@@ -31,12 +30,17 @@ pub(super) enum OpenFileOutput {
     InvalidFilename,
 }
 
+pub(super) enum RangeError {
+    Unsatisfiable,
+    MultipleRangesNotSupported,
+}
+
 pub(super) struct FileOpened {
     pub(super) extent: FileRequestExtent,
     pub(super) chunk_size: usize,
     pub(super) mime_header_value: HeaderValue,
     pub(super) maybe_encoding: Option<Encoding>,
-    pub(super) maybe_range: Option<Result<Vec<RangeInclusive<u64>>, RangeUnsatisfiableError>>,
+    pub(super) maybe_range: Option<Result<Vec<RangeInclusive<u64>>, RangeError>>,
     pub(super) last_modified: Option<LastModified>,
     pub(super) precompression_configured: bool,
     pub(super) etag: Option<ETag>,
@@ -196,8 +200,6 @@ pub(super) async fn open_file<B: Backend>(
         let size = meta.len();
         let maybe_range = try_parse_range(range_header.as_deref(), size);
         if let Some(Ok(ranges)) = maybe_range.as_ref() {
-            // if there is any other amount of ranges than 1 we'll return an
-            // unsatisfiable later as there isn't yet support for multipart ranges
             if ranges.len() == 1 {
                 file.seek(SeekFrom::Start(*ranges[0].start())).await?;
             }
@@ -444,17 +446,20 @@ async fn maybe_redirect_or_append_path<B: Backend>(
 fn try_parse_range(
     maybe_range_ref: Option<&str>,
     file_size: u64,
-) -> Option<Result<Vec<RangeInclusive<u64>>, RangeUnsatisfiableError>> {
+) -> Option<Result<Vec<RangeInclusive<u64>>, RangeError>> {
     maybe_range_ref.map(|header_value| {
-        let parsed = http_range_header::parse_range_header(header_value)?;
+        let parsed = http_range_header::parse_range_header(header_value)
+            .map_err(|_| RangeError::Unsatisfiable)?;
 
         if parsed.ranges.len() > 1 {
             // ServeDir/ServeFile do not support multipart responses, so reject
             // multi-range requests before validate() runs overlap checks.
-            return Err(RangeUnsatisfiableError::OverlappingRanges);
+            return Err(RangeError::MultipleRangesNotSupported);
         }
 
-        parsed.validate(file_size)
+        parsed
+            .validate(file_size)
+            .map_err(|_| RangeError::Unsatisfiable)
     })
 }
 

--- a/tower-http/src/services/fs/serve_dir/open_file.rs
+++ b/tower-http/src/services/fs/serve_dir/open_file.rs
@@ -40,7 +40,7 @@ pub(super) struct FileOpened {
     pub(super) chunk_size: usize,
     pub(super) mime_header_value: HeaderValue,
     pub(super) maybe_encoding: Option<Encoding>,
-    pub(super) maybe_range: Option<Result<Vec<RangeInclusive<u64>>, RangeError>>,
+    pub(super) maybe_range: Option<Result<RangeInclusive<u64>, RangeError>>,
     pub(super) last_modified: Option<LastModified>,
     pub(super) precompression_configured: bool,
     pub(super) etag: Option<ETag>,
@@ -199,10 +199,8 @@ pub(super) async fn open_file<B: Backend>(
 
         let size = meta.len();
         let maybe_range = try_parse_range(range_header.as_deref(), size);
-        if let Some(Ok(ranges)) = maybe_range.as_ref() {
-            if ranges.len() == 1 {
-                file.seek(SeekFrom::Start(*ranges[0].start())).await?;
-            }
+        if let Some(Ok(range)) = maybe_range.as_ref() {
+            file.seek(SeekFrom::Start(*range.start())).await?;
         }
 
         Ok(OpenFileOutput::FileOpened(Box::new(FileOpened {
@@ -446,7 +444,7 @@ async fn maybe_redirect_or_append_path<B: Backend>(
 fn try_parse_range(
     maybe_range_ref: Option<&str>,
     file_size: u64,
-) -> Option<Result<Vec<RangeInclusive<u64>>, RangeError>> {
+) -> Option<Result<RangeInclusive<u64>, RangeError>> {
     maybe_range_ref.map(|header_value| {
         let parsed = http_range_header::parse_range_header(header_value)
             .map_err(|_| RangeError::Unsatisfiable)?;
@@ -457,9 +455,11 @@ fn try_parse_range(
             return Err(RangeError::MultipleRangesNotSupported);
         }
 
-        parsed
+        let mut ranges = parsed
             .validate(file_size)
-            .map_err(|_| RangeError::Unsatisfiable)
+            .map_err(|_| RangeError::Unsatisfiable)?;
+
+        ranges.pop().ok_or(RangeError::Unsatisfiable)
     })
 }
 

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -684,6 +684,27 @@ async fn read_partial_errs_on_bad_range() {
 }
 
 #[tokio::test]
+async fn multipart_range_valid_returns_multipart_error_body() {
+    let svc = ServeDir::new("..");
+    let req = Request::builder()
+        .uri("/README.md")
+        .header("Range", "bytes=0-0,2-2")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::RANGE_NOT_SATISFIABLE);
+    let file_contents = std::fs::read("../README.md").unwrap();
+    assert_eq!(
+        res.headers()["content-range"],
+        &format!("bytes */{}", file_contents.len())
+    );
+
+    let body = body_into_text(res.into_body()).await;
+    assert_eq!(body, "Cannot serve multipart range requests");
+}
+
+#[tokio::test]
 async fn accept_encoding_identity() {
     let svc = ServeDir::new(REPO_ROOT);
     let req = Request::builder()

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -688,7 +688,7 @@ async fn read_partial_errs_on_bad_range() {
 
 #[tokio::test]
 async fn multipart_range_valid_returns_multipart_error_body() {
-    let svc = ServeDir::new("..");
+    let svc = ServeDir::new(REPO_ROOT);
     let req = Request::builder()
         .uri("/README.md")
         .header("Range", "bytes=0-0,2-2")
@@ -697,7 +697,28 @@ async fn multipart_range_valid_returns_multipart_error_body() {
     let res = svc.oneshot(req).await.unwrap();
 
     assert_eq!(res.status(), StatusCode::RANGE_NOT_SATISFIABLE);
-    let file_contents = std::fs::read("../README.md").unwrap();
+    let file_contents = std::fs::read(README_PATH).unwrap();
+    assert_eq!(
+        res.headers()["content-range"],
+        &format!("bytes */{}", file_contents.len())
+    );
+
+    let body = body_into_text(res.into_body()).await;
+    assert_eq!(body, "Cannot serve multipart range requests");
+}
+
+#[tokio::test]
+async fn multipart_range_overlap_returns_multipart_error_body() {
+    let svc = ServeDir::new(REPO_ROOT);
+    let req = Request::builder()
+        .uri("/README.md")
+        .header("Range", "bytes=0-2,1-3")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::RANGE_NOT_SATISFIABLE);
+    let file_contents = std::fs::read(README_PATH).unwrap();
     assert_eq!(
         res.headers()["content-range"],
         &format!("bytes */{}", file_contents.len())

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -663,7 +663,10 @@ async fn read_partial_errs_on_garbage_header() {
     assert_eq!(
         res.headers()["content-range"],
         &format!("bytes */{}", file_contents.len())
-    )
+    );
+
+    let body = body_into_text(res.into_body()).await;
+    assert!(body.is_empty());
 }
 
 #[tokio::test]

--- a/tower-http/src/services/fs/serve_file.rs
+++ b/tower-http/src/services/fs/serve_file.rs
@@ -143,7 +143,6 @@ where
 mod tests {
     use crate::services::ServeFile;
     use crate::test_helpers::Body;
-    use async_compression::tokio::bufread::ZstdDecoder;
     use brotli::BrotliDecompress;
     use flate2::bufread::DeflateDecoder;
     use flate2::bufread::GzDecoder;
@@ -154,7 +153,6 @@ mod tests {
     use mime::Mime;
     use std::io::Read;
     use std::str::FromStr;
-    use tokio::io::AsyncReadExt;
     use tower::ServiceExt;
 
     /// Expected prefix of the decompressed content in precompressed test files.
@@ -386,9 +384,8 @@ mod tests {
         assert_eq!(res.headers()["content-encoding"], "zstd");
 
         let body = res.into_body().collect().await.unwrap().to_bytes();
-        let mut decoder = ZstdDecoder::new(&body[..]);
-        let mut decompressed = String::new();
-        decoder.read_to_string(&mut decompressed).await.unwrap();
+        let decompressed = zstd::stream::decode_all(&body[..]).unwrap();
+        let decompressed = String::from_utf8(decompressed).unwrap();
         assert!(decompressed.starts_with(EXPECTED_CONTENT_PREFIX));
     }
 


### PR DESCRIPTION
## Motivation

`ServeDir` / `ServeFile` do not support multipart range responses, but they validate multi-range `Range` headers before later rejecting them with `416 Range Not Satisfiable`.

This means requests that are guaranteed to be rejected still pay the cost of `validate(file_size)`, including its pairwise overlap checks.

## Solution

Reject multiple ranges before calling `validate(file_size)`:

- parse the range header as before
- return a local `MultipleRangesNotSupported` error when more than one range is present
- only call `validate(file_size)` for single-range requests
- preserve the multipart-specific `416` response body for valid multi-range requests

This also adds regression coverage for the multipart-specific response body.

Note: syntactically parsed multi-range requests that would previously fail semantic validation, such as overlapping or reversed ranges, are now rejected as unsupported multiple ranges before validation. The status and `Content-Range` remain unchanged, but the `416` body becomes the multipart-specific message.

Refs: #660
