### PR TITLE
fix: restore tokio and async-compression as no-op features

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# Unreleased
+
+## Fixed
+
+- Restore `tokio` and `async-compression` as no-op features. These will be
+  removed next breaking release
+
 # 0.6.9
 
 ## Added:

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -120,6 +120,11 @@ decompression-full = ["decompression-br", "decompression-deflate", "decompressio
 decompression-gzip = ["dep:async-compression", "async-compression?/gzip", "futures-core", "dep:http-body", "dep:http-body-util", "tokio-util", "dep:tokio"]
 decompression-zstd = ["dep:async-compression", "async-compression?/zstd", "futures-core", "dep:http-body", "dep:http-body-util", "tokio-util", "dep:tokio"]
 
+# FIXME: rip this out come 0.7.0.
+# ref: https://github.com/tower-rs/tower-http/pull/666#issuecomment-4382555061
+tokio = []
+async-compression = []
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
As discussed in: https://github.com/tower-rs/tower-http/pull/666

Adding back in the previously implicit `tokio` and `async-compression` features as no-ops. We can rip them out come `0.7.0`.

In the meantime, no need to break users that (for whatever reason) might be naming `tower-http = ["tokio"]` while using some other dependency that requires `tower-http = ">= 0.6.9"`.