### PR TITLE
ci: fix flaky encoding test, add nightly stress test job

### DIFF
--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -1,0 +1,54 @@
+name: Stress Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      duration_minutes:
+        description: "Stress test duration in minutes (max 50 to leave setup/teardown headroom)"
+        required: false
+        default: "30"
+        type: string
+      test_filter:
+        description: "Optional nextest filter expression, substring match on test names"
+        required: false
+        default: ""
+        type: string
+  schedule:
+    # Daily at 06:00 UTC
+    - cron: "0 6 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: stress-test
+  cancel-in-progress: false
+
+jobs:
+  stress-test:
+    name: Stress Test
+    runs-on: ubuntu-latest
+    # Leave ~20 minutes of headroom for toolchain install, cache restore, and build.
+    timeout-minutes: ${{ fromJson(inputs.duration_minutes || '30') + 20 }}
+    env:
+      RUST_BACKTRACE: 1
+      DURATION_MINUTES: ${{ inputs.duration_minutes || '30' }}
+      TEST_FILTER: ${{ inputs.test_filter }}
+    steps:
+    - uses: actions/checkout@v6
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-nextest@0.9.132
+    - name: Run stress test
+      run: |
+        if [ -n "$TEST_FILTER" ]; then
+          cargo nextest run --workspace --all-features --no-fail-fast \
+            --stress-duration "${DURATION_MINUTES}m" -E "test($TEST_FILTER)"
+        else
+          cargo nextest run --workspace --all-features --no-fail-fast \
+            --stress-duration "${DURATION_MINUTES}m"
+        fi

--- a/tower-http/src/compression/layer.rs
+++ b/tower-http/src/compression/layer.rs
@@ -144,17 +144,28 @@ mod tests {
 
     #[tokio::test]
     async fn accept_encoding_configuration_works() -> Result<(), crate::BoxError> {
+        use std::io::Read;
+
+        fn decode<R: Read>(mut r: R) -> std::io::Result<Vec<u8>> {
+            let mut buf = Vec::new();
+            r.read_to_end(&mut buf)?;
+            Ok(buf)
+        }
+
+        // Read the source file once so we can verify each response round-trips to the same bytes.
+        let expected = tokio::fs::read("Cargo.toml").await?;
+
+        // Configure a layer that only offers deflate, then confirm the response is actually
+        // deflate-encoded by decoding it and comparing to the original content.
         let deflate_only_layer = CompressionLayer::new()
             .quality(CompressionLevel::Best)
             .no_br()
             .no_gzip();
 
         let mut service = ServiceBuilder::new()
-            // Compress responses based on the `Accept-Encoding` header.
             .layer(deflate_only_layer)
             .service_fn(handle);
 
-        // Call the service with the deflate only layer
         let request = Request::builder()
             .header(ACCEPT_ENCODING, "gzip, deflate, br")
             .body(Body::empty())?;
@@ -163,23 +174,23 @@ mod tests {
 
         assert_eq!(response.headers()["content-encoding"], "deflate");
 
-        // Read the body
-        let body = response.into_body();
-        let bytes = body.collect().await.unwrap().to_bytes();
+        let deflate_body = response.into_body().collect().await?.to_bytes();
 
-        let deflate_bytes_len = bytes.len();
+        // The "deflate" Content-Encoding is RFC 1950 zlib framing (2-byte header + Adler-32),
+        // not raw RFC 1951 deflate, so use ZlibDecoder rather than DeflateDecoder.
+        let decoded = decode(flate2::bufread::ZlibDecoder::new(&deflate_body[..]))?;
+        assert_eq!(decoded, expected);
 
+        // Same check for brotli.
         let br_only_layer = CompressionLayer::new()
             .quality(CompressionLevel::Best)
             .no_gzip()
             .no_deflate();
 
         let mut service = ServiceBuilder::new()
-            // Compress responses based on the `Accept-Encoding` header.
             .layer(br_only_layer)
             .service_fn(handle);
 
-        // Call the service with the br only layer
         let request = Request::builder()
             .header(ACCEPT_ENCODING, "gzip, deflate, br")
             .body(Body::empty())?;
@@ -188,15 +199,11 @@ mod tests {
 
         assert_eq!(response.headers()["content-encoding"], "br");
 
-        // Read the body
-        let body = response.into_body();
-        let bytes = body.collect().await.unwrap().to_bytes();
+        let br_body = response.into_body().collect().await?.to_bytes();
 
-        let br_byte_length = bytes.len();
-
-        // check the corresponding algorithms are actually used
-        // br should compresses better than deflate
-        assert!(br_byte_length < deflate_bytes_len * 9 / 10);
+        // 4096 is the decoder's internal read-buffer size, not a content-length bound.
+        let decoded = decode(brotli::Decompressor::new(&br_body[..], 4096))?;
+        assert_eq!(decoded, expected);
 
         Ok(())
     }


### PR DESCRIPTION
Fixes https://github.com/tower-rs/tower-http/issues/668

### Summary

The flaky assertion compared brotli and deflate output sizes on a 5.5 KB input where the ratio is only ~2.5% under the threshold, so streaming chunk timing occasionally pushed it over. Replaced the size-ratio proxy with a direct round-trip decode check using `flate2` and `brotli`, which verifies the actual invariant: that the configured codec was used.

Also added a daily stress-test workflow, with `workflow_dispatch` for manual runs and a scheduled daily run, so this class of flake surfaces before hitting PR authors.

### Testing

Ran `cargo nextest run --stress-duration` against the target test and the full suite; no failures.
