### PR TITLE
ci: use static timeout in stress-test workflow

### DIFF
--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -28,8 +28,9 @@ jobs:
   stress-test:
     name: Stress Test
     runs-on: ubuntu-latest
-    # Leave ~20 minutes of headroom for toolchain install, cache restore, and build.
-    timeout-minutes: ${{ fromJson(inputs.duration_minutes || '30') + 20 }}
+    # Accommodates the documented max duration_minutes of 50 plus toolchain install,
+    # cache restore, and build headroom.
+    timeout-minutes: 75
     env:
       RUST_BACKTRACE: 1
       DURATION_MINUTES: ${{ inputs.duration_minutes || '30' }}


### PR DESCRIPTION
#670 had a bug in its new (non-blocking) ci flow:

```
 Invalid workflow file: .github/workflows/stress-test.yml#L1
(Line: 32, Col: 22): Unexpected symbol: '+'. Located at position 43 within expression: fromJson(inputs.duration_minutes || '30') + 20, (Line: 32, Col: 22): Unexpected value '${{ fromJson(inputs.duration_minutes || '30') + 20 }}'
```
https://github.com/tower-rs/tower-http/actions/runs/25456875505

I tried to get too clever with arithmetic expressions, just hardcoding the value instead.