### PR TITLE
feat(set_header): refactor and improve multiple header middleware

### DIFF
--- a/tower-http/src/set_header/mod.rs
+++ b/tower-http/src/set_header/mod.rs
@@ -10,7 +10,7 @@ pub mod response;
 #[doc(inline)]
 pub use self::{
     request::{SetRequestHeader, SetRequestHeaderLayer},
-    response::{SetResponseHeader, SetResponseHeaderLayer},
+    response::{HeaderMetadata, SetResponseHeader, SetResponseHeaderLayer},
 };
 
 /// Trait for producing header values.

--- a/tower-http/src/set_header/response/mod.rs
+++ b/tower-http/src/set_header/response/mod.rs
@@ -101,14 +101,8 @@
 //! let mut svc = ServiceBuilder::new()
 //!     .layer(
 //!         SetMultipleResponseHeadersLayer::overriding(vec![
-//!             HeaderMetadata {
-//!                 header_name: header::CONTENT_TYPE,
-//!                 make: HeaderValue::from_static("text/html"),
-//!             },
-//!             HeaderMetadata {
-//!                 header_name: header::CACHE_CONTROL,
-//!                 make: HeaderValue::from_static("no-cache"),
-//!             },
+//!             (header::CONTENT_TYPE, HeaderValue::from_static("text/html")).into(),
+//!             (header::CACHE_CONTROL, HeaderValue::from_static("no-cache")).into(),
 //!         ])
 //!     )
 //!     .service(render_html);
@@ -142,16 +136,13 @@
 //! let mut svc = ServiceBuilder::new()
 //!     .layer(
 //!         SetMultipleResponseHeadersLayer::overriding(vec![
-//!             HeaderMetadata {
-//!                 header_name: header::CONTENT_LENGTH,
-//!                 make: |response: &Response<Full<Bytes>>| {
-//!                     if let Some(size) = response.body().size_hint().exact() {
-//!                         Some(HeaderValue::from_str(&size.to_string()).unwrap())
-//!                     } else {
-//!                         None
-//!                     }
-//!                 },
-//!             },
+//!             (header::CONTENT_LENGTH, |response: &Response<Full<Bytes>>| {
+//!                 if let Some(size) = response.body().size_hint().exact() {
+//!                     Some(HeaderValue::from_str(&size.to_string()).unwrap())
+//!                 } else {
+//!                     None
+//!                 }
+//!             }).into(),
 //!         ])
 //!     )
 //!     .service(render_html);

--- a/tower-http/src/set_header/response/mod.rs
+++ b/tower-http/src/set_header/response/mod.rs
@@ -1,0 +1,182 @@
+//! Middleware for setting headers on HTTP responses.
+//!
+//! This module provides middleware for setting one or more headers on HTTP responses, either with fixed values or values determined dynamically from the response.
+//!
+//! # Single Header
+//!
+//! Use [`SetResponseHeaderLayer`] and [`SetResponseHeader`] to set a single header. The header value can be a fixed value or computed dynamically using a closure. See the [`MakeHeaderValue`] trait for details.
+//!
+//! ## Example: Fixed Value
+//!
+//! ```
+//! use http::{Request, Response, header::{self, HeaderValue}};
+//! use tower::{Service, ServiceExt, ServiceBuilder};
+//! use tower_http::set_header::SetResponseHeaderLayer;
+//! use http_body_util::Full;
+//! use bytes::Bytes;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let render_html = tower::service_fn(|request: Request<Full<Bytes>>| async move {
+//! #     Ok::<_, std::convert::Infallible>(Response::new(request.into_body()))
+//! # });
+//!
+//! let mut svc = ServiceBuilder::new()
+//!     .layer(
+//!         SetResponseHeaderLayer::if_not_present(
+//!             header::CONTENT_TYPE,
+//!             HeaderValue::from_static("text/html"),
+//!         )
+//!     )
+//!     .service(render_html);
+//!
+//! let request = Request::new(Full::default());
+//!
+//! let response = svc.ready().await?.call(request).await?;
+//!
+//! assert_eq!(response.headers()["content-type"], "text/html");
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Example: Dynamic Value
+//!
+//! ```
+//! use http::{Request, Response, header::{self, HeaderValue}};
+//! use tower::{Service, ServiceExt, ServiceBuilder};
+//! use tower_http::set_header::SetResponseHeaderLayer;
+//! use bytes::Bytes;
+//! use http_body_util::Full;
+//! use http_body::Body as _; // for `Body::size_hint`
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let render_html = tower::service_fn(|request: Request<Full<Bytes>>| async move {
+//! #     Ok::<_, std::convert::Infallible>(Response::new(Full::from("1234567890")))
+//! # });
+//!
+//! let mut svc = ServiceBuilder::new()
+//!     .layer(
+//!         SetResponseHeaderLayer::overriding(
+//!             header::CONTENT_LENGTH,
+//!             |response: &Response<Full<Bytes>>| {
+//!                 if let Some(size) = response.body().size_hint().exact() {
+//!                     Some(HeaderValue::from_str(&size.to_string()).unwrap())
+//!                 } else {
+//!                     None
+//!                 }
+//!             }
+//!         )
+//!     )
+//!     .service(render_html);
+//!
+//! let request = Request::new(Full::default());
+//!
+//! let response = svc.ready().await?.call(request).await?;
+//!
+//! assert_eq!(response.headers()["content-length"], "10");
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Multiple Headers
+//!
+//! Use [`SetMultipleResponseHeadersLayer`] and [`SetMultipleResponseHeader`] to set multiple headers at once. Each header can have a fixed value or be computed dynamically.
+//!
+//! ## Example: Multiple Fixed Values
+//!
+//! ```
+//! use http::{Request, Response, header::{self, HeaderValue}};
+//! use tower::{Service, ServiceExt, ServiceBuilder};
+//! use tower_http::set_header::response::{SetMultipleResponseHeadersLayer, ResponseHeaderSetMetadata};
+//! use http_body_util::Full;
+//! use bytes::Bytes;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let render_html = tower::service_fn(|request: Request<Full<Bytes>>| async move {
+//! #     Ok::<_, std::convert::Infallible>(Response::new(request.into_body()))
+//! # });
+//!
+//! let mut svc = ServiceBuilder::new()
+//!     .layer(
+//!         SetMultipleResponseHeadersLayer::overriding(vec![
+//!             ResponseHeaderSetMetadata {
+//!                 header_name: header::CONTENT_TYPE,
+//!                 make: HeaderValue::from_static("text/html"),
+//!             },
+//!             ResponseHeaderSetMetadata {
+//!                 header_name: header::CACHE_CONTROL,
+//!                 make: HeaderValue::from_static("no-cache"),
+//!             },
+//!         ])
+//!     )
+//!     .service(render_html);
+//!
+//! let request = Request::new(Full::default());
+//!
+//! let response = svc.ready().await?.call(request).await?;
+//!
+//! assert_eq!(response.headers()["content-type"], "text/html");
+//! assert_eq!(response.headers()["cache-control"], "no-cache");
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Example: Multiple Dynamic Values
+//!
+//! ```
+//! use http::{Request, Response, header::{self, HeaderValue}};
+//! use tower::{Service, ServiceExt, ServiceBuilder};
+//! use tower_http::set_header::response::{SetMultipleResponseHeadersLayer, ResponseHeaderSetMetadata};
+//! use bytes::Bytes;
+//! use http_body_util::Full;
+//! use http_body::Body as _; // for `Body::size_hint`
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let render_html = tower::service_fn(|request: Request<Full<Bytes>>| async move {
+//! #     Ok::<_, std::convert::Infallible>(Response::new(Full::from("1234567890")))
+//! # });
+//!
+//! let mut svc = ServiceBuilder::new()
+//!     .layer(
+//!         SetMultipleResponseHeadersLayer::overriding(vec![
+//!             ResponseHeaderSetMetadata {
+//!                 header_name: header::CONTENT_LENGTH,
+//!                 make: |response: &Response<Full<Bytes>>| {
+//!                     if let Some(size) = response.body().size_hint().exact() {
+//!                         Some(HeaderValue::from_str(&size.to_string()).unwrap())
+//!                     } else {
+//!                         None
+//!                     }
+//!                 },
+//!             },
+//!         ])
+//!     )
+//!     .service(render_html);
+//!
+//! let request = Request::new(Full::default());
+//!
+//! let response = svc.ready().await?.call(request).await?;
+//!
+//! assert_eq!(response.headers()["content-length"], "10");
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Modes
+//!
+//! - `overriding`: If a previous value exists for the same header, it is removed and replaced with the new value.
+//! - `appending`: The new header is always added, preserving any existing values. If previous values exist, the header will have multiple values.
+//! - `if_not_present`: If a previous value exists for the header, the new value is not inserted.
+//!
+//! See [`SetResponseHeaderLayer`], [`SetResponseHeader`], [`SetMultipleResponseHeadersLayer`], and [`SetMultipleResponseHeader`] for more details.
+
+mod multiple_header;
+mod single_header;
+
+pub use multiple_header::{
+    HeaderMetadata, SetMultipleResponseHeader, SetMultipleResponseHeadersLayer,
+};
+pub use single_header::{SetResponseHeader, SetResponseHeaderLayer};

--- a/tower-http/src/set_header/response/mod.rs
+++ b/tower-http/src/set_header/response/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! # Single Header
 //!
-//! Use [`SetResponseHeaderLayer`] and [`SetResponseHeader`] to set a single header. The header value can be a fixed value or computed dynamically using a closure. See the [`MakeHeaderValue`] trait for details.
+//! Use [`SetResponseHeaderLayer`] and [`SetResponseHeader`] to set a single header. The header value can be a fixed value or computed dynamically using a closure. See [`crate::set_header::MakeHeaderValue`] for details.
 //!
 //! ## Example: Fixed Value
 //!

--- a/tower-http/src/set_header/response/mod.rs
+++ b/tower-http/src/set_header/response/mod.rs
@@ -88,7 +88,7 @@
 //! ```
 //! use http::{Request, Response, header::{self, HeaderValue}};
 //! use tower::{Service, ServiceExt, ServiceBuilder};
-//! use tower_http::set_header::response::{SetMultipleResponseHeadersLayer, ResponseHeaderSetMetadata};
+//! use tower_http::set_header::response::{SetMultipleResponseHeadersLayer, HeaderMetadata};
 //! use http_body_util::Full;
 //! use bytes::Bytes;
 //!
@@ -101,11 +101,11 @@
 //! let mut svc = ServiceBuilder::new()
 //!     .layer(
 //!         SetMultipleResponseHeadersLayer::overriding(vec![
-//!             ResponseHeaderSetMetadata {
+//!             HeaderMetadata {
 //!                 header_name: header::CONTENT_TYPE,
 //!                 make: HeaderValue::from_static("text/html"),
 //!             },
-//!             ResponseHeaderSetMetadata {
+//!             HeaderMetadata {
 //!                 header_name: header::CACHE_CONTROL,
 //!                 make: HeaderValue::from_static("no-cache"),
 //!             },
@@ -128,7 +128,7 @@
 //! ```
 //! use http::{Request, Response, header::{self, HeaderValue}};
 //! use tower::{Service, ServiceExt, ServiceBuilder};
-//! use tower_http::set_header::response::{SetMultipleResponseHeadersLayer, ResponseHeaderSetMetadata};
+//! use tower_http::set_header::response::{SetMultipleResponseHeadersLayer, HeaderMetadata};
 //! use bytes::Bytes;
 //! use http_body_util::Full;
 //! use http_body::Body as _; // for `Body::size_hint`
@@ -142,7 +142,7 @@
 //! let mut svc = ServiceBuilder::new()
 //!     .layer(
 //!         SetMultipleResponseHeadersLayer::overriding(vec![
-//!             ResponseHeaderSetMetadata {
+//!             HeaderMetadata {
 //!                 header_name: header::CONTENT_LENGTH,
 //!                 make: |response: &Response<Full<Bytes>>| {
 //!                     if let Some(size) = response.body().size_hint().exact() {

--- a/tower-http/src/set_header/response/multiple_header.rs
+++ b/tower-http/src/set_header/response/multiple_header.rs
@@ -1,4 +1,8 @@
-use http::{header::HeaderName, Request, Response};
+//! Set multiple headers on the response.
+//!
+//! See the root [`crate::set_header::response`] module for full documentation and usage examples.
+//!
+use http::{header::HeaderName, HeaderValue, Request, Response};
 use pin_project_lite::pin_project;
 use std::{
     fmt,
@@ -11,37 +15,74 @@ use tower_service::Service;
 
 use crate::set_header::{InsertHeaderMode, MakeHeaderValue};
 
-pub trait HeaderMetadataGenerator<M> {
-    fn to_metadata(self) -> HeaderMetadata<M>;
+/// A trait that combines MakeHeaderValue and Clone capability for trait objects.
+trait CloneableMakeHeaderValue<T>: MakeHeaderValue<T> + Send + Sync {
+    fn clone_box(&self) -> Box<dyn CloneableMakeHeaderValue<T>>;
+}
+
+impl<T, M> CloneableMakeHeaderValue<T> for M
+where
+    M: MakeHeaderValue<T> + Clone + Send + Sync + 'static,
+{
+    fn clone_box(&self) -> Box<dyn CloneableMakeHeaderValue<T>> {
+        Box::new(self.clone())
+    }
+}
+
+/// A "Bridge" struct that allows for trait object-based header value generation.
+struct BoxedMakeHeaderValue<T>(Box<dyn CloneableMakeHeaderValue<T>>);
+
+impl<T> BoxedMakeHeaderValue<T> {
+    /// Create a new BoxedMakeHeaderValue from any maker that implements MakeHeaderValue and Clone.
+    fn new<M>(maker: M) -> Self
+    where
+        M: MakeHeaderValue<T> + Clone + Send + Sync + 'static,
+    {
+        Self(Box::new(maker))
+    }
+}
+
+impl<T> Clone for BoxedMakeHeaderValue<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone_box())
+    }
+}
+
+impl<T> MakeHeaderValue<T> for BoxedMakeHeaderValue<T> {
+    fn make_header_value(&mut self, message: &T) -> Option<HeaderValue> {
+        self.0.make_header_value(message)
+    }
+}
+
+impl<T> fmt::Debug for BoxedMakeHeaderValue<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BoxedMakeHeaderValue").finish()
+    }
 }
 
 /// Metadata describing a response header to be set by [`SetMultipleResponseHeadersLayer`] or [`SetMultipleResponseHeader`].
 #[derive(Clone, Debug)]
-pub struct HeaderMetadata<M> {
+pub struct HeaderMetadata<T> {
     /// The name of the header to set.
-    pub header_name: HeaderName,
+    header_name: HeaderName,
     /// The value or value factory for the header.
-    pub make: M,
+    make: BoxedMakeHeaderValue<T>,
 }
 
-impl<M> HeaderMetadataGenerator<M> for HeaderMetadata<M> {
-    fn to_metadata(self) -> HeaderMetadata<M> {
-        self
-    }
-}
-
-impl<M> HeaderMetadataGenerator<M> for (HeaderName, M) {
-    fn to_metadata(self) -> HeaderMetadata<M> {
-        HeaderMetadata {
-            header_name: self.0,
-            make: self.1,
+impl<T> HeaderMetadata<T> {
+    /// Create a new HeaderMetadata with the given header name and value factory.
+    fn new<M: CloneableMakeHeaderValue<T> + Clone + 'static>(
+        header_name: HeaderName,
+        make: M,
+    ) -> Self {
+        Self {
+            header_name,
+            make: BoxedMakeHeaderValue::new(make),
         }
     }
-}
 
-impl<M> HeaderMetadata<M> {
     /// Convert this metadata into a [`HeaderInsertionConfig`] with the given insertion mode.
-    fn convert_to_header_config(self, mode: InsertHeaderMode) -> HeaderInsertionConfig<M> {
+    fn build_config(self, mode: InsertHeaderMode) -> HeaderInsertionConfig<T> {
         HeaderInsertionConfig {
             header_name: self.header_name,
             make: self.make,
@@ -50,45 +91,67 @@ impl<M> HeaderMetadata<M> {
     }
 }
 
-#[derive(Clone, Debug)]
-struct HeaderInsertionConfig<M> {
+impl<T, M> From<(HeaderName, M)> for HeaderMetadata<T>
+where
+    M: CloneableMakeHeaderValue<T> + Clone + 'static,
+{
+    fn from((header_name, make): (HeaderName, M)) -> Self {
+        HeaderMetadata::new(header_name, make)
+    }
+}
+
+struct HeaderInsertionConfig<T> {
     header_name: HeaderName,
-    make: M,
+    make: BoxedMakeHeaderValue<T>,
     mode: InsertHeaderMode,
+}
+
+impl<T> Clone for HeaderInsertionConfig<T>
+where
+    BoxedMakeHeaderValue<T>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            make: self.make.clone(),
+            mode: self.mode,
+        }
+    }
+}
+
+impl<T> fmt::Debug for HeaderInsertionConfig<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HeaderInsertionConfig")
+            .field("header_name", &self.header_name)
+            .field("mode", &self.mode)
+            .field("make", &"BoxedMakeHeaderValue")
+            .finish()
+    }
 }
 
 /// Layer that applies [`SetMultipleResponseHeader`] which adds multiple response headers.
 ///
 /// See [`SetMultipleResponseHeader`] for more details.
-pub struct SetMultipleResponseHeadersLayer<M> {
-    headers: Vec<HeaderInsertionConfig<M>>,
+pub struct SetMultipleResponseHeadersLayer<T> {
+    headers: Vec<HeaderInsertionConfig<T>>,
 }
 
-impl<M> fmt::Debug for SetMultipleResponseHeadersLayer<M> {
+impl<T> fmt::Debug for SetMultipleResponseHeadersLayer<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for metadata in &self.headers {
-            f.debug_struct("SetMultipleResponseHeadersLayer")
-                .field("header_name", &metadata.header_name)
-                .field("mode", &metadata.mode)
-                .field("make", &std::any::type_name::<M>())
-                .finish()?;
-        }
-
-        Ok(())
+        f.debug_struct("SetMultipleResponseHeadersLayer")
+            .field("headers", &self.headers)
+            .finish()
     }
 }
 
-impl<M> SetMultipleResponseHeadersLayer<M> {
+impl<T> SetMultipleResponseHeadersLayer<T> {
     /// Create a new [`SetMultipleResponseHeadersLayer`] that overrides any existing values for the same header.
     ///
     /// If any previous value exists for the same header, it is removed and replaced with the new matching header value.
-    pub fn overriding(metadata: Vec<impl HeaderMetadataGenerator<M>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<M>> = metadata
+    pub fn overriding(metadata: Vec<HeaderMetadata<T>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<T>> = metadata
             .into_iter()
-            .map(|m| {
-                m.to_metadata()
-                    .convert_to_header_config(InsertHeaderMode::Override)
-            })
+            .map(|m| m.build_config(InsertHeaderMode::Override))
             .collect();
 
         Self::new(headers)
@@ -97,13 +160,10 @@ impl<M> SetMultipleResponseHeadersLayer<M> {
     /// Create a new [`SetMultipleResponseHeadersLayer`] that appends header values.
     ///
     /// The new header is always added, preserving any existing values. If previous values exist, the header will have multiple values.
-    pub fn appending(metadata: Vec<impl HeaderMetadataGenerator<M>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<M>> = metadata
+    pub fn appending(metadata: Vec<HeaderMetadata<T>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<T>> = metadata
             .into_iter()
-            .map(|m| {
-                m.to_metadata()
-                    .convert_to_header_config(InsertHeaderMode::Append)
-            })
+            .map(|m| m.build_config(InsertHeaderMode::Append))
             .collect();
 
         Self::new(headers)
@@ -112,29 +172,23 @@ impl<M> SetMultipleResponseHeadersLayer<M> {
     /// Create a new [`SetMultipleResponseHeadersLayer`] that only inserts if the header is not already present.
     ///
     /// If a previous value exists for the header, the new value is not inserted.
-    pub fn if_not_present(metadata: Vec<impl HeaderMetadataGenerator<M>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<M>> = metadata
+    pub fn if_not_present(metadata: Vec<HeaderMetadata<T>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<T>> = metadata
             .into_iter()
-            .map(|m| {
-                m.to_metadata()
-                    .convert_to_header_config(InsertHeaderMode::IfNotPresent)
-            })
+            .map(|m| m.build_config(InsertHeaderMode::IfNotPresent))
             .collect();
 
         Self::new(headers)
     }
 
     /// Internal constructor for a new [`SetMultipleResponseHeadersLayer`] from a list of headers.
-    fn new(headers: Vec<HeaderInsertionConfig<M>>) -> Self {
+    fn new(headers: Vec<HeaderInsertionConfig<T>>) -> Self {
         Self { headers }
     }
 }
 
-impl<S, M> Layer<S> for SetMultipleResponseHeadersLayer<M>
-where
-    M: Clone,
-{
-    type Service = SetMultipleResponseHeader<S, M>;
+impl<S, T> Layer<S> for SetMultipleResponseHeadersLayer<T> {
+    type Service = SetMultipleResponseHeader<S, T>;
 
     fn layer(&self, inner: S) -> Self::Service {
         SetMultipleResponseHeader {
@@ -145,23 +199,21 @@ where
 }
 
 /// Middleware that sets multiple headers on the response.
+
 #[derive(Clone)]
-pub struct SetMultipleResponseHeader<S, M> {
+pub struct SetMultipleResponseHeader<S, T> {
     inner: S,
-    headers: Vec<HeaderInsertionConfig<M>>,
+    headers: Vec<HeaderInsertionConfig<T>>,
 }
 
-impl<S, M> SetMultipleResponseHeader<S, M> {
+impl<S, T> SetMultipleResponseHeader<S, T> {
     /// Create a new [`SetMultipleResponseHeader`] that overrides any existing values for the same header.
     ///
     /// If a previous value exists for the same header, it is removed and replaced with the new header value.
-    pub fn overriding(inner: S, metadata: Vec<impl HeaderMetadataGenerator<M>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<M>> = metadata
+    pub fn overriding(inner: S, metadata: Vec<HeaderMetadata<T>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<T>> = metadata
             .into_iter()
-            .map(|m| {
-                m.to_metadata()
-                    .convert_to_header_config(InsertHeaderMode::Override)
-            })
+            .map(|m| m.build_config(InsertHeaderMode::Override))
             .collect();
 
         Self::new(inner, headers)
@@ -170,13 +222,10 @@ impl<S, M> SetMultipleResponseHeader<S, M> {
     /// Create a new [`SetMultipleResponseHeader`] that appends header values.
     ///
     /// The new header is always added, preserving any existing values. If previous values exist, the header will have multiple values.
-    pub fn appending(inner: S, metadata: Vec<impl HeaderMetadataGenerator<M>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<M>> = metadata
+    pub fn appending(inner: S, metadata: Vec<HeaderMetadata<T>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<T>> = metadata
             .into_iter()
-            .map(|m| {
-                m.to_metadata()
-                    .convert_to_header_config(InsertHeaderMode::Append)
-            })
+            .map(|m| m.build_config(InsertHeaderMode::Append))
             .collect();
 
         Self::new(inner, headers)
@@ -185,51 +234,43 @@ impl<S, M> SetMultipleResponseHeader<S, M> {
     /// Create a new [`SetMultipleResponseHeader`] that only inserts if the header is not already present.
     ///
     /// If a previous value exists for the header, the new value is not inserted.
-    pub fn if_not_present(inner: S, metadata: Vec<impl HeaderMetadataGenerator<M>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<M>> = metadata
+    pub fn if_not_present(inner: S, metadata: Vec<HeaderMetadata<T>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<T>> = metadata
             .into_iter()
-            .map(|m| {
-                m.to_metadata()
-                    .convert_to_header_config(InsertHeaderMode::IfNotPresent)
-            })
+            .map(|m| m.build_config(InsertHeaderMode::IfNotPresent))
             .collect();
 
         Self::new(inner, headers)
     }
 
     /// Internal constructor for a new [`SetMultipleResponseHeader`] from an inner service and a list of headers.
-    fn new(inner: S, headers: Vec<HeaderInsertionConfig<M>>) -> Self {
+    fn new(inner: S, headers: Vec<HeaderInsertionConfig<T>>) -> Self {
         Self { inner, headers }
     }
 
     define_inner_service_accessors!();
 }
 
-impl<S, M> fmt::Debug for SetMultipleResponseHeader<S, M>
+impl<S, T> fmt::Debug for SetMultipleResponseHeader<S, T>
 where
     S: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for metadata in &self.headers {
-            f.debug_struct("SetMultipleResponseHeader")
-                .field("header_name", &metadata.header_name)
-                .field("mode", &metadata.mode)
-                .field("make", &std::any::type_name::<M>())
-                .finish()?;
-        }
-
-        Ok(())
+        f.debug_struct("SetMultipleResponseHeader")
+            .field("inner", &self.inner)
+            .field("headers", &self.headers)
+            .finish()
     }
 }
 
-impl<ReqBody, ResBody, S, M> Service<Request<ReqBody>> for SetMultipleResponseHeader<S, M>
+impl<ReqBody, ResBody, S> Service<Request<ReqBody>>
+    for SetMultipleResponseHeader<S, Response<ResBody>>
 where
     S: Service<Request<ReqBody>, Response = Response<ResBody>>,
-    M: MakeHeaderValue<Response<ResBody>> + Clone,
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = ResponseFuture<S::Future, M>;
+    type Future = ResponseFuture<S::Future, Response<ResBody>>;
 
     #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -248,17 +289,16 @@ where
 pin_project! {
     /// Response future for [`SetMultipleResponseHeader`].
     #[derive(Debug)]
-    pub struct ResponseFuture<F, M> {
+    pub struct ResponseFuture<F, T> {
         #[pin]
         future: F,
-        headers: Vec<HeaderInsertionConfig<M>>,
+        headers: Vec<HeaderInsertionConfig<T>>,
     }
 }
 
-impl<F, ResBody, E, M> Future for ResponseFuture<F, M>
+impl<F, ResBody, E> Future for ResponseFuture<F, Response<ResBody>>
 where
     F: Future<Output = Result<Response<ResBody>, E>>,
-    M: MakeHeaderValue<Response<ResBody>>,
 {
     type Output = F::Output;
 
@@ -295,7 +335,7 @@ mod tests {
                     .unwrap();
                 Ok::<_, Infallible>(res)
             }),
-            vec![(header::CONTENT_TYPE, HeaderValue::from_static("text/html"))],
+            vec![(header::CONTENT_TYPE, HeaderValue::from_static("text/html")).into()],
         );
 
         let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
@@ -315,7 +355,7 @@ mod tests {
                     .unwrap();
                 Ok::<_, Infallible>(res)
             }),
-            vec![(header::CONTENT_TYPE, HeaderValue::from_static("text/html"))],
+            vec![(header::CONTENT_TYPE, HeaderValue::from_static("text/html")).into()],
         );
 
         let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
@@ -336,7 +376,7 @@ mod tests {
                     .unwrap();
                 Ok::<_, Infallible>(res)
             }),
-            vec![(header::CONTENT_TYPE, HeaderValue::from_static("text/html"))],
+            vec![(header::CONTENT_TYPE, HeaderValue::from_static("text/html")).into()],
         );
 
         let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
@@ -353,7 +393,7 @@ mod tests {
                 let res = Response::builder().body(Body::empty()).unwrap();
                 Ok::<_, Infallible>(res)
             }),
-            vec![(header::CONTENT_TYPE, HeaderValue::from_static("text/html"))],
+            vec![(header::CONTENT_TYPE, HeaderValue::from_static("text/html")).into()],
         );
 
         let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
@@ -365,44 +405,51 @@ mod tests {
 
     #[test]
     fn test_tuple_metadata_impl() {
-        use super::*;
         let tuple: (HeaderName, HeaderValue) =
             (header::CONTENT_TYPE, HeaderValue::from_static("foo"));
-        let meta = tuple.to_metadata();
+        let meta: HeaderMetadata<HeaderValue> = tuple.into();
         assert_eq!(meta.header_name, header::CONTENT_TYPE);
-        assert_eq!(meta.make, HeaderValue::from_static("foo"));
+        // Check that the header value is correct by making a header value from meta.make
+        let mut make = meta.make.clone();
+        assert_eq!(
+            make.make_header_value(&HeaderValue::from_static("foo")),
+            Some(HeaderValue::from_static("foo"))
+        );
     }
 
     #[test]
     fn test_convert_to_header_config_struct_and_tuple() {
-        use super::*;
-        let meta = HeaderMetadata {
+        let meta: HeaderMetadata<HeaderValue> = HeaderMetadata::<HeaderValue> {
             header_name: header::CONTENT_TYPE,
-            make: HeaderValue::from_static("bar"),
+            make: BoxedMakeHeaderValue::new(HeaderValue::from_static("bar")),
         };
-        let rh = meta.convert_to_header_config(crate::set_header::InsertHeaderMode::Override);
+        let rh = meta.build_config(crate::set_header::InsertHeaderMode::Override);
         assert_eq!(rh.header_name, header::CONTENT_TYPE);
-        assert_eq!(rh.make, HeaderValue::from_static("bar"));
+        let mut make = rh.make.clone();
+        assert_eq!(
+            make.make_header_value(&HeaderValue::from_static("bar")),
+            Some(HeaderValue::from_static("bar"))
+        );
 
         let tuple: (HeaderName, HeaderValue) =
             (header::CONTENT_TYPE, HeaderValue::from_static("baz"));
-        let rh2 = tuple
-            .to_metadata()
-            .convert_to_header_config(crate::set_header::InsertHeaderMode::Override);
+        let meta: HeaderMetadata<HeaderValue> = tuple.into();
+        let rh2 = meta.build_config(crate::set_header::InsertHeaderMode::Override);
         assert_eq!(rh2.header_name, header::CONTENT_TYPE);
-        assert_eq!(rh2.make, HeaderValue::from_static("baz"));
+        let mut make2 = rh2.make.clone();
+        assert_eq!(
+            make2.make_header_value(&HeaderValue::from_static("baz")),
+            Some(HeaderValue::from_static("baz"))
+        );
     }
 
     #[test]
     fn test_debug_impls() {
-        use super::*;
-        let meta = HeaderMetadata {
-            header_name: header::CONTENT_TYPE,
-            make: HeaderValue::from_static("bar"),
-        };
+        let meta: HeaderMetadata<HeaderValue> =
+            (header::CONTENT_TYPE, HeaderValue::from_static("bar")).into();
         let rh = meta
             .clone()
-            .convert_to_header_config(crate::set_header::InsertHeaderMode::Override);
+            .build_config(crate::set_header::InsertHeaderMode::Override);
         let layer = SetMultipleResponseHeadersLayer::overriding(vec![meta]);
         let debug_str = format!("{:?}", layer);
         assert!(debug_str.contains("SetMultipleResponseHeadersLayer"));
@@ -413,9 +460,74 @@ mod tests {
             tower::service_fn(|_req: Request<Body>| async {
                 Ok::<_, std::convert::Infallible>(Response::new(Body::empty()))
             }),
-            vec![(header::CONTENT_TYPE, HeaderValue::from_static("foo"))],
+            vec![(header::CONTENT_TYPE, HeaderValue::from_static("foo")).into()]
+                as Vec<HeaderMetadata<HeaderValue>>,
         );
         let debug_svc = format!("{:?}", svc);
         assert!(debug_svc.contains("SetMultipleResponseHeader"));
+    }
+
+    #[tokio::test]
+    async fn test_layer_construction_and_multiple_headers() {
+        // Multiple different headers in the same vec
+        let svc = tower::ServiceBuilder::new()
+            .layer(SetMultipleResponseHeadersLayer::overriding(vec![
+                (header::CONTENT_TYPE, HeaderValue::from_static("text/html")).into(),
+                (header::CACHE_CONTROL, HeaderValue::from_static("no-cache")).into(),
+            ]))
+            .service(service_fn(|_req: Request<Body>| async {
+                Ok::<_, Infallible>(Response::new(Body::empty()))
+            }));
+
+        let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
+        assert_eq!(res.headers()["content-type"], "text/html");
+        assert_eq!(res.headers()["cache-control"], "no-cache");
+    }
+
+    #[tokio::test]
+    async fn test_layer_with_empty_vec() {
+        let svc = tower::ServiceBuilder::new()
+            .layer(SetMultipleResponseHeadersLayer::<Response<Body>>::overriding(vec![]))
+            .service(service_fn(|_req: Request<Body>| async {
+                Ok::<_, Infallible>(Response::new(Body::empty()))
+            }));
+
+        let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
+        // No headers should be set
+        assert_eq!(res.headers().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_layer_with_static_and_closure_headers_fixed() {
+        // Wrap the static value
+        let static_meta = (header::CONTENT_TYPE, HeaderValue::from_static("text/html")).into();
+
+        // Wrap the closure
+        let closure_meta = (header::X_FRAME_OPTIONS, |_res: &Response<Body>| {
+            Some(HeaderValue::from_static("DENY"))
+        })
+            .into();
+
+        let svc = tower::ServiceBuilder::new()
+            .layer(SetMultipleResponseHeadersLayer::overriding(vec![
+                static_meta,
+                closure_meta,
+            ]))
+            .service(service_fn(|_req: Request<Body>| async {
+                Ok::<_, Infallible>(Response::new(Body::empty()))
+            }));
+
+        let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
+        assert_eq!(res.headers()["content-type"], "text/html");
+        assert_eq!(res.headers()["x-frame-options"], "DENY");
+    }
+
+    #[test]
+    fn test_debug_layer_and_service() {
+        let meta: HeaderMetadata<HeaderValue> =
+            (header::CONTENT_TYPE, HeaderValue::from_static("foo")).into();
+        let layer = SetMultipleResponseHeadersLayer::overriding(vec![meta]);
+        let debug_str = format!("{:?}", layer);
+        assert!(debug_str.contains("SetMultipleResponseHeadersLayer"));
     }
 }

--- a/tower-http/src/set_header/response/multiple_header.rs
+++ b/tower-http/src/set_header/response/multiple_header.rs
@@ -71,7 +71,7 @@ pub struct HeaderMetadata<T> {
 
 impl<T> HeaderMetadata<T> {
     /// Create a new HeaderMetadata with the given header name and value factory.
-    fn new<M: CloneableMakeHeaderValue<T> + Clone + 'static>(
+    fn new<M: MakeHeaderValue<T> + Clone + 'static + Send + Sync>(
         header_name: HeaderName,
         make: M,
     ) -> Self {
@@ -93,7 +93,7 @@ impl<T> HeaderMetadata<T> {
 
 impl<T, M> From<(HeaderName, M)> for HeaderMetadata<T>
 where
-    M: CloneableMakeHeaderValue<T> + Clone + 'static,
+    M: MakeHeaderValue<T> + Clone + 'static + Send + Sync,
 {
     fn from((header_name, make): (HeaderName, M)) -> Self {
         HeaderMetadata::new(header_name, make)

--- a/tower-http/src/set_header/response/multiple_header.rs
+++ b/tower-http/src/set_header/response/multiple_header.rs
@@ -407,7 +407,7 @@ mod tests {
         let debug_str = format!("{:?}", layer);
         assert!(debug_str.contains("SetMultipleResponseHeadersLayer"));
         let debug_rh = format!("{:?}", rh);
-        assert!(debug_rh.contains("ResponseHeader"));
+        assert!(debug_rh.contains("HeaderInsertionConfig"));
 
         let svc = SetMultipleResponseHeader::overriding(
             tower::service_fn(|_req: Request<Body>| async {

--- a/tower-http/src/set_header/response/multiple_header.rs
+++ b/tower-http/src/set_header/response/multiple_header.rs
@@ -1,0 +1,421 @@
+use http::{header::HeaderName, Request, Response};
+use pin_project_lite::pin_project;
+use std::{
+    fmt,
+    future::Future,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+use tower_layer::Layer;
+use tower_service::Service;
+
+use crate::set_header::{InsertHeaderMode, MakeHeaderValue};
+
+pub trait HeaderMetadataGenerator<M> {
+    fn to_metadata(self) -> HeaderMetadata<M>;
+}
+
+/// Metadata describing a response header to be set by [`SetMultipleResponseHeadersLayer`] or [`SetMultipleResponseHeader`].
+#[derive(Clone, Debug)]
+pub struct HeaderMetadata<M> {
+    /// The name of the header to set.
+    pub header_name: HeaderName,
+    /// The value or value factory for the header.
+    pub make: M,
+}
+
+impl<M> HeaderMetadataGenerator<M> for HeaderMetadata<M> {
+    fn to_metadata(self) -> HeaderMetadata<M> {
+        self
+    }
+}
+
+impl<M> HeaderMetadataGenerator<M> for (HeaderName, M) {
+    fn to_metadata(self) -> HeaderMetadata<M> {
+        HeaderMetadata {
+            header_name: self.0,
+            make: self.1,
+        }
+    }
+}
+
+impl<M> HeaderMetadata<M> {
+    /// Convert this metadata into a [`HeaderInsertionConfig`] with the given insertion mode.
+    fn convert_to_header_config(self, mode: InsertHeaderMode) -> HeaderInsertionConfig<M> {
+        HeaderInsertionConfig {
+            header_name: self.header_name,
+            make: self.make,
+            mode,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct HeaderInsertionConfig<M> {
+    header_name: HeaderName,
+    make: M,
+    mode: InsertHeaderMode,
+}
+
+/// Layer that applies [`SetMultipleResponseHeader`] which adds multiple response headers.
+///
+/// See [`SetMultipleResponseHeader`] for more details.
+pub struct SetMultipleResponseHeadersLayer<M> {
+    headers: Vec<HeaderInsertionConfig<M>>,
+}
+
+impl<M> fmt::Debug for SetMultipleResponseHeadersLayer<M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for metadata in &self.headers {
+            f.debug_struct("SetMultipleResponseHeadersLayer")
+                .field("header_name", &metadata.header_name)
+                .field("mode", &metadata.mode)
+                .field("make", &std::any::type_name::<M>())
+                .finish()?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<M> SetMultipleResponseHeadersLayer<M> {
+    /// Create a new [`SetMultipleResponseHeadersLayer`] that overrides any existing values for the same header.
+    ///
+    /// If any previous value exists for the same header, it is removed and replaced with the new matching header value.
+    pub fn overriding(metadata: Vec<impl HeaderMetadataGenerator<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
+            .into_iter()
+            .map(|m| {
+                m.to_metadata()
+                    .convert_to_header_config(InsertHeaderMode::Override)
+            })
+            .collect();
+
+        Self::new(headers)
+    }
+
+    /// Create a new [`SetMultipleResponseHeadersLayer`] that appends header values.
+    ///
+    /// The new header is always added, preserving any existing values. If previous values exist, the header will have multiple values.
+    pub fn appending(metadata: Vec<impl HeaderMetadataGenerator<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
+            .into_iter()
+            .map(|m| {
+                m.to_metadata()
+                    .convert_to_header_config(InsertHeaderMode::Append)
+            })
+            .collect();
+
+        Self::new(headers)
+    }
+
+    /// Create a new [`SetMultipleResponseHeadersLayer`] that only inserts if the header is not already present.
+    ///
+    /// If a previous value exists for the header, the new value is not inserted.
+    pub fn if_not_present(metadata: Vec<impl HeaderMetadataGenerator<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
+            .into_iter()
+            .map(|m| {
+                m.to_metadata()
+                    .convert_to_header_config(InsertHeaderMode::IfNotPresent)
+            })
+            .collect();
+
+        Self::new(headers)
+    }
+
+    /// Internal constructor for a new [`SetMultipleResponseHeadersLayer`] from a list of headers.
+    fn new(headers: Vec<HeaderInsertionConfig<M>>) -> Self {
+        Self { headers }
+    }
+}
+
+impl<S, M> Layer<S> for SetMultipleResponseHeadersLayer<M>
+where
+    M: Clone,
+{
+    type Service = SetMultipleResponseHeader<S, M>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        SetMultipleResponseHeader {
+            inner,
+            headers: self.headers.clone(),
+        }
+    }
+}
+
+/// Middleware that sets multiple headers on the response.
+#[derive(Clone)]
+pub struct SetMultipleResponseHeader<S, M> {
+    inner: S,
+    headers: Vec<HeaderInsertionConfig<M>>,
+}
+
+impl<S, M> SetMultipleResponseHeader<S, M> {
+    /// Create a new [`SetMultipleResponseHeader`] that overrides any existing values for the same header.
+    ///
+    /// If a previous value exists for the same header, it is removed and replaced with the new header value.
+    pub fn overriding(inner: S, metadata: Vec<impl HeaderMetadataGenerator<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
+            .into_iter()
+            .map(|m| {
+                m.to_metadata()
+                    .convert_to_header_config(InsertHeaderMode::Override)
+            })
+            .collect();
+
+        Self::new(inner, headers)
+    }
+
+    /// Create a new [`SetMultipleResponseHeader`] that appends header values.
+    ///
+    /// The new header is always added, preserving any existing values. If previous values exist, the header will have multiple values.
+    pub fn appending(inner: S, metadata: Vec<impl HeaderMetadataGenerator<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
+            .into_iter()
+            .map(|m| {
+                m.to_metadata()
+                    .convert_to_header_config(InsertHeaderMode::Append)
+            })
+            .collect();
+
+        Self::new(inner, headers)
+    }
+
+    /// Create a new [`SetMultipleResponseHeader`] that only inserts if the header is not already present.
+    ///
+    /// If a previous value exists for the header, the new value is not inserted.
+    pub fn if_not_present(inner: S, metadata: Vec<impl HeaderMetadataGenerator<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
+            .into_iter()
+            .map(|m| {
+                m.to_metadata()
+                    .convert_to_header_config(InsertHeaderMode::IfNotPresent)
+            })
+            .collect();
+
+        Self::new(inner, headers)
+    }
+
+    /// Internal constructor for a new [`SetMultipleResponseHeader`] from an inner service and a list of headers.
+    fn new(inner: S, headers: Vec<HeaderInsertionConfig<M>>) -> Self {
+        Self { inner, headers }
+    }
+
+    define_inner_service_accessors!();
+}
+
+impl<S, M> fmt::Debug for SetMultipleResponseHeader<S, M>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for metadata in &self.headers {
+            f.debug_struct("SetMultipleResponseHeader")
+                .field("header_name", &metadata.header_name)
+                .field("mode", &metadata.mode)
+                .field("make", &std::any::type_name::<M>())
+                .finish()?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<ReqBody, ResBody, S, M> Service<Request<ReqBody>> for SetMultipleResponseHeader<S, M>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    M: MakeHeaderValue<Response<ResBody>> + Clone,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future, M>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    /// Call the inner service and apply all configured headers to the response.
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        ResponseFuture {
+            future: self.inner.call(req),
+            headers: self.headers.clone(),
+        }
+    }
+}
+
+pin_project! {
+    /// Response future for [`SetMultipleResponseHeader`].
+    #[derive(Debug)]
+    pub struct ResponseFuture<F, M> {
+        #[pin]
+        future: F,
+        headers: Vec<HeaderInsertionConfig<M>>,
+    }
+}
+
+impl<F, ResBody, E, M> Future for ResponseFuture<F, M>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+    M: MakeHeaderValue<Response<ResBody>>,
+{
+    type Output = F::Output;
+
+    /// Polls the inner future and applies all configured headers to the response before returning it.
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let mut res = ready!(this.future.poll(cx)?);
+
+        for header in this.headers {
+            header
+                .mode
+                .apply(&header.header_name, &mut res, &mut header.make);
+        }
+
+        Poll::Ready(Ok(res))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::Body;
+    use http::{header, HeaderValue};
+    use std::convert::Infallible;
+    use tower::{service_fn, ServiceExt};
+
+    #[tokio::test]
+    async fn test_override_mode() {
+        let svc = SetMultipleResponseHeader::overriding(
+            service_fn(|_req: Request<Body>| async {
+                let res = Response::builder()
+                    .header(header::CONTENT_TYPE, "good-content")
+                    .body(Body::empty())
+                    .unwrap();
+                Ok::<_, Infallible>(res)
+            }),
+            vec![(header::CONTENT_TYPE, HeaderValue::from_static("text/html"))],
+        );
+
+        let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
+
+        let mut values = res.headers().get_all(header::CONTENT_TYPE).iter();
+        assert_eq!(values.next().unwrap(), "text/html");
+        assert_eq!(values.next(), None);
+    }
+
+    #[tokio::test]
+    async fn test_append_mode() {
+        let svc = SetMultipleResponseHeader::appending(
+            service_fn(|_req: Request<Body>| async {
+                let res = Response::builder()
+                    .header(header::CONTENT_TYPE, "good-content")
+                    .body(Body::empty())
+                    .unwrap();
+                Ok::<_, Infallible>(res)
+            }),
+            vec![(header::CONTENT_TYPE, HeaderValue::from_static("text/html"))],
+        );
+
+        let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
+
+        let mut values = res.headers().get_all(header::CONTENT_TYPE).iter();
+        assert_eq!(values.next().unwrap(), "good-content");
+        assert_eq!(values.next().unwrap(), "text/html");
+        assert_eq!(values.next(), None);
+    }
+
+    #[tokio::test]
+    async fn test_skip_if_present_mode() {
+        let svc = SetMultipleResponseHeader::if_not_present(
+            service_fn(|_req: Request<Body>| async {
+                let res = Response::builder()
+                    .header(header::CONTENT_TYPE, "good-content")
+                    .body(Body::empty())
+                    .unwrap();
+                Ok::<_, Infallible>(res)
+            }),
+            vec![(header::CONTENT_TYPE, HeaderValue::from_static("text/html"))],
+        );
+
+        let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
+
+        let mut values = res.headers().get_all(header::CONTENT_TYPE).iter();
+        assert_eq!(values.next().unwrap(), "good-content");
+        assert_eq!(values.next(), None);
+    }
+
+    #[tokio::test]
+    async fn test_skip_if_present_mode_when_not_present() {
+        let svc = SetMultipleResponseHeader::if_not_present(
+            service_fn(|_req: Request<Body>| async {
+                let res = Response::builder().body(Body::empty()).unwrap();
+                Ok::<_, Infallible>(res)
+            }),
+            vec![(header::CONTENT_TYPE, HeaderValue::from_static("text/html"))],
+        );
+
+        let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
+
+        let mut values = res.headers().get_all(header::CONTENT_TYPE).iter();
+        assert_eq!(values.next().unwrap(), "text/html");
+        assert_eq!(values.next(), None);
+    }
+
+    #[test]
+    fn test_tuple_metadata_impl() {
+        use super::*;
+        let tuple: (HeaderName, HeaderValue) =
+            (header::CONTENT_TYPE, HeaderValue::from_static("foo"));
+        let meta = tuple.to_metadata();
+        assert_eq!(meta.header_name, header::CONTENT_TYPE);
+        assert_eq!(meta.make, HeaderValue::from_static("foo"));
+    }
+
+    #[test]
+    fn test_convert_to_header_config_struct_and_tuple() {
+        use super::*;
+        let meta = HeaderMetadata {
+            header_name: header::CONTENT_TYPE,
+            make: HeaderValue::from_static("bar"),
+        };
+        let rh = meta.convert_to_header_config(crate::set_header::InsertHeaderMode::Override);
+        assert_eq!(rh.header_name, header::CONTENT_TYPE);
+        assert_eq!(rh.make, HeaderValue::from_static("bar"));
+
+        let tuple: (HeaderName, HeaderValue) =
+            (header::CONTENT_TYPE, HeaderValue::from_static("baz"));
+        let rh2 = tuple
+            .to_metadata()
+            .convert_to_header_config(crate::set_header::InsertHeaderMode::Override);
+        assert_eq!(rh2.header_name, header::CONTENT_TYPE);
+        assert_eq!(rh2.make, HeaderValue::from_static("baz"));
+    }
+
+    #[test]
+    fn test_debug_impls() {
+        use super::*;
+        let meta = HeaderMetadata {
+            header_name: header::CONTENT_TYPE,
+            make: HeaderValue::from_static("bar"),
+        };
+        let rh = meta
+            .clone()
+            .convert_to_header_config(crate::set_header::InsertHeaderMode::Override);
+        let layer = SetMultipleResponseHeadersLayer::overriding(vec![meta]);
+        let debug_str = format!("{:?}", layer);
+        assert!(debug_str.contains("SetMultipleResponseHeadersLayer"));
+        let debug_rh = format!("{:?}", rh);
+        assert!(debug_rh.contains("ResponseHeader"));
+
+        let svc = SetMultipleResponseHeader::overriding(
+            tower::service_fn(|_req: Request<Body>| async {
+                Ok::<_, std::convert::Infallible>(Response::new(Body::empty()))
+            }),
+            vec![(header::CONTENT_TYPE, HeaderValue::from_static("foo"))],
+        );
+        let debug_svc = format!("{:?}", svc);
+        assert!(debug_svc.contains("SetMultipleResponseHeader"));
+    }
+}

--- a/tower-http/src/set_header/response/single_header.rs
+++ b/tower-http/src/set_header/response/single_header.rs
@@ -1,3 +1,7 @@
+//! Set a single header on the response.
+//!
+//! See the root [`crate::set_header::response`] module for full documentation and usage examples.
+//!
 use http::{header::HeaderName, Request, Response};
 use pin_project_lite::pin_project;
 use std::{

--- a/tower-http/src/set_header/response/single_header.rs
+++ b/tower-http/src/set_header/response/single_header.rs
@@ -1,100 +1,3 @@
-//! Set a header on the response.
-//!
-//! The header value to be set may be provided as a fixed value when the
-//! middleware is constructed, or determined dynamically based on the response
-//! by a closure. See the [`MakeHeaderValue`] trait for details.
-//!
-//! # Example
-//!
-//! Setting a header from a fixed value provided when the middleware is constructed:
-//!
-//! ```
-//! use http::{Request, Response, header::{self, HeaderValue}};
-//! use tower::{Service, ServiceExt, ServiceBuilder};
-//! use tower_http::set_header::SetResponseHeaderLayer;
-//! use http_body_util::Full;
-//! use bytes::Bytes;
-//!
-//! # #[tokio::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # let render_html = tower::service_fn(|request: Request<Full<Bytes>>| async move {
-//! #     Ok::<_, std::convert::Infallible>(Response::new(request.into_body()))
-//! # });
-//! #
-//! let mut svc = ServiceBuilder::new()
-//!     .layer(
-//!         // Layer that sets `Content-Type: text/html` on responses.
-//!         //
-//!         // `if_not_present` will only insert the header if it does not already
-//!         // have a value.
-//!         SetResponseHeaderLayer::if_not_present(
-//!             header::CONTENT_TYPE,
-//!             HeaderValue::from_static("text/html"),
-//!         )
-//!     )
-//!     .service(render_html);
-//!
-//! let request = Request::new(Full::default());
-//!
-//! let response = svc.ready().await?.call(request).await?;
-//!
-//! assert_eq!(response.headers()["content-type"], "text/html");
-//! #
-//! # Ok(())
-//! # }
-//! ```
-//!
-//! Setting a header based on a value determined dynamically from the response:
-//!
-//! ```
-//! use http::{Request, Response, header::{self, HeaderValue}};
-//! use tower::{Service, ServiceExt, ServiceBuilder};
-//! use tower_http::set_header::SetResponseHeaderLayer;
-//! use bytes::Bytes;
-//! use http_body_util::Full;
-//! use http_body::Body as _; // for `Body::size_hint`
-//!
-//! # #[tokio::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # let render_html = tower::service_fn(|request: Request<Full<Bytes>>| async move {
-//! #     Ok::<_, std::convert::Infallible>(Response::new(Full::from("1234567890")))
-//! # });
-//! #
-//! let mut svc = ServiceBuilder::new()
-//!     .layer(
-//!         // Layer that sets `Content-Length` if the body has a known size.
-//!         // Bodies with streaming responses wont have a known size.
-//!         //
-//!         // `overriding` will insert the header and override any previous values it
-//!         // may have.
-//!         SetResponseHeaderLayer::overriding(
-//!             header::CONTENT_LENGTH,
-//!             |response: &Response<Full<Bytes>>| {
-//!                 if let Some(size) = response.body().size_hint().exact() {
-//!                     // If the response body has a known size, returning `Some` will
-//!                     // set the `Content-Length` header to that value.
-//!                     Some(HeaderValue::from_str(&size.to_string()).unwrap())
-//!                 } else {
-//!                     // If the response body doesn't have a known size, return `None`
-//!                     // to skip setting the header on this response.
-//!                     None
-//!                 }
-//!             }
-//!         )
-//!     )
-//!     .service(render_html);
-//!
-//! let request = Request::new(Full::default());
-//!
-//! let response = svc.ready().await?.call(request).await?;
-//!
-//! assert_eq!(response.headers()["content-length"], "10");
-//! #
-//! # Ok(())
-//! # }
-//! ```
-
-use super::{InsertHeaderMode, MakeHeaderValue};
 use http::{header::HeaderName, Request, Response};
 use pin_project_lite::pin_project;
 use std::{
@@ -105,6 +8,8 @@ use std::{
 };
 use tower_layer::Layer;
 use tower_service::Service;
+
+use crate::set_header::{InsertHeaderMode, MakeHeaderValue};
 
 /// Layer that applies [`SetResponseHeader`] which adds a response header.
 ///


### PR DESCRIPTION
## Motivation

Fixes #571

Offering the ability to add multiple headers at once

## Solution

For better code organisation, the `response.rs` file, which handles the response request, is now a module and split into two files. One for setting a single header and the other for multiple, while still maintaining the current API structure.

The functions handling setting headers take a dynamic variable that implements `HeaderMetadataGenerator`. The newly created `HeaderMetadata` and tuple of `(HeaderName, M)` currently implemented in `M` can be `HeaderValue` (A test case covers this). This also helps with maintainability
