### PR TITLE
Relaxed Vary header defaults

### DIFF
--- a/tower-http/src/cors/allow_headers.rs
+++ b/tower-http/src/cors/allow_headers.rs
@@ -58,6 +58,10 @@ impl AllowHeaders {
         matches!(&self.0, AllowHeadersInner::Const(Some(v)) if v == WILDCARD)
     }
 
+    pub(super) fn varies_with_request_headers(&self) -> bool {
+        matches!(&self.0, AllowHeadersInner::MirrorRequest)
+    }
+
     pub(super) fn to_header(&self, parts: &RequestParts) -> Option<(HeaderName, HeaderValue)> {
         let allow_headers = match &self.0 {
             AllowHeadersInner::Const(v) => v.clone()?,

--- a/tower-http/src/cors/allow_headers.rs
+++ b/tower-http/src/cors/allow_headers.rs
@@ -59,7 +59,7 @@ impl AllowHeaders {
     }
 
     pub(super) fn varies_with_request_headers(&self) -> bool {
-        matches!(&self.0, AllowHeadersInner::MirrorRequest)
+        !matches!(&self.0, AllowHeadersInner::Const(_))
     }
 
     pub(super) fn to_header(&self, parts: &RequestParts) -> Option<(HeaderName, HeaderValue)> {

--- a/tower-http/src/cors/allow_methods.rs
+++ b/tower-http/src/cors/allow_methods.rs
@@ -73,7 +73,7 @@ impl AllowMethods {
     }
 
     pub(super) fn varies_with_request_method(&self) -> bool {
-        matches!(&self.0, AllowMethodsInner::MirrorRequest)
+        !matches!(&self.0, AllowMethodsInner::Const(_))
     }
 
     pub(super) fn to_header(&self, parts: &RequestParts) -> Option<(HeaderName, HeaderValue)> {

--- a/tower-http/src/cors/allow_methods.rs
+++ b/tower-http/src/cors/allow_methods.rs
@@ -72,6 +72,10 @@ impl AllowMethods {
         matches!(&self.0, AllowMethodsInner::Const(Some(v)) if v == WILDCARD)
     }
 
+    pub(super) fn varies_with_request_method(&self) -> bool {
+        matches!(&self.0, AllowMethodsInner::MirrorRequest)
+    }
+
     pub(super) fn to_header(&self, parts: &RequestParts) -> Option<(HeaderName, HeaderValue)> {
         let allow_methods = match &self.0 {
             AllowMethodsInner::Const(v) => v.clone()?,

--- a/tower-http/src/cors/allow_origin.rs
+++ b/tower-http/src/cors/allow_origin.rs
@@ -111,6 +111,10 @@ impl AllowOrigin {
         matches!(&self.0, OriginInner::Const(v) if v == WILDCARD)
     }
 
+    pub(super) fn varies_with_origin(&self) -> bool {
+        !matches!(&self.0, OriginInner::Const(_))
+    }
+
     pub(super) fn to_future(
         &self,
         origin: Option<&HeaderValue>,

--- a/tower-http/src/cors/mod.rs
+++ b/tower-http/src/cors/mod.rs
@@ -431,12 +431,20 @@ impl CorsLayer {
 
     /// Set the value(s) of the [`Vary`][mdn] header.
     ///
-    /// In contrast to the other headers, this one has a non-empty default of
-    /// [`preflight_request_headers()`].
+    /// By default, this value is derived from whether CORS response headers are
+    /// request-dependent:
     ///
-    /// You only need to set this if you want to remove some of these defaults,
-    /// or if you use a closure for one of the other headers and want to add a
-    /// vary header accordingly.
+    /// - `Origin` is included when `Access-Control-Allow-Origin` depends on the
+    ///   request's `Origin` header (for example, origin lists or predicates).
+    /// - `Access-Control-Request-Method` is included when
+    ///   `Access-Control-Allow-Methods` mirrors `Access-Control-Request-Method`.
+    /// - `Access-Control-Request-Headers` is included when
+    ///   `Access-Control-Allow-Headers` mirrors `Access-Control-Request-Headers`.
+    /// - If none of those values are request-dependent, no `Vary` header is
+    ///   added.
+    ///
+    /// Calling this method sets `Vary` explicitly and pins it to the provided
+    /// value, regardless of future changes to those other CORS settings.
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary
     pub fn vary<T>(mut self, headers: T) -> Self
@@ -446,6 +454,30 @@ impl CorsLayer {
         self.vary = headers.into();
         self.is_vary_custom = true;
         self
+    }
+
+    fn update_vary_header(&mut self) {
+        if !self.is_vary_custom {
+            let vary_origin = self.allow_origin.varies_with_origin();
+            let vary_method = self.allow_methods.varies_with_request_method();
+            let vary_headers = self.allow_headers.varies_with_request_headers();
+
+            if !(vary_origin || vary_method || vary_headers) {
+                self.vary = Vary::list([]);
+            } else {
+                let mut vary_header_names = Vec::new();
+                if vary_origin {
+                    vary_header_names.push(header::ORIGIN);
+                }
+                if vary_method {
+                    vary_header_names.push(header::ACCESS_CONTROL_REQUEST_METHOD);
+                }
+                if vary_headers {
+                    vary_header_names.push(header::ACCESS_CONTROL_REQUEST_HEADERS);
+                }
+                self.vary = Vary::list(vary_header_names);
+            }
+        }
     }
 }
 
@@ -497,28 +529,7 @@ impl<S> Layer<S> for CorsLayer {
         let mut layer = self.clone();
 
         // Only set Vary if not custom
-        if !layer.is_vary_custom {
-            // If all origins, methods, and headers are allowed, omit Vary
-            let all_origins = layer.allow_origin.is_wildcard();
-            let all_methods = layer.allow_methods.is_wildcard();
-            let all_headers = layer.allow_headers.is_wildcard();
-            if all_origins && all_methods && all_headers {
-                layer.vary = Vary::list([]);
-            } else {
-                // Otherwise, set Vary to the appropriate headers
-                let mut vary_headers = Vec::new();
-                if !all_origins {
-                    vary_headers.push(header::ORIGIN);
-                }
-                if !all_methods {
-                    vary_headers.push(header::ACCESS_CONTROL_REQUEST_METHOD);
-                }
-                if !all_headers {
-                    vary_headers.push(header::ACCESS_CONTROL_REQUEST_HEADERS);
-                }
-                layer.vary = Vary::list(vary_headers);
-            }
-        }
+        layer.update_vary_header();
 
         Cors { inner, layer }
     }
@@ -666,27 +677,8 @@ impl<S> Cors<S> {
     {
         self.layer = f(self.layer);
 
-        // Centralize Vary header logic here as well
-        if !self.layer.is_vary_custom {
-            let all_origins = self.layer.allow_origin.is_wildcard();
-            let all_methods = self.layer.allow_methods.is_wildcard();
-            let all_headers = self.layer.allow_headers.is_wildcard();
-            if all_origins && all_methods && all_headers {
-                self.layer.vary = Vary::list([]);
-            } else {
-                let mut vary_headers = Vec::new();
-                if !all_origins {
-                    vary_headers.push(header::ORIGIN);
-                }
-                if !all_methods {
-                    vary_headers.push(header::ACCESS_CONTROL_REQUEST_METHOD);
-                }
-                if !all_headers {
-                    vary_headers.push(header::ACCESS_CONTROL_REQUEST_HEADERS);
-                }
-                self.layer.vary = Vary::list(vary_headers);
-            }
-        }
+        // Only set Vary if not custom
+        self.layer.update_vary_header();
         self
     }
 }

--- a/tower-http/src/cors/mod.rs
+++ b/tower-http/src/cors/mod.rs
@@ -51,10 +51,7 @@
 
 use allow_origin::AllowOriginFuture;
 use bytes::{BufMut, BytesMut};
-use http::{
-    header::{self, HeaderName},
-    HeaderMap, HeaderValue, Method, Request, Response,
-};
+use http::{header, HeaderMap, HeaderValue, Method, Request, Response};
 use pin_project_lite::pin_project;
 use std::{
     future::Future,
@@ -432,9 +429,6 @@ impl CorsLayer {
 
     /// Set the value(s) of the [`Vary`][mdn] header.
     ///
-    /// In contrast to the other headers, this one has a non-empty default of
-    /// [`preflight_request_headers()`].
-    ///
     /// You only need to set this if you want to remove some of these defaults,
     /// or if you use a closure for one of the other headers and want to add a
     /// vary header accordingly.
@@ -806,15 +800,4 @@ fn ensure_usable_cors_rules(layer: &CorsLayer) {
              with `Access-Control-Expose-Headers: *`"
         );
     }
-}
-
-/// Returns an iterator over the three request headers that may be involved in a CORS preflight request.
-///
-/// This is the default set of header names returned in the `vary` header
-pub fn preflight_request_headers() -> impl Iterator<Item = HeaderName> {
-    IntoIterator::into_iter([
-        header::ORIGIN,
-        header::ACCESS_CONTROL_REQUEST_METHOD,
-        header::ACCESS_CONTROL_REQUEST_HEADERS,
-    ])
 }

--- a/tower-http/src/cors/mod.rs
+++ b/tower-http/src/cors/mod.rs
@@ -51,7 +51,7 @@
 
 use allow_origin::AllowOriginFuture;
 use bytes::{BufMut, BytesMut};
-use http::{header, HeaderMap, HeaderValue, Method, Request, Response};
+use http::{header, HeaderMap, HeaderName, HeaderValue, Method, Request, Response};
 use pin_project_lite::pin_project;
 use std::{
     future::Future,
@@ -129,11 +129,33 @@ impl CorsLayer {
     /// - All origins allowed.
     /// - All headers exposed.
     pub fn permissive() -> Self {
-        Self::new()
+        let mut layer = Self::new()
             .allow_headers(Any)
             .allow_methods(Any)
             .allow_origin(Any)
-            .expose_headers(Any)
+            .expose_headers(Any);
+
+        let mut vary = Vary::default();
+
+        if layer.allow_origin.is_wildcard() {
+            vary = vary.without_header(header::ORIGIN);
+        }
+
+        if layer.allow_headers.is_wildcard() {
+            vary = vary.without_header(header::ACCESS_CONTROL_REQUEST_HEADERS);
+        }
+
+        if layer.allow_methods.is_wildcard() {
+            vary = vary.without_header(header::ACCESS_CONTROL_REQUEST_METHOD);
+        }
+
+        layer.vary = if vary.is_empty() {
+            Vary::list([])
+        } else {
+            vary
+        };
+
+        layer
     }
 
     /// A very permissive configuration:
@@ -428,6 +450,9 @@ impl CorsLayer {
     }
 
     /// Set the value(s) of the [`Vary`][mdn] header.
+    ///
+    /// In contrast to the other headers, this one has a non-empty default of
+    /// [`preflight_request_headers()`].
     ///
     /// You only need to set this if you want to remove some of these defaults,
     /// or if you use a closure for one of the other headers and want to add a
@@ -800,4 +825,15 @@ fn ensure_usable_cors_rules(layer: &CorsLayer) {
              with `Access-Control-Expose-Headers: *`"
         );
     }
+}
+
+/// Returns an iterator over the three request headers that may be involved in a CORS preflight request.
+///
+/// This is the default set of header names returned in the `vary` header
+pub fn preflight_request_headers() -> impl Iterator<Item = HeaderName> {
+    IntoIterator::into_iter([
+        header::ORIGIN,
+        header::ACCESS_CONTROL_REQUEST_METHOD,
+        header::ACCESS_CONTROL_REQUEST_HEADERS,
+    ])
 }

--- a/tower-http/src/cors/mod.rs
+++ b/tower-http/src/cors/mod.rs
@@ -520,10 +520,7 @@ impl<S> Layer<S> for CorsLayer {
             }
         }
 
-        Cors {
-            inner,
-            layer,
-        }
+        Cors { inner, layer }
     }
 }
 

--- a/tower-http/src/cors/mod.rs
+++ b/tower-http/src/cors/mod.rs
@@ -201,26 +201,6 @@ impl CorsLayer {
         T: Into<AllowHeaders>,
     {
         self.allow_headers = headers.into();
-        if !self.is_vary_custom {
-            if self.allow_headers.is_wildcard() {
-                self.vary = self
-                    .vary
-                    .without_header(header::ACCESS_CONTROL_REQUEST_HEADERS);
-            } else {
-                // Ensure header is present
-                let mut vary = self.vary.clone();
-                let name = header::ACCESS_CONTROL_REQUEST_HEADERS;
-                if !vary.to_header().map_or(false, |(_, v)| {
-                    v.to_str()
-                        .unwrap_or("")
-                        .split(',')
-                        .any(|s| s.trim().eq_ignore_ascii_case(name.as_str()))
-                }) {
-                    vary = Vary::list([name]);
-                }
-                self.vary = vary;
-            }
-        }
         self
     }
 
@@ -297,25 +277,6 @@ impl CorsLayer {
         T: Into<AllowMethods>,
     {
         self.allow_methods = methods.into();
-        if !self.is_vary_custom {
-            if self.allow_methods.is_wildcard() {
-                self.vary = self
-                    .vary
-                    .without_header(header::ACCESS_CONTROL_REQUEST_METHOD);
-            } else {
-                let mut vary = self.vary.clone();
-                let name = header::ACCESS_CONTROL_REQUEST_METHOD;
-                if !vary.to_header().map_or(false, |(_, v)| {
-                    v.to_str()
-                        .unwrap_or("")
-                        .split(',')
-                        .any(|s| s.trim().eq_ignore_ascii_case(name.as_str()))
-                }) {
-                    vary = Vary::list([name]);
-                }
-                self.vary = vary;
-            }
-        }
         self
     }
 
@@ -419,23 +380,6 @@ impl CorsLayer {
         T: Into<AllowOrigin>,
     {
         self.allow_origin = origin.into();
-        if !self.is_vary_custom {
-            if self.allow_origin.is_wildcard() {
-                self.vary = self.vary.without_header(header::ORIGIN);
-            } else {
-                let mut vary = self.vary.clone();
-                let name = header::ORIGIN;
-                if !vary.to_header().map_or(false, |(_, v)| {
-                    v.to_str()
-                        .unwrap_or("")
-                        .split(',')
-                        .any(|s| s.trim().eq_ignore_ascii_case(name.as_str()))
-                }) {
-                    vary = Vary::list([name]);
-                }
-                self.vary = vary;
-            }
-        }
         self
     }
 
@@ -549,9 +493,36 @@ impl<S> Layer<S> for CorsLayer {
     fn layer(&self, inner: S) -> Self::Service {
         ensure_usable_cors_rules(self);
 
+        // Clone the layer to modify Vary header logic
+        let mut layer = self.clone();
+
+        // Only set Vary if not custom
+        if !layer.is_vary_custom {
+            // If all origins, methods, and headers are allowed, omit Vary
+            let all_origins = layer.allow_origin.is_wildcard();
+            let all_methods = layer.allow_methods.is_wildcard();
+            let all_headers = layer.allow_headers.is_wildcard();
+            if all_origins && all_methods && all_headers {
+                layer.vary = Vary::list([]);
+            } else {
+                // Otherwise, set Vary to the appropriate headers
+                let mut vary_headers = Vec::new();
+                if !all_origins {
+                    vary_headers.push(header::ORIGIN);
+                }
+                if !all_methods {
+                    vary_headers.push(header::ACCESS_CONTROL_REQUEST_METHOD);
+                }
+                if !all_headers {
+                    vary_headers.push(header::ACCESS_CONTROL_REQUEST_HEADERS);
+                }
+                layer.vary = Vary::list(vary_headers);
+            }
+        }
+
         Cors {
             inner,
-            layer: self.clone(),
+            layer,
         }
     }
 }
@@ -697,6 +668,28 @@ impl<S> Cors<S> {
         F: FnOnce(CorsLayer) -> CorsLayer,
     {
         self.layer = f(self.layer);
+
+        // Centralize Vary header logic here as well
+        if !self.layer.is_vary_custom {
+            let all_origins = self.layer.allow_origin.is_wildcard();
+            let all_methods = self.layer.allow_methods.is_wildcard();
+            let all_headers = self.layer.allow_headers.is_wildcard();
+            if all_origins && all_methods && all_headers {
+                self.layer.vary = Vary::list([]);
+            } else {
+                let mut vary_headers = Vec::new();
+                if !all_origins {
+                    vary_headers.push(header::ORIGIN);
+                }
+                if !all_methods {
+                    vary_headers.push(header::ACCESS_CONTROL_REQUEST_METHOD);
+                }
+                if !all_headers {
+                    vary_headers.push(header::ACCESS_CONTROL_REQUEST_HEADERS);
+                }
+                self.layer.vary = Vary::list(vary_headers);
+            }
+        }
         self
     }
 }

--- a/tower-http/src/cors/mod.rs
+++ b/tower-http/src/cors/mod.rs
@@ -456,6 +456,7 @@ impl CorsLayer {
         self
     }
 
+    /// Recomputes the `Vary` header, if it hasn't been set explicitly.
     fn update_vary_header(&mut self) {
         if !self.is_vary_custom {
             let vary_origin = self.allow_origin.varies_with_origin();
@@ -528,7 +529,6 @@ impl<S> Layer<S> for CorsLayer {
         // Clone the layer to modify Vary header logic
         let mut layer = self.clone();
 
-        // Only set Vary if not custom
         layer.update_vary_header();
 
         Cors { inner, layer }
@@ -677,7 +677,6 @@ impl<S> Cors<S> {
     {
         self.layer = f(self.layer);
 
-        // Only set Vary if not custom
         self.layer.update_vary_header();
         self
     }

--- a/tower-http/src/cors/mod.rs
+++ b/tower-http/src/cors/mod.rs
@@ -96,6 +96,7 @@ pub struct CorsLayer {
     expose_headers: ExposeHeaders,
     max_age: MaxAge,
     vary: Vary,
+    is_vary_custom: bool,
 }
 
 #[allow(clippy::declare_interior_mutable_const)]
@@ -119,6 +120,7 @@ impl CorsLayer {
             expose_headers: Default::default(),
             max_age: Default::default(),
             vary: Default::default(),
+            is_vary_custom: false,
         }
     }
 
@@ -129,33 +131,11 @@ impl CorsLayer {
     /// - All origins allowed.
     /// - All headers exposed.
     pub fn permissive() -> Self {
-        let mut layer = Self::new()
+        Self::new()
             .allow_headers(Any)
             .allow_methods(Any)
             .allow_origin(Any)
-            .expose_headers(Any);
-
-        let mut vary = Vary::default();
-
-        if layer.allow_origin.is_wildcard() {
-            vary = vary.without_header(header::ORIGIN);
-        }
-
-        if layer.allow_headers.is_wildcard() {
-            vary = vary.without_header(header::ACCESS_CONTROL_REQUEST_HEADERS);
-        }
-
-        if layer.allow_methods.is_wildcard() {
-            vary = vary.without_header(header::ACCESS_CONTROL_REQUEST_METHOD);
-        }
-
-        layer.vary = if vary.is_empty() {
-            Vary::list([])
-        } else {
-            vary
-        };
-
-        layer
+            .expose_headers(Any)
     }
 
     /// A very permissive configuration:
@@ -221,6 +201,26 @@ impl CorsLayer {
         T: Into<AllowHeaders>,
     {
         self.allow_headers = headers.into();
+        if !self.is_vary_custom {
+            if self.allow_headers.is_wildcard() {
+                self.vary = self
+                    .vary
+                    .without_header(header::ACCESS_CONTROL_REQUEST_HEADERS);
+            } else {
+                // Ensure header is present
+                let mut vary = self.vary.clone();
+                let name = header::ACCESS_CONTROL_REQUEST_HEADERS;
+                if !vary.to_header().map_or(false, |(_, v)| {
+                    v.to_str()
+                        .unwrap_or("")
+                        .split(',')
+                        .any(|s| s.trim().eq_ignore_ascii_case(name.as_str()))
+                }) {
+                    vary = Vary::list([name]);
+                }
+                self.vary = vary;
+            }
+        }
         self
     }
 
@@ -297,6 +297,25 @@ impl CorsLayer {
         T: Into<AllowMethods>,
     {
         self.allow_methods = methods.into();
+        if !self.is_vary_custom {
+            if self.allow_methods.is_wildcard() {
+                self.vary = self
+                    .vary
+                    .without_header(header::ACCESS_CONTROL_REQUEST_METHOD);
+            } else {
+                let mut vary = self.vary.clone();
+                let name = header::ACCESS_CONTROL_REQUEST_METHOD;
+                if !vary.to_header().map_or(false, |(_, v)| {
+                    v.to_str()
+                        .unwrap_or("")
+                        .split(',')
+                        .any(|s| s.trim().eq_ignore_ascii_case(name.as_str()))
+                }) {
+                    vary = Vary::list([name]);
+                }
+                self.vary = vary;
+            }
+        }
         self
     }
 
@@ -400,6 +419,23 @@ impl CorsLayer {
         T: Into<AllowOrigin>,
     {
         self.allow_origin = origin.into();
+        if !self.is_vary_custom {
+            if self.allow_origin.is_wildcard() {
+                self.vary = self.vary.without_header(header::ORIGIN);
+            } else {
+                let mut vary = self.vary.clone();
+                let name = header::ORIGIN;
+                if !vary.to_header().map_or(false, |(_, v)| {
+                    v.to_str()
+                        .unwrap_or("")
+                        .split(',')
+                        .any(|s| s.trim().eq_ignore_ascii_case(name.as_str()))
+                }) {
+                    vary = Vary::list([name]);
+                }
+                self.vary = vary;
+            }
+        }
         self
     }
 
@@ -464,6 +500,7 @@ impl CorsLayer {
         T: Into<Vary>,
     {
         self.vary = headers.into();
+        self.is_vary_custom = true;
         self
     }
 }

--- a/tower-http/src/cors/tests.rs
+++ b/tower-http/src/cors/tests.rs
@@ -6,8 +6,8 @@ use tower::{service_fn, util::ServiceExt, Layer};
 
 use crate::cors::{AllowOrigin, CorsLayer};
 
-const DEFAULT_VARY_HEADERS: HeaderValue = HeaderValue::from_static("accept, accept-encoding");
-const CUSTOM_VARY_HEADERS: [HeaderName; 3] = [
+const INITIAL_VARY_HEADERS: HeaderValue = HeaderValue::from_static("accept, accept-encoding");
+const ADDITIONAL_VARY_HEADERS: [HeaderName; 3] = [
     header::ORIGIN,
     header::ACCESS_CONTROL_REQUEST_METHOD,
     header::ACCESS_CONTROL_REQUEST_HEADERS,
@@ -21,7 +21,7 @@ const CUSTOM_VARY_HEADERS: [HeaderName; 3] = [
 async fn vary_set_by_inner_service() {
     async fn inner_svc(_: Request<Body>) -> Result<Response<Body>, Infallible> {
         Ok(Response::builder()
-            .header(header::VARY, DEFAULT_VARY_HEADERS)
+            .header(header::VARY, INITIAL_VARY_HEADERS)
             .body(Body::empty())
             .unwrap())
     }
@@ -29,7 +29,7 @@ async fn vary_set_by_inner_service() {
     let svc = CorsLayer::permissive().layer(service_fn(inner_svc));
     let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
     let mut vary_headers = res.headers().get_all(header::VARY).into_iter();
-    assert_eq!(vary_headers.next(), Some(&DEFAULT_VARY_HEADERS));
+    assert_eq!(vary_headers.next(), Some(&INITIAL_VARY_HEADERS));
     assert_eq!(vary_headers.next(), None);
 }
 
@@ -45,18 +45,18 @@ async fn include_custom_permissive_to_vary_set_by_inner_service() {
 
     async fn inner_svc(_: Request<Body>) -> Result<Response<Body>, Infallible> {
         Ok(Response::builder()
-            .header(header::VARY, DEFAULT_VARY_HEADERS)
+            .header(header::VARY, INITIAL_VARY_HEADERS)
             .body(Body::empty())
             .unwrap())
     }
 
     let svc = CorsLayer::permissive()
-        .vary(Vary::list(CUSTOM_VARY_HEADERS))
+        .vary(Vary::list(ADDITIONAL_VARY_HEADERS))
         .layer(service_fn(inner_svc));
 
     let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
     let mut vary_headers = res.headers().get_all(header::VARY).into_iter();
-    assert_eq!(vary_headers.next(), Some(&DEFAULT_VARY_HEADERS));
+    assert_eq!(vary_headers.next(), Some(&INITIAL_VARY_HEADERS));
     assert_eq!(vary_headers.next(), Some(&PERMISSIVE_CORS_VARY_HEADERS));
     assert_eq!(vary_headers.next(), None);
 }

--- a/tower-http/src/cors/tests.rs
+++ b/tower-http/src/cors/tests.rs
@@ -1,10 +1,17 @@
 use std::convert::Infallible;
 
-use crate::test_helpers::Body;
-use http::{header, HeaderValue, Request, Response};
+use crate::{cors::Vary, test_helpers::Body};
+use http::{header, HeaderName, HeaderValue, Request, Response};
 use tower::{service_fn, util::ServiceExt, Layer};
 
 use crate::cors::{AllowOrigin, CorsLayer};
+
+const DEFAULT_VARY_HEADERS: HeaderValue = HeaderValue::from_static("accept, accept-encoding");
+const CUSTOM_VARY_HEADERS: [HeaderName; 3] = [
+    header::ORIGIN,
+    header::ACCESS_CONTROL_REQUEST_METHOD,
+    header::ACCESS_CONTROL_REQUEST_HEADERS,
+];
 
 #[tokio::test]
 #[allow(
@@ -12,14 +19,9 @@ use crate::cors::{AllowOrigin, CorsLayer};
     clippy::borrow_interior_mutable_const
 )]
 async fn vary_set_by_inner_service() {
-    const CUSTOM_VARY_HEADERS: HeaderValue = HeaderValue::from_static("accept, accept-encoding");
-    const PERMISSIVE_CORS_VARY_HEADERS: HeaderValue = HeaderValue::from_static(
-        "origin, access-control-request-method, access-control-request-headers",
-    );
-
     async fn inner_svc(_: Request<Body>) -> Result<Response<Body>, Infallible> {
         Ok(Response::builder()
-            .header(header::VARY, CUSTOM_VARY_HEADERS)
+            .header(header::VARY, DEFAULT_VARY_HEADERS)
             .body(Body::empty())
             .unwrap())
     }
@@ -27,7 +29,34 @@ async fn vary_set_by_inner_service() {
     let svc = CorsLayer::permissive().layer(service_fn(inner_svc));
     let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
     let mut vary_headers = res.headers().get_all(header::VARY).into_iter();
-    assert_eq!(vary_headers.next(), Some(&CUSTOM_VARY_HEADERS));
+    assert_eq!(vary_headers.next(), Some(&DEFAULT_VARY_HEADERS));
+    assert_eq!(vary_headers.next(), None);
+}
+
+#[tokio::test]
+#[allow(
+    clippy::declare_interior_mutable_const,
+    clippy::borrow_interior_mutable_const
+)]
+async fn include_custom_permissive_to_vary_set_by_inner_service() {
+    const PERMISSIVE_CORS_VARY_HEADERS: HeaderValue = HeaderValue::from_static(
+        "origin, access-control-request-method, access-control-request-headers",
+    );
+
+    async fn inner_svc(_: Request<Body>) -> Result<Response<Body>, Infallible> {
+        Ok(Response::builder()
+            .header(header::VARY, DEFAULT_VARY_HEADERS)
+            .body(Body::empty())
+            .unwrap())
+    }
+
+    let svc = CorsLayer::permissive()
+        .vary(Vary::list(CUSTOM_VARY_HEADERS))
+        .layer(service_fn(inner_svc));
+
+    let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
+    let mut vary_headers = res.headers().get_all(header::VARY).into_iter();
+    assert_eq!(vary_headers.next(), Some(&DEFAULT_VARY_HEADERS));
     assert_eq!(vary_headers.next(), Some(&PERMISSIVE_CORS_VARY_HEADERS));
     assert_eq!(vary_headers.next(), None);
 }

--- a/tower-http/src/cors/tests.rs
+++ b/tower-http/src/cors/tests.rs
@@ -18,19 +18,18 @@ const ADDITIONAL_VARY_HEADERS: [HeaderName; 3] = [
     clippy::declare_interior_mutable_const,
     clippy::borrow_interior_mutable_const
 )]
-async fn vary_set_by_inner_service() {
-    async fn inner_svc(_: Request<Body>) -> Result<Response<Body>, Infallible> {
-        Ok(Response::builder()
-            .header(header::VARY, INITIAL_VARY_HEADERS)
-            .body(Body::empty())
-            .unwrap())
-    }
+async fn permissive_vary_header_is_empty() {
+    let svc = CorsLayer::permissive().layer(service_fn(|_: Request<Body>| async {
+        Ok::<_, Infallible>(Response::new(Body::empty()))
+    }));
 
-    let svc = CorsLayer::permissive().layer(service_fn(inner_svc));
-    let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
-    let mut vary_headers = res.headers().get_all(header::VARY).into_iter();
-    assert_eq!(vary_headers.next(), Some(&INITIAL_VARY_HEADERS));
-    assert_eq!(vary_headers.next(), None);
+    let req = Request::builder().body(Body::empty()).unwrap();
+
+    let res = svc.oneshot(req).await.unwrap();
+    assert!(
+        res.headers().get(header::VARY).is_none(),
+        "Vary header should be omitted for permissive config"
+    );
 }
 
 #[tokio::test]
@@ -58,6 +57,47 @@ async fn include_custom_permissive_to_vary_set_by_inner_service() {
     let mut vary_headers = res.headers().get_all(header::VARY).into_iter();
     assert_eq!(vary_headers.next(), Some(&INITIAL_VARY_HEADERS));
     assert_eq!(vary_headers.next(), Some(&PERMISSIVE_CORS_VARY_HEADERS));
+    assert_eq!(vary_headers.next(), None);
+}
+
+#[tokio::test]
+async fn permissive_with_custom_vary_builder() {
+    let custom_vary = HeaderValue::from_static("x-foo");
+    let svc = CorsLayer::permissive()
+        .vary(Vary::list([header::HeaderName::from_static("x-foo")]))
+        .layer(service_fn(|_: Request<Body>| async {
+            Ok::<_, Infallible>(Response::new(Body::empty()))
+        }));
+
+    let req = Request::builder().body(Body::empty()).unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    let vary = res.headers().get(header::VARY);
+    assert_eq!(vary, Some(&custom_vary));
+}
+
+#[tokio::test]
+async fn permissive_with_inner_and_builder_vary() {
+    let custom_vary = HeaderValue::from_static("x-foo");
+    let inner_vary = HeaderValue::from_static("accept-encoding");
+    let svc = CorsLayer::permissive()
+        .vary(Vary::list([header::HeaderName::from_static("x-foo")]))
+        .layer(service_fn(|_: Request<Body>| {
+            let inner_vary = inner_vary.clone();
+            async move {
+                Ok::<_, Infallible>(
+                    Response::builder()
+                        .header(header::VARY, inner_vary)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+            }
+        }));
+
+    let req = Request::builder().body(Body::empty()).unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    let mut vary_headers = res.headers().get_all(header::VARY).iter();
+    assert_eq!(vary_headers.next(), Some(&inner_vary));
+    assert_eq!(vary_headers.next(), Some(&custom_vary));
     assert_eq!(vary_headers.next(), None);
 }
 

--- a/tower-http/src/cors/tests.rs
+++ b/tower-http/src/cors/tests.rs
@@ -1,10 +1,10 @@
 use std::convert::Infallible;
 
 use crate::{cors::Vary, test_helpers::Body};
-use http::{header, HeaderName, HeaderValue, Request, Response};
+use http::{header, HeaderName, HeaderValue, Method, Request, Response};
 use tower::{service_fn, util::ServiceExt, Layer};
 
-use crate::cors::{AllowOrigin, CorsLayer};
+use crate::cors::{AllowHeaders, AllowMethods, AllowOrigin, Any, Cors, CorsLayer};
 
 const INITIAL_VARY_HEADERS: HeaderValue = HeaderValue::from_static("accept, accept-encoding");
 const ADDITIONAL_VARY_HEADERS: [HeaderName; 3] = [
@@ -14,10 +14,6 @@ const ADDITIONAL_VARY_HEADERS: [HeaderName; 3] = [
 ];
 
 #[tokio::test]
-#[allow(
-    clippy::declare_interior_mutable_const,
-    clippy::borrow_interior_mutable_const
-)]
 async fn permissive_vary_header_is_empty() {
     let svc = CorsLayer::permissive().layer(service_fn(|_: Request<Body>| async {
         Ok::<_, Infallible>(Response::new(Body::empty()))
@@ -33,10 +29,6 @@ async fn permissive_vary_header_is_empty() {
 }
 
 #[tokio::test]
-#[allow(
-    clippy::declare_interior_mutable_const,
-    clippy::borrow_interior_mutable_const
-)]
 async fn include_custom_permissive_to_vary_set_by_inner_service() {
     const PERMISSIVE_CORS_VARY_HEADERS: HeaderValue = HeaderValue::from_static(
         "origin, access-control-request-method, access-control-request-headers",
@@ -139,4 +131,116 @@ async fn test_allow_origin_async_predicate() {
 
     let res = allow_origin.to_future(Some(&invalid_origin), &parts).await;
     assert!(res.is_none());
+}
+
+#[tokio::test]
+async fn derived_vary_header_for_mixed_wildcard_configuration() {
+    let svc = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(AllowMethods::mirror_request())
+        .allow_headers(AllowHeaders::mirror_request())
+        .layer(service_fn(|_: Request<Body>| async {
+            Ok::<_, Infallible>(Response::new(Body::empty()))
+        }));
+
+    let req = Request::builder()
+        .method(Method::OPTIONS)
+        .header(header::ORIGIN, "https://example.com")
+        .header(header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+        .header(header::ACCESS_CONTROL_REQUEST_HEADERS, "content-type")
+        .body(Body::empty())
+        .unwrap();
+
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(
+        res.headers().get(header::VARY),
+        Some(&HeaderValue::from_static(
+            "access-control-request-method, access-control-request-headers",
+        ))
+    );
+}
+
+#[tokio::test]
+async fn very_permissive_emits_vary_headers() {
+    let svc = CorsLayer::very_permissive().layer(service_fn(|_: Request<Body>| async {
+        Ok::<_, Infallible>(Response::new(Body::empty()))
+    }));
+
+    let req = Request::builder()
+        .method(Method::OPTIONS)
+        .header(header::ORIGIN, "https://example.com")
+        .header(header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+        .header(header::ACCESS_CONTROL_REQUEST_HEADERS, "content-type")
+        .body(Body::empty())
+        .unwrap();
+
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(
+        res.headers().get(header::VARY),
+        Some(&HeaderValue::from_static(
+            "origin, access-control-request-method, access-control-request-headers",
+        ))
+    );
+}
+
+#[tokio::test]
+async fn cors_map_layer_smoke_without_vary_header() {
+    let svc = Cors::new(service_fn(|_: Request<Body>| async {
+        Ok::<_, Infallible>(Response::new(Body::empty()))
+    }))
+    .allow_origin(Any)
+    .allow_methods(Any)
+    .allow_headers(Any);
+
+    let res = svc.oneshot(Request::new(Body::empty())).await.unwrap();
+
+    assert!(res.headers().get(header::VARY).is_none());
+}
+
+#[tokio::test]
+async fn cors_map_layer_smoke_with_vary_header() {
+    let svc = Cors::new(service_fn(|_: Request<Body>| async {
+        Ok::<_, Infallible>(Response::new(Body::empty()))
+    }))
+    .allow_origin(Any)
+    .allow_methods(AllowMethods::mirror_request())
+    .allow_headers(Any);
+
+    let req = Request::builder()
+        .method(Method::OPTIONS)
+        .header(header::ORIGIN, "https://example.com")
+        .header(header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+        .body(Body::empty())
+        .unwrap();
+
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(
+        res.headers().get(header::VARY),
+        Some(&HeaderValue::from_static("access-control-request-method"))
+    );
+}
+
+#[tokio::test]
+async fn exact_origin_does_not_emit_origin_vary_header() {
+    let svc = CorsLayer::new()
+        .allow_origin(AllowOrigin::exact(HeaderValue::from_static(
+            "http://example.com",
+        )))
+        .allow_methods([Method::GET])
+        .allow_headers([header::CONTENT_TYPE])
+        .layer(service_fn(|_: Request<Body>| async {
+            Ok::<_, Infallible>(Response::new(Body::empty()))
+        }));
+
+    let req = Request::builder()
+        .header(header::ORIGIN, "http://example.com")
+        .body(Body::empty())
+        .unwrap();
+
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert!(res.headers().get(header::VARY).is_none());
 }

--- a/tower-http/src/cors/vary.rs
+++ b/tower-http/src/cors/vary.rs
@@ -36,12 +36,6 @@ impl Vary {
             .expect("comma-separated list of HeaderValues is always a valid HeaderValue");
         Some((header::VARY, header_val))
     }
-
-    pub(super) fn without_header(mut self, header: HeaderName) -> Self {
-        let value: HeaderValue = header.into();
-        self.0.retain(|h| h != value);
-        self
-    }
 }
 
 impl Default for Vary {

--- a/tower-http/src/cors/vary.rs
+++ b/tower-http/src/cors/vary.rs
@@ -42,10 +42,6 @@ impl Vary {
         self.0.retain(|h| h != value);
         self
     }
-
-    pub(super) fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
 }
 
 impl Default for Vary {

--- a/tower-http/src/cors/vary.rs
+++ b/tower-http/src/cors/vary.rs
@@ -1,14 +1,12 @@
 use http::header::{self, HeaderName, HeaderValue};
 
-use super::preflight_request_headers;
-
 /// Holds configuration for how to set the [`Vary`][mdn] header.
 ///
 /// See [`CorsLayer::vary`] for more details.
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary
 /// [`CorsLayer::vary`]: super::CorsLayer::vary
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Vary(Vec<HeaderValue>);
 
 impl Vary {
@@ -35,12 +33,6 @@ impl Vary {
         let header_val = HeaderValue::from_bytes(&res)
             .expect("comma-separated list of HeaderValues is always a valid HeaderValue");
         Some((header::VARY, header_val))
-    }
-}
-
-impl Default for Vary {
-    fn default() -> Self {
-        Self::list(preflight_request_headers())
     }
 }
 

--- a/tower-http/src/cors/vary.rs
+++ b/tower-http/src/cors/vary.rs
@@ -38,8 +38,8 @@ impl Vary {
     }
 
     pub(super) fn without_header(mut self, header: HeaderName) -> Self {
-        self.0
-            .retain(|h| h != &HeaderValue::from_str(header.as_str()).unwrap());
+        let value: HeaderValue = header.into();
+        self.0.retain(|h| h != value);
         self
     }
 

--- a/tower-http/src/cors/vary.rs
+++ b/tower-http/src/cors/vary.rs
@@ -1,12 +1,14 @@
 use http::header::{self, HeaderName, HeaderValue};
 
+use crate::cors::preflight_request_headers;
+
 /// Holds configuration for how to set the [`Vary`][mdn] header.
 ///
 /// See [`CorsLayer::vary`] for more details.
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary
 /// [`CorsLayer::vary`]: super::CorsLayer::vary
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct Vary(Vec<HeaderValue>);
 
 impl Vary {
@@ -33,6 +35,22 @@ impl Vary {
         let header_val = HeaderValue::from_bytes(&res)
             .expect("comma-separated list of HeaderValues is always a valid HeaderValue");
         Some((header::VARY, header_val))
+    }
+
+    pub(super) fn without_header(mut self, header: HeaderName) -> Self {
+        self.0
+            .retain(|h| h != &HeaderValue::from_str(header.as_str()).unwrap());
+        self
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl Default for Vary {
+    fn default() -> Self {
+        Self::list(preflight_request_headers())
     }
 }
 


### PR DESCRIPTION
## Motivation

Fixes #539 

Relaxes the default Vary header to an empty list.

## Solution

Instead of the custom `Default` implementation adding some header values, it now simply returns the out-of-the-box `Default`, which is an empty Vector.

Also, I altered the test to reflect the new change and an additional test.
