### PR TITLE
feat: set multiple request header

### DIFF
--- a/tower-http/src/set_header/mod.rs
+++ b/tower-http/src/set_header/mod.rs
@@ -12,7 +12,7 @@ pub mod response;
 #[doc(inline)]
 pub use self::{
     request::{SetRequestHeader, SetRequestHeaderLayer},
-    response::{HeaderMetadata, SetResponseHeader, SetResponseHeaderLayer},
+    response::{SetResponseHeader, SetResponseHeaderLayer},
 };
 
 /// Trait for producing header values.
@@ -153,5 +153,75 @@ impl<T> MakeHeaderValue<T> for BoxedMakeHeaderValue<T> {
 impl<T> fmt::Debug for BoxedMakeHeaderValue<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BoxedMakeHeaderValue").finish()
+    }
+}
+
+/// Metadata describing a response header to be set.
+#[derive(Clone, Debug)]
+pub struct HeaderMetadata<T> {
+    /// The name of the header to set.
+    header_name: HeaderName,
+    /// The value or value factory for the header.
+    make: BoxedMakeHeaderValue<T>,
+}
+
+impl<T> HeaderMetadata<T> {
+    /// Create a new HeaderMetadata with the given header name and value factory.
+    fn new<M: MakeHeaderValue<T> + Clone + 'static + Send + Sync>(
+        header_name: HeaderName,
+        make: M,
+    ) -> Self {
+        Self {
+            header_name,
+            make: BoxedMakeHeaderValue::new(make),
+        }
+    }
+
+    /// Convert this metadata into a [`HeaderInsertionConfig`] with the given insertion mode.
+    fn build_config(self, mode: InsertHeaderMode) -> HeaderInsertionConfig<T> {
+        HeaderInsertionConfig {
+            header_name: self.header_name,
+            make: self.make,
+            mode,
+        }
+    }
+}
+
+impl<T, M> From<(HeaderName, M)> for HeaderMetadata<T>
+where
+    M: MakeHeaderValue<T> + Clone + 'static + Send + Sync,
+{
+    fn from((header_name, make): (HeaderName, M)) -> Self {
+        HeaderMetadata::new(header_name, make)
+    }
+}
+
+/// Configuration for inserting a header into a response or request.
+struct HeaderInsertionConfig<T> {
+    header_name: HeaderName,
+    make: BoxedMakeHeaderValue<T>,
+    mode: InsertHeaderMode,
+}
+
+impl<T> Clone for HeaderInsertionConfig<T>
+where
+    BoxedMakeHeaderValue<T>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            make: self.make.clone(),
+            mode: self.mode,
+        }
+    }
+}
+
+impl<T> fmt::Debug for HeaderInsertionConfig<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HeaderInsertionConfig")
+            .field("header_name", &self.header_name)
+            .field("mode", &self.mode)
+            .field("make", &"BoxedMakeHeaderValue")
+            .finish()
     }
 }

--- a/tower-http/src/set_header/mod.rs
+++ b/tower-http/src/set_header/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! See [request] and [response] for more details.
 
+use std::fmt;
+
 use http::{header::HeaderName, HeaderMap, HeaderValue, Request, Response};
 
 pub mod request;
@@ -106,5 +108,50 @@ impl<B> Headers for Response<B> {
 
     fn headers_mut(&mut self) -> &mut HeaderMap {
         Response::headers_mut(self)
+    }
+}
+
+/// A trait that combines MakeHeaderValue and Clone capability for trait objects.
+trait CloneableMakeHeaderValue<T>: MakeHeaderValue<T> + Send + Sync {
+    fn clone_box(&self) -> Box<dyn CloneableMakeHeaderValue<T>>;
+}
+
+impl<T, M> CloneableMakeHeaderValue<T> for M
+where
+    M: MakeHeaderValue<T> + Clone + Send + Sync + 'static,
+{
+    fn clone_box(&self) -> Box<dyn CloneableMakeHeaderValue<T>> {
+        Box::new(self.clone())
+    }
+}
+
+/// A "Bridge" struct that allows for trait object-based header value generation.
+struct BoxedMakeHeaderValue<T>(Box<dyn CloneableMakeHeaderValue<T>>);
+
+impl<T> BoxedMakeHeaderValue<T> {
+    /// Create a new BoxedMakeHeaderValue from any maker that implements MakeHeaderValue and Clone.
+    fn new<M>(maker: M) -> Self
+    where
+        M: MakeHeaderValue<T> + Clone + Send + Sync + 'static,
+    {
+        Self(Box::new(maker))
+    }
+}
+
+impl<T> Clone for BoxedMakeHeaderValue<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone_box())
+    }
+}
+
+impl<T> MakeHeaderValue<T> for BoxedMakeHeaderValue<T> {
+    fn make_header_value(&mut self, message: &T) -> Option<HeaderValue> {
+        self.0.make_header_value(message)
+    }
+}
+
+impl<T> fmt::Debug for BoxedMakeHeaderValue<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BoxedMakeHeaderValue").finish()
     }
 }

--- a/tower-http/src/set_header/mod.rs
+++ b/tower-http/src/set_header/mod.rs
@@ -156,7 +156,7 @@ impl<T> fmt::Debug for BoxedMakeHeaderValue<T> {
     }
 }
 
-/// Metadata describing a response header to be set.
+/// Metadata describing a request or response header to be set.
 #[derive(Clone, Debug)]
 pub struct HeaderMetadata<T> {
     /// The name of the header to set.

--- a/tower-http/src/set_header/request/mod.rs
+++ b/tower-http/src/set_header/request/mod.rs
@@ -89,7 +89,8 @@
 //! ```
 //! use http::{Request, Response, header::{self, HeaderValue}};
 //! use tower::{Service, ServiceExt, ServiceBuilder};
-//! use tower_http::set_header::request::{SetMultipleRequestHeadersLayer, HeaderMetadata};
+//! use tower_http::set_header::request::{SetMultipleRequestHeadersLayer};
+//! use tower_http::set_header::HeaderMetadata;
 //! use bytes::Bytes;
 //! use http_body_util::Full;
 //!
@@ -130,7 +131,5 @@
 mod multiple_headers;
 mod single_header;
 
-pub use multiple_headers::{
-    HeaderMetadata, SetMultipleRequestHeader, SetMultipleRequestHeadersLayer,
-};
+pub use multiple_headers::{SetMultipleRequestHeader, SetMultipleRequestHeadersLayer};
 pub use single_header::{SetRequestHeader, SetRequestHeaderLayer};

--- a/tower-http/src/set_header/request/mod.rs
+++ b/tower-http/src/set_header/request/mod.rs
@@ -84,13 +84,20 @@
 //! # }
 //! ```
 //!
+//! # Multiple Headers
+//!
+//! Use [`SetMultipleRequestHeadersLayer`] and [`SetMultipleRequestHeader`] to set multiple headers at once. Each header can have a fixed value or be computed dynamically.
+//!
+//! Note: this layer uses boxing (allocation + dynamic dispatch) to support mixed producer
+//! types in a single `vec`. Stacking multiple [`SetRequestHeaderLayer`] instances avoids this at the
+//! cost of a more complex composed service type.
+//!
 //! ## Example: Multiple Dynamic Values
 //!
 //! ```
 //! use http::{Request, Response, header::{self, HeaderValue}};
 //! use tower::{Service, ServiceExt, ServiceBuilder};
-//! use tower_http::set_header::request::{SetMultipleRequestHeadersLayer};
-//! use tower_http::set_header::HeaderMetadata;
+//! use tower_http::set_header::{HeaderMetadata, request::{SetMultipleRequestHeadersLayer}};
 //! use bytes::Bytes;
 //! use http_body_util::Full;
 //!

--- a/tower-http/src/set_header/request/mod.rs
+++ b/tower-http/src/set_header/request/mod.rs
@@ -1,0 +1,136 @@
+//! Middleware for setting headers on HTTP requests.
+//!
+//! This module provides middleware for setting one or more headers on HTTP requests, either with fixed values or values determined dynamically from the request.
+//!
+//! # Single Header
+//!
+//! Use [`SetRequestHeaderLayer`] and [`SetRequestHeader`] to set a single header. The header value can be a fixed value or computed dynamically using a closure. See [`crate::set_header::MakeHeaderValue`] for details.
+//!
+//! ## Example: Fixed Value
+//!
+//! ```
+//! use http::{Request, Response, header::{self, HeaderValue}};
+//! use tower::{Service, ServiceExt, ServiceBuilder};
+//! use tower_http::set_header::SetRequestHeaderLayer;
+//! use http_body_util::Full;
+//! use bytes::Bytes;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let http_client = tower::service_fn(|_: Request<Full<Bytes>>| async move {
+//! #     Ok::<_, std::convert::Infallible>(Response::new(Full::<Bytes>::default()))
+//! # });
+//! #
+//! let mut svc = ServiceBuilder::new()
+//!     .layer(
+//!         // Layer that sets `User-Agent: my very cool app` on requests.
+//!         //
+//!         // `if_not_present` will only insert the header if it does not already
+//!         // have a value.
+//!         SetRequestHeaderLayer::if_not_present(
+//!             header::USER_AGENT,
+//!             HeaderValue::from_static("my very cool app"),
+//!         )
+//!     )
+//!     .service(http_client);
+//!
+//! let request = Request::new(Full::default());
+//!
+//! let response = svc.ready().await?.call(request).await?;
+//! #
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Setting a header based on a value determined dynamically from the request:
+//!
+//! ```
+//! use http::{Request, Response, header::{self, HeaderValue}};
+//! use tower::{Service, ServiceExt, ServiceBuilder};
+//! use tower_http::set_header::SetRequestHeaderLayer;
+//! use bytes::Bytes;
+//! use http_body_util::Full;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let http_client = tower::service_fn(|_: Request<Full<Bytes>>| async move {
+//! #     Ok::<_, std::convert::Infallible>(Response::new(Full::<Bytes>::default()))
+//! # });
+//! fn date_header_value() -> HeaderValue {
+//!     // ...
+//!     # HeaderValue::from_static("now")
+//! }
+//!
+//! let mut svc = ServiceBuilder::new()
+//!     .layer(
+//!         // Layer that sets `Date` to the current date and time.
+//!         //
+//!         // `overriding` will insert the header and override any previous values it
+//!         // may have.
+//!         SetRequestHeaderLayer::overriding(
+//!             header::DATE,
+//!             |request: &Request<Full<Bytes>>| {
+//!                 Some(date_header_value())
+//!             }
+//!         )
+//!     )
+//!     .service(http_client);
+//!
+//! let request = Request::new(Full::default());
+//!
+//! let response = svc.ready().await?.call(request).await?;
+//! #
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Example: Multiple Dynamic Values
+//!
+//! ```
+//! use http::{Request, Response, header::{self, HeaderValue}};
+//! use tower::{Service, ServiceExt, ServiceBuilder};
+//! use tower_http::set_header::request::{SetMultipleRequestHeadersLayer, HeaderMetadata};
+//! use bytes::Bytes;
+//! use http_body_util::Full;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let http_client = tower::service_fn(|_: Request<Full<Bytes>>| async move {
+//! #     Ok::<_, std::convert::Infallible>(Response::new(Full::<Bytes>::default()))
+//! # });
+//!
+//! let mut svc = ServiceBuilder::new()
+//!     .layer(
+//!         SetMultipleRequestHeadersLayer::overriding(vec![
+//!             (header::DATE, |_: &Request<Full<Bytes>>| {
+//!                 Some(HeaderValue::from_static("now"))
+//!             }).into(),
+//!         ])
+//!     )
+//!     .service(tower::service_fn(|req: Request<Full<Bytes>>| async move {
+//!         assert_eq!(req.headers()["date"], "now");
+//!         Ok::<_, std::convert::Infallible>(Response::new(Full::<Bytes>::default()))
+//!     }));
+//!
+//! let request = Request::new(Full::default());
+//!
+//! let _response = svc.ready().await?.call(request).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Modes
+//!
+//! - `overriding`: If a previous value exists for the same header, it is removed and replaced with the new value.
+//! - `appending`: The new header is always added, preserving any existing values. If previous values exist, the header will have multiple values.
+//! - `if_not_present`: If a previous value exists for the header, the new value is not inserted.
+//!
+//! See [`SetRequestHeaderLayer`], [`SetRequestHeader`], [`SetMultipleRequestHeadersLayer`], and [`SetMultipleRequestHeader`] for more details.
+
+mod multiple_headers;
+mod single_header;
+
+pub use multiple_headers::{
+    HeaderMetadata, SetMultipleRequestHeader, SetMultipleRequestHeadersLayer,
+};
+pub use single_header::{SetRequestHeader, SetRequestHeaderLayer};

--- a/tower-http/src/set_header/request/multiple_headers.rs
+++ b/tower-http/src/set_header/request/multiple_headers.rs
@@ -15,19 +15,9 @@ use crate::set_header::{HeaderInsertionConfig, HeaderMetadata, InsertHeaderMode}
 /// Layer that applies [`SetMultipleRequestHeader`] which adds multiple request headers.
 ///
 /// See [`SetMultipleRequestHeader`] for more details.
+#[derive(Clone)]
 pub struct SetMultipleRequestHeadersLayer<M> {
     headers: Vec<HeaderInsertionConfig<M>>,
-}
-
-impl<M> Clone for SetMultipleRequestHeadersLayer<M>
-where
-    M: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            headers: self.headers.clone(),
-        }
-    }
 }
 
 impl<M> fmt::Debug for SetMultipleRequestHeadersLayer<M> {

--- a/tower-http/src/set_header/request/multiple_headers.rs
+++ b/tower-http/src/set_header/request/multiple_headers.rs
@@ -2,7 +2,7 @@
 //!
 //! See the root [`crate::set_header::request`] module for full documentation and usage examples.
 //!
-use http::{header::HeaderName, Request, Response};
+use http::{Request, Response};
 use std::{
     fmt,
     task::{Context, Poll},
@@ -10,85 +10,30 @@ use std::{
 use tower_layer::Layer;
 use tower_service::Service;
 
-use crate::set_header::{BoxedMakeHeaderValue, InsertHeaderMode, MakeHeaderValue};
-
-/// Metadata describing a request header to be set by [`SetMultipleRequestHeadersLayer`] or [`SetMultipleRequestHeader`].
-#[derive(Clone, Debug)]
-pub struct HeaderMetadata<T> {
-    /// The name of the header to set.
-    header_name: HeaderName,
-    /// The value or value factory for the header.
-    make: BoxedMakeHeaderValue<T>,
-}
-
-impl<T> HeaderMetadata<T> {
-    /// Create a new HeaderMetadata with the given header name and value factory.
-    fn new<M: MakeHeaderValue<T> + Clone + 'static + Send + Sync>(
-        header_name: HeaderName,
-        make: M,
-    ) -> Self {
-        Self {
-            header_name,
-            make: BoxedMakeHeaderValue::new(make),
-        }
-    }
-
-    /// Convert this metadata into a [`HeaderInsertionConfig`] with the given insertion mode.
-    fn build_config(self, mode: InsertHeaderMode) -> HeaderInsertionConfig<T> {
-        HeaderInsertionConfig {
-            header_name: self.header_name,
-            make: self.make,
-            mode,
-        }
-    }
-}
-
-impl<T, M> From<(HeaderName, M)> for HeaderMetadata<T>
-where
-    M: MakeHeaderValue<T> + Clone + 'static + Send + Sync,
-{
-    fn from((header_name, make): (HeaderName, M)) -> Self {
-        HeaderMetadata::new(header_name, make)
-    }
-}
-
-struct HeaderInsertionConfig<T> {
-    header_name: HeaderName,
-    make: BoxedMakeHeaderValue<T>,
-    mode: InsertHeaderMode,
-}
-
-impl<T> Clone for HeaderInsertionConfig<T>
-where
-    BoxedMakeHeaderValue<T>: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            header_name: self.header_name.clone(),
-            make: self.make.clone(),
-            mode: self.mode,
-        }
-    }
-}
-
-impl<T> fmt::Debug for HeaderInsertionConfig<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("HeaderInsertionConfig")
-            .field("header_name", &self.header_name)
-            .field("mode", &self.mode)
-            .field("make", &"BoxedMakeHeaderValue")
-            .finish()
-    }
-}
+use crate::set_header::{HeaderInsertionConfig, HeaderMetadata, InsertHeaderMode};
 
 /// Layer that applies [`SetMultipleRequestHeader`] which adds multiple request headers.
 ///
 /// See [`SetMultipleRequestHeader`] for more details.
-pub struct SetMultipleRequestHeadersLayer<T> {
-    headers: Vec<HeaderInsertionConfig<T>>,
+pub struct SetMultipleRequestHeadersLayer<M> {
+    headers: Vec<HeaderInsertionConfig<M>>,
 }
 
-impl<T> fmt::Debug for SetMultipleRequestHeadersLayer<T> {
+impl<M> Clone for SetMultipleRequestHeadersLayer<M>
+where
+    M: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            headers: self.headers.clone(),
+        }
+    }
+}
+
+impl<M> fmt::Debug for SetMultipleRequestHeadersLayer<M>
+where
+    M: Clone,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SetMultipleRequestHeadersLayer")
             .field("headers", &self.headers)
@@ -96,12 +41,12 @@ impl<T> fmt::Debug for SetMultipleRequestHeadersLayer<T> {
     }
 }
 
-impl<T> SetMultipleRequestHeadersLayer<T> {
+impl<M> SetMultipleRequestHeadersLayer<M> {
     /// Create a new [`SetMultipleRequestHeadersLayer`].
     ///
     /// If any previous value exists for the same header, it is removed and replaced with the new matching header value.
-    pub fn overriding(metadata: Vec<HeaderMetadata<T>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+    pub fn overriding(metadata: Vec<HeaderMetadata<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
             .into_iter()
             .map(|m| m.build_config(InsertHeaderMode::Override))
             .collect();
@@ -113,8 +58,8 @@ impl<T> SetMultipleRequestHeadersLayer<T> {
     ///
     /// The new header is always added, preserving any existing values. If previous values exist,
     /// the header will have multiple values.
-    pub fn appending(metadata: Vec<HeaderMetadata<T>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+    pub fn appending(metadata: Vec<HeaderMetadata<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
             .into_iter()
             .map(|m| m.build_config(InsertHeaderMode::Append))
             .collect();
@@ -125,8 +70,8 @@ impl<T> SetMultipleRequestHeadersLayer<T> {
     /// Create a new [`SetMultipleRequestHeadersLayer`].
     ///
     /// If a previous value exists for the header, the new value is not inserted.
-    pub fn if_not_present(metadata: Vec<HeaderMetadata<T>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+    pub fn if_not_present(metadata: Vec<HeaderMetadata<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
             .into_iter()
             .map(|m| m.build_config(InsertHeaderMode::IfNotPresent))
             .collect();
@@ -135,13 +80,13 @@ impl<T> SetMultipleRequestHeadersLayer<T> {
     }
 
     /// Internal constructor for a new [`SetMultipleRequestHeadersLayer`] from a list of headers.
-    fn new(headers: Vec<HeaderInsertionConfig<T>>) -> Self {
+    fn new(headers: Vec<HeaderInsertionConfig<M>>) -> Self {
         Self { headers }
     }
 }
 
-impl<S, T> Layer<S> for SetMultipleRequestHeadersLayer<T> {
-    type Service = SetMultipleRequestHeader<S, T>;
+impl<S, M> Layer<S> for SetMultipleRequestHeadersLayer<M> {
+    type Service = SetMultipleRequestHeader<S, M>;
 
     fn layer(&self, inner: S) -> Self::Service {
         SetMultipleRequestHeader {
@@ -153,18 +98,18 @@ impl<S, T> Layer<S> for SetMultipleRequestHeadersLayer<T> {
 
 /// Middleware that sets multiple headers on the request.
 #[derive(Clone)]
-pub struct SetMultipleRequestHeader<S, T> {
+pub struct SetMultipleRequestHeader<S, M> {
     inner: S,
-    headers: Vec<HeaderInsertionConfig<T>>,
+    headers: Vec<HeaderInsertionConfig<M>>,
 }
 
-impl<S, T> SetMultipleRequestHeader<S, T> {
+impl<S, M> SetMultipleRequestHeader<S, M> {
     /// Create a new [`SetMultipleRequestHeader`].
     ///
     /// If a previous value exists for the same header, it is removed and replaced with the new
     /// header value.
-    pub fn overriding(inner: S, metadata: Vec<HeaderMetadata<T>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+    pub fn overriding(inner: S, metadata: Vec<HeaderMetadata<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
             .into_iter()
             .map(|m| m.build_config(InsertHeaderMode::Override))
             .collect();
@@ -176,8 +121,8 @@ impl<S, T> SetMultipleRequestHeader<S, T> {
     ///
     /// The new header is always added, preserving any existing values. If previous values exist,
     /// the header will have multiple values.
-    pub fn appending(inner: S, metadata: Vec<HeaderMetadata<T>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+    pub fn appending(inner: S, metadata: Vec<HeaderMetadata<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
             .into_iter()
             .map(|m| m.build_config(InsertHeaderMode::Append))
             .collect();
@@ -188,8 +133,8 @@ impl<S, T> SetMultipleRequestHeader<S, T> {
     /// Create a new [`SetMultipleRequestHeader`].
     ///
     /// If a previous value exists for the header, the new value is not inserted.
-    pub fn if_not_present(inner: S, metadata: Vec<HeaderMetadata<T>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+    pub fn if_not_present(inner: S, metadata: Vec<HeaderMetadata<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
             .into_iter()
             .map(|m| m.build_config(InsertHeaderMode::IfNotPresent))
             .collect();
@@ -198,14 +143,14 @@ impl<S, T> SetMultipleRequestHeader<S, T> {
     }
 
     /// Internal constructor for a new [`SetMultipleRequestHeader`] from an inner service and a list of headers.
-    fn new(inner: S, headers: Vec<HeaderInsertionConfig<T>>) -> Self {
+    fn new(inner: S, headers: Vec<HeaderInsertionConfig<M>>) -> Self {
         Self { inner, headers }
     }
 
     define_inner_service_accessors!();
 }
 
-impl<S, T> fmt::Debug for SetMultipleRequestHeader<S, T>
+impl<S, M> fmt::Debug for SetMultipleRequestHeader<S, M>
 where
     S: fmt::Debug,
 {
@@ -380,26 +325,33 @@ mod tests {
 
     #[tokio::test]
     async fn test_layer_with_empty_vec() {
-        let _ = tower::ServiceBuilder::new()
-            .layer(SetMultipleRequestHeadersLayer::<Response<Body>>::overriding(vec![]))
+        let header_metadatas: Vec<HeaderMetadata<Request<Body>>> = vec![];
+        let svc = tower::ServiceBuilder::new()
+            .layer(SetMultipleRequestHeadersLayer::<Request<Body>>::overriding(
+                header_metadatas,
+            ))
             .service(service_fn(|req: Request<Body>| async move {
                 assert_eq!(req.headers().len(), 0);
                 Ok::<_, Infallible>(Response::new(Body::empty()))
             }));
+
+        _ = svc.oneshot(Request::new(Body::empty())).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_layer_with_static_and_closure_headers_fixed() {
         // Wrap the static value
-        let static_meta = (header::CONTENT_TYPE, HeaderValue::from_static("text/html")).into();
+        let static_meta: HeaderMetadata<Request<Body>> =
+            (header::CONTENT_TYPE, HeaderValue::from_static("text/html")).into();
 
         // Wrap the closure
-        let closure_meta = (header::X_FRAME_OPTIONS, |_res: &Response<Body>| {
-            Some(HeaderValue::from_static("DENY"))
-        })
-            .into();
+        let closure_meta: HeaderMetadata<Request<Body>> =
+            (header::X_FRAME_OPTIONS, |_req: &Request<Body>| {
+                Some(HeaderValue::from_static("DENY"))
+            })
+                .into();
 
-        let _ = tower::ServiceBuilder::new()
+        let svc = tower::ServiceBuilder::new()
             .layer(SetMultipleRequestHeadersLayer::overriding(vec![
                 static_meta,
                 closure_meta,
@@ -407,8 +359,11 @@ mod tests {
             .service(service_fn(|req: Request<Body>| async move {
                 assert_eq!(req.headers()["content-type"], "text/html");
                 assert_eq!(req.headers()["x-frame-options"], "DENY");
+
                 Ok::<_, Infallible>(Response::new(Body::empty()))
             }));
+
+        _ = svc.oneshot(Request::new(Body::empty())).await.unwrap();
     }
 
     #[test]

--- a/tower-http/src/set_header/request/multiple_headers.rs
+++ b/tower-http/src/set_header/request/multiple_headers.rs
@@ -1,0 +1,422 @@
+//! Set multiple headers on the request.
+//!
+//! See the root [`crate::set_header::request`] module for full documentation and usage examples.
+//!
+use http::{header::HeaderName, Request, Response};
+use std::{
+    fmt,
+    task::{Context, Poll},
+};
+use tower_layer::Layer;
+use tower_service::Service;
+
+use crate::set_header::{BoxedMakeHeaderValue, InsertHeaderMode, MakeHeaderValue};
+
+/// Metadata describing a request header to be set by [`SetMultipleRequestHeadersLayer`] or [`SetMultipleRequestHeader`].
+#[derive(Clone, Debug)]
+pub struct HeaderMetadata<T> {
+    /// The name of the header to set.
+    header_name: HeaderName,
+    /// The value or value factory for the header.
+    make: BoxedMakeHeaderValue<T>,
+}
+
+impl<T> HeaderMetadata<T> {
+    /// Create a new HeaderMetadata with the given header name and value factory.
+    fn new<M: MakeHeaderValue<T> + Clone + 'static + Send + Sync>(
+        header_name: HeaderName,
+        make: M,
+    ) -> Self {
+        Self {
+            header_name,
+            make: BoxedMakeHeaderValue::new(make),
+        }
+    }
+
+    /// Convert this metadata into a [`HeaderInsertionConfig`] with the given insertion mode.
+    fn build_config(self, mode: InsertHeaderMode) -> HeaderInsertionConfig<T> {
+        HeaderInsertionConfig {
+            header_name: self.header_name,
+            make: self.make,
+            mode,
+        }
+    }
+}
+
+impl<T, M> From<(HeaderName, M)> for HeaderMetadata<T>
+where
+    M: MakeHeaderValue<T> + Clone + 'static + Send + Sync,
+{
+    fn from((header_name, make): (HeaderName, M)) -> Self {
+        HeaderMetadata::new(header_name, make)
+    }
+}
+
+struct HeaderInsertionConfig<T> {
+    header_name: HeaderName,
+    make: BoxedMakeHeaderValue<T>,
+    mode: InsertHeaderMode,
+}
+
+impl<T> Clone for HeaderInsertionConfig<T>
+where
+    BoxedMakeHeaderValue<T>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            make: self.make.clone(),
+            mode: self.mode,
+        }
+    }
+}
+
+impl<T> fmt::Debug for HeaderInsertionConfig<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HeaderInsertionConfig")
+            .field("header_name", &self.header_name)
+            .field("mode", &self.mode)
+            .field("make", &"BoxedMakeHeaderValue")
+            .finish()
+    }
+}
+
+/// Layer that applies [`SetMultipleRequestHeader`] which adds multiple request headers.
+///
+/// See [`SetMultipleRequestHeader`] for more details.
+pub struct SetMultipleRequestHeadersLayer<T> {
+    headers: Vec<HeaderInsertionConfig<T>>,
+}
+
+impl<T> fmt::Debug for SetMultipleRequestHeadersLayer<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SetMultipleRequestHeadersLayer")
+            .field("headers", &self.headers)
+            .finish()
+    }
+}
+
+impl<T> SetMultipleRequestHeadersLayer<T> {
+    /// Create a new [`SetMultipleRequestHeadersLayer`].
+    ///
+    /// If any previous value exists for the same header, it is removed and replaced with the new matching header value.
+    pub fn overriding(metadata: Vec<HeaderMetadata<T>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+            .into_iter()
+            .map(|m| m.build_config(InsertHeaderMode::Override))
+            .collect();
+
+        Self::new(headers)
+    }
+
+    /// Create a new [`SetMultipleRequestHeadersLayer`].
+    ///
+    /// The new header is always added, preserving any existing values. If previous values exist,
+    /// the header will have multiple values.
+    pub fn appending(metadata: Vec<HeaderMetadata<T>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+            .into_iter()
+            .map(|m| m.build_config(InsertHeaderMode::Append))
+            .collect();
+
+        Self::new(headers)
+    }
+
+    /// Create a new [`SetMultipleRequestHeadersLayer`].
+    ///
+    /// If a previous value exists for the header, the new value is not inserted.
+    pub fn if_not_present(metadata: Vec<HeaderMetadata<T>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+            .into_iter()
+            .map(|m| m.build_config(InsertHeaderMode::IfNotPresent))
+            .collect();
+
+        Self::new(headers)
+    }
+
+    /// Internal constructor for a new [`SetMultipleRequestHeadersLayer`] from a list of headers.
+    fn new(headers: Vec<HeaderInsertionConfig<T>>) -> Self {
+        Self { headers }
+    }
+}
+
+impl<S, T> Layer<S> for SetMultipleRequestHeadersLayer<T> {
+    type Service = SetMultipleRequestHeader<S, T>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        SetMultipleRequestHeader {
+            inner,
+            headers: self.headers.clone(),
+        }
+    }
+}
+
+/// Middleware that sets multiple headers on the request.
+#[derive(Clone)]
+pub struct SetMultipleRequestHeader<S, T> {
+    inner: S,
+    headers: Vec<HeaderInsertionConfig<T>>,
+}
+
+impl<S, T> SetMultipleRequestHeader<S, T> {
+    /// Create a new [`SetMultipleRequestHeader`].
+    ///
+    /// If a previous value exists for the same header, it is removed and replaced with the new
+    /// header value.
+    pub fn overriding(inner: S, metadata: Vec<HeaderMetadata<T>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+            .into_iter()
+            .map(|m| m.build_config(InsertHeaderMode::Override))
+            .collect();
+
+        Self::new(inner, headers)
+    }
+
+    /// Create a new [`SetMultipleRequestHeader`].
+    ///
+    /// The new header is always added, preserving any existing values. If previous values exist,
+    /// the header will have multiple values.
+    pub fn appending(inner: S, metadata: Vec<HeaderMetadata<T>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+            .into_iter()
+            .map(|m| m.build_config(InsertHeaderMode::Append))
+            .collect();
+
+        Self::new(inner, headers)
+    }
+
+    /// Create a new [`SetMultipleRequestHeader`].
+    ///
+    /// If a previous value exists for the header, the new value is not inserted.
+    pub fn if_not_present(inner: S, metadata: Vec<HeaderMetadata<T>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+            .into_iter()
+            .map(|m| m.build_config(InsertHeaderMode::IfNotPresent))
+            .collect();
+
+        Self::new(inner, headers)
+    }
+
+    /// Internal constructor for a new [`SetMultipleRequestHeader`] from an inner service and a list of headers.
+    fn new(inner: S, headers: Vec<HeaderInsertionConfig<T>>) -> Self {
+        Self { inner, headers }
+    }
+
+    define_inner_service_accessors!();
+}
+
+impl<S, T> fmt::Debug for SetMultipleRequestHeader<S, T>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SetMultipleRequestHeader")
+            .field("inner", &self.inner)
+            .field("headers", &self.headers)
+            .finish()
+    }
+}
+
+impl<ReqBody, ResBody, S> Service<Request<ReqBody>>
+    for SetMultipleRequestHeader<S, Request<ReqBody>>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        for header in &mut self.headers {
+            header
+                .mode
+                .apply(&header.header_name, &mut req, &mut header.make);
+        }
+
+        self.inner.call(req)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::Body;
+    use http::{header, HeaderValue, Request, Response};
+    use std::convert::Infallible;
+    use tower::{service_fn, ServiceExt};
+
+    #[tokio::test]
+    async fn test_override_mode() {
+        let svc = SetMultipleRequestHeader::overriding(
+            service_fn(|req: Request<Body>| async move {
+                assert_eq!(req.headers()["content-type"], "text/html");
+                Ok::<_, Infallible>(Response::new(Body::empty()))
+            }),
+            vec![(header::CONTENT_TYPE, HeaderValue::from_static("text/html")).into()],
+        );
+
+        let mut req = Request::new(Body::empty());
+
+        // Add an initial CONTENT_TYPE header to the request
+        req.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("good-content"),
+        );
+
+        let _ = svc.oneshot(req).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_append_mode() {
+        let svc = SetMultipleRequestHeader::appending(
+            service_fn(|req: Request<Body>| async move {
+                let mut values = req.headers().get_all("content-type").iter();
+                assert_eq!(values.next().unwrap(), "good-content");
+                assert_eq!(values.next().unwrap(), "text/html");
+                assert_eq!(values.next(), None);
+
+                Ok::<_, Infallible>(Response::new(Body::empty()))
+            }),
+            vec![(header::CONTENT_TYPE, HeaderValue::from_static("text/html")).into()],
+        );
+
+        // Add an initial CONTENT_TYPE header to the request
+        let mut req = Request::new(Body::empty());
+        req.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("good-content"),
+        );
+
+        _ = svc.oneshot(req).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_skip_if_present_mode() {
+        let svc = SetMultipleRequestHeader::if_not_present(
+            service_fn(|req: Request<Body>| async move {
+                let mut values = req.headers().get_all("content-type").iter();
+                assert_eq!(values.next().unwrap(), "good-content");
+                assert_eq!(values.next(), None);
+
+                Ok::<_, Infallible>(Response::new(Body::empty()))
+            }),
+            vec![(header::CONTENT_TYPE, HeaderValue::from_static("text/html")).into()],
+        );
+
+        // Add an initial CONTENT_TYPE header to the request
+        let mut req = Request::new(Body::empty());
+        req.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("good-content"),
+        );
+
+        let _ = svc.oneshot(req).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_skip_if_present_mode_when_not_present() {
+        let svc = SetMultipleRequestHeader::if_not_present(
+            service_fn(|req: Request<Body>| async move {
+                let mut values = req.headers().get_all("content-type").iter();
+                assert_eq!(values.next().unwrap(), "text/html");
+                assert_eq!(values.next(), None);
+                Ok::<_, Infallible>(Response::new(Body::empty()))
+            }),
+            vec![(header::CONTENT_TYPE, HeaderValue::from_static("text/html")).into()],
+        );
+
+        // No header to the request
+        let req = Request::new(Body::empty());
+
+        _ = svc.oneshot(req).await.unwrap();
+    }
+
+    #[test]
+    fn test_debug_impls() {
+        let meta: HeaderMetadata<HeaderValue> =
+            (header::CONTENT_TYPE, HeaderValue::from_static("bar")).into();
+        let rh = meta
+            .clone()
+            .build_config(crate::set_header::InsertHeaderMode::Override);
+        let layer = SetMultipleRequestHeadersLayer::overriding(vec![meta]);
+        let debug_str = format!("{:?}", layer);
+        assert!(debug_str.contains("SetMultipleRequestHeadersLayer"));
+        let debug_rh = format!("{:?}", rh);
+        assert!(debug_rh.contains("HeaderInsertionConfig"));
+
+        let svc = SetMultipleRequestHeader::overriding(
+            tower::service_fn(|_req: Request<Body>| async {
+                Ok::<_, std::convert::Infallible>(Response::new(Body::empty()))
+            }),
+            vec![(header::CONTENT_TYPE, HeaderValue::from_static("foo")).into()]
+                as Vec<HeaderMetadata<HeaderValue>>,
+        );
+        let debug_svc = format!("{:?}", svc);
+        assert!(debug_svc.contains("SetMultipleRequestHeader"));
+    }
+
+    #[tokio::test]
+    async fn test_layer_construction_and_multiple_headers() {
+        // Multiple different headers in the same vec
+        let svc = tower::ServiceBuilder::new()
+            .layer(SetMultipleRequestHeadersLayer::overriding(vec![
+                (header::CONTENT_TYPE, HeaderValue::from_static("text/html")).into(),
+                (header::CACHE_CONTROL, HeaderValue::from_static("no-cache")).into(),
+            ]))
+            .service(service_fn(|req: Request<Body>| async move {
+                assert_eq!(req.headers()["content-type"], "text/html");
+                assert_eq!(req.headers()["cache-control"], "no-cache");
+
+                Ok::<_, Infallible>(Response::new(Body::empty()))
+            }));
+
+        _ = svc.oneshot(Request::new(Body::empty())).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_layer_with_empty_vec() {
+        let _ = tower::ServiceBuilder::new()
+            .layer(SetMultipleRequestHeadersLayer::<Response<Body>>::overriding(vec![]))
+            .service(service_fn(|req: Request<Body>| async move {
+                assert_eq!(req.headers().len(), 0);
+                Ok::<_, Infallible>(Response::new(Body::empty()))
+            }));
+    }
+
+    #[tokio::test]
+    async fn test_layer_with_static_and_closure_headers_fixed() {
+        // Wrap the static value
+        let static_meta = (header::CONTENT_TYPE, HeaderValue::from_static("text/html")).into();
+
+        // Wrap the closure
+        let closure_meta = (header::X_FRAME_OPTIONS, |_res: &Response<Body>| {
+            Some(HeaderValue::from_static("DENY"))
+        })
+            .into();
+
+        let _ = tower::ServiceBuilder::new()
+            .layer(SetMultipleRequestHeadersLayer::overriding(vec![
+                static_meta,
+                closure_meta,
+            ]))
+            .service(service_fn(|req: Request<Body>| async move {
+                assert_eq!(req.headers()["content-type"], "text/html");
+                assert_eq!(req.headers()["x-frame-options"], "DENY");
+                Ok::<_, Infallible>(Response::new(Body::empty()))
+            }));
+    }
+
+    #[test]
+    fn test_debug_layer_and_service() {
+        let meta: HeaderMetadata<HeaderValue> =
+            (header::CONTENT_TYPE, HeaderValue::from_static("foo")).into();
+        let layer = SetMultipleRequestHeadersLayer::overriding(vec![meta]);
+        let debug_str = format!("{:?}", layer);
+        assert!(debug_str.contains("SetMultipleRequestHeadersLayer"));
+    }
+}

--- a/tower-http/src/set_header/request/multiple_headers.rs
+++ b/tower-http/src/set_header/request/multiple_headers.rs
@@ -30,10 +30,7 @@ where
     }
 }
 
-impl<M> fmt::Debug for SetMultipleRequestHeadersLayer<M>
-where
-    M: Clone,
-{
+impl<M> fmt::Debug for SetMultipleRequestHeadersLayer<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SetMultipleRequestHeadersLayer")
             .field("headers", &self.headers)

--- a/tower-http/src/set_header/request/single_header.rs
+++ b/tower-http/src/set_header/request/single_header.rs
@@ -1,90 +1,7 @@
-//! Set a header on the request.
+//! Set a single header on the request.
 //!
-//! The header value to be set may be provided as a fixed value when the
-//! middleware is constructed, or determined dynamically based on the request
-//! by a closure. See the [`MakeHeaderValue`] trait for details.
+//! See the root [`crate::set_header::request`] module for full documentation and usage examples.
 //!
-//! # Example
-//!
-//! Setting a header from a fixed value provided when the middleware is constructed:
-//!
-//! ```
-//! use http::{Request, Response, header::{self, HeaderValue}};
-//! use tower::{Service, ServiceExt, ServiceBuilder};
-//! use tower_http::set_header::SetRequestHeaderLayer;
-//! use http_body_util::Full;
-//! use bytes::Bytes;
-//!
-//! # #[tokio::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # let http_client = tower::service_fn(|_: Request<Full<Bytes>>| async move {
-//! #     Ok::<_, std::convert::Infallible>(Response::new(Full::<Bytes>::default()))
-//! # });
-//! #
-//! let mut svc = ServiceBuilder::new()
-//!     .layer(
-//!         // Layer that sets `User-Agent: my very cool app` on requests.
-//!         //
-//!         // `if_not_present` will only insert the header if it does not already
-//!         // have a value.
-//!         SetRequestHeaderLayer::if_not_present(
-//!             header::USER_AGENT,
-//!             HeaderValue::from_static("my very cool app"),
-//!         )
-//!     )
-//!     .service(http_client);
-//!
-//! let request = Request::new(Full::default());
-//!
-//! let response = svc.ready().await?.call(request).await?;
-//! #
-//! # Ok(())
-//! # }
-//! ```
-//!
-//! Setting a header based on a value determined dynamically from the request:
-//!
-//! ```
-//! use http::{Request, Response, header::{self, HeaderValue}};
-//! use tower::{Service, ServiceExt, ServiceBuilder};
-//! use tower_http::set_header::SetRequestHeaderLayer;
-//! use bytes::Bytes;
-//! use http_body_util::Full;
-//!
-//! # #[tokio::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # let http_client = tower::service_fn(|_: Request<Full<Bytes>>| async move {
-//! #     Ok::<_, std::convert::Infallible>(Response::new(Full::<Bytes>::default()))
-//! # });
-//! fn date_header_value() -> HeaderValue {
-//!     // ...
-//!     # HeaderValue::from_static("now")
-//! }
-//!
-//! let mut svc = ServiceBuilder::new()
-//!     .layer(
-//!         // Layer that sets `Date` to the current date and time.
-//!         //
-//!         // `overriding` will insert the header and override any previous values it
-//!         // may have.
-//!         SetRequestHeaderLayer::overriding(
-//!             header::DATE,
-//!             |request: &Request<Full<Bytes>>| {
-//!                 Some(date_header_value())
-//!             }
-//!         )
-//!     )
-//!     .service(http_client);
-//!
-//! let request = Request::new(Full::default());
-//!
-//! let response = svc.ready().await?.call(request).await?;
-//! #
-//! # Ok(())
-//! # }
-//! ```
-
-use super::{InsertHeaderMode, MakeHeaderValue};
 use http::{header::HeaderName, Request, Response};
 use std::{
     fmt,
@@ -92,6 +9,8 @@ use std::{
 };
 use tower_layer::Layer;
 use tower_service::Service;
+
+use crate::set_header::{InsertHeaderMode, MakeHeaderValue};
 
 /// Layer that applies [`SetRequestHeader`] which adds a request header.
 ///

--- a/tower-http/src/set_header/response/mod.rs
+++ b/tower-http/src/set_header/response/mod.rs
@@ -88,7 +88,8 @@
 //! ```
 //! use http::{Request, Response, header::{self, HeaderValue}};
 //! use tower::{Service, ServiceExt, ServiceBuilder};
-//! use tower_http::set_header::response::{SetMultipleResponseHeadersLayer, HeaderMetadata};
+//! use tower_http::set_header::response::{SetMultipleResponseHeadersLayer};
+//! use tower_http::set_header::HeaderMetadata;
 //! use http_body_util::Full;
 //! use bytes::Bytes;
 //!
@@ -122,7 +123,8 @@
 //! ```
 //! use http::{Request, Response, header::{self, HeaderValue}};
 //! use tower::{Service, ServiceExt, ServiceBuilder};
-//! use tower_http::set_header::response::{SetMultipleResponseHeadersLayer, HeaderMetadata};
+//! use tower_http::set_header::response::{SetMultipleResponseHeadersLayer};
+//! use tower_http::set_header::HeaderMetadata;
 //! use bytes::Bytes;
 //! use http_body_util::Full;
 //! use http_body::Body as _; // for `Body::size_hint`
@@ -164,10 +166,8 @@
 //!
 //! See [`SetResponseHeaderLayer`], [`SetResponseHeader`], [`SetMultipleResponseHeadersLayer`], and [`SetMultipleResponseHeader`] for more details.
 
-mod multiple_header;
+mod multiple_headers;
 mod single_header;
 
-pub use multiple_header::{
-    HeaderMetadata, SetMultipleResponseHeader, SetMultipleResponseHeadersLayer,
-};
+pub use multiple_headers::{SetMultipleResponseHeader, SetMultipleResponseHeadersLayer};
 pub use single_header::{SetResponseHeader, SetResponseHeaderLayer};

--- a/tower-http/src/set_header/response/mod.rs
+++ b/tower-http/src/set_header/response/mod.rs
@@ -83,13 +83,16 @@
 //!
 //! Use [`SetMultipleResponseHeadersLayer`] and [`SetMultipleResponseHeader`] to set multiple headers at once. Each header can have a fixed value or be computed dynamically.
 //!
+//! Note: this layer uses boxing (allocation + dynamic dispatch) to support mixed producer
+//! types in a single vec. Stacking multiple [`SetResponseHeaderLayer`] avoids this at the
+//! cost of a more complex composed service type.
+//!
 //! ## Example: Multiple Fixed Values
 //!
 //! ```
 //! use http::{Request, Response, header::{self, HeaderValue}};
 //! use tower::{Service, ServiceExt, ServiceBuilder};
-//! use tower_http::set_header::response::{SetMultipleResponseHeadersLayer};
-//! use tower_http::set_header::HeaderMetadata;
+//! use tower_http::set_header::{HeaderMetadata, response::{SetMultipleResponseHeadersLayer}};
 //! use http_body_util::Full;
 //! use bytes::Bytes;
 //!
@@ -123,8 +126,7 @@
 //! ```
 //! use http::{Request, Response, header::{self, HeaderValue}};
 //! use tower::{Service, ServiceExt, ServiceBuilder};
-//! use tower_http::set_header::response::{SetMultipleResponseHeadersLayer};
-//! use tower_http::set_header::HeaderMetadata;
+//! use tower_http::set_header::{HeaderMetadata, response::{SetMultipleResponseHeadersLayer}};
 //! use bytes::Bytes;
 //! use http_body_util::Full;
 //! use http_body::Body as _; // for `Body::size_hint`

--- a/tower-http/src/set_header/response/multiple_header.rs
+++ b/tower-http/src/set_header/response/multiple_header.rs
@@ -2,7 +2,7 @@
 //!
 //! See the root [`crate::set_header::response`] module for full documentation and usage examples.
 //!
-use http::{header::HeaderName, HeaderValue, Request, Response};
+use http::{header::HeaderName, Request, Response};
 use pin_project_lite::pin_project;
 use std::{
     fmt,
@@ -13,52 +13,7 @@ use std::{
 use tower_layer::Layer;
 use tower_service::Service;
 
-use crate::set_header::{InsertHeaderMode, MakeHeaderValue};
-
-/// A trait that combines MakeHeaderValue and Clone capability for trait objects.
-trait CloneableMakeHeaderValue<T>: MakeHeaderValue<T> + Send + Sync {
-    fn clone_box(&self) -> Box<dyn CloneableMakeHeaderValue<T>>;
-}
-
-impl<T, M> CloneableMakeHeaderValue<T> for M
-where
-    M: MakeHeaderValue<T> + Clone + Send + Sync + 'static,
-{
-    fn clone_box(&self) -> Box<dyn CloneableMakeHeaderValue<T>> {
-        Box::new(self.clone())
-    }
-}
-
-/// A "Bridge" struct that allows for trait object-based header value generation.
-struct BoxedMakeHeaderValue<T>(Box<dyn CloneableMakeHeaderValue<T>>);
-
-impl<T> BoxedMakeHeaderValue<T> {
-    /// Create a new BoxedMakeHeaderValue from any maker that implements MakeHeaderValue and Clone.
-    fn new<M>(maker: M) -> Self
-    where
-        M: MakeHeaderValue<T> + Clone + Send + Sync + 'static,
-    {
-        Self(Box::new(maker))
-    }
-}
-
-impl<T> Clone for BoxedMakeHeaderValue<T> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone_box())
-    }
-}
-
-impl<T> MakeHeaderValue<T> for BoxedMakeHeaderValue<T> {
-    fn make_header_value(&mut self, message: &T) -> Option<HeaderValue> {
-        self.0.make_header_value(message)
-    }
-}
-
-impl<T> fmt::Debug for BoxedMakeHeaderValue<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("BoxedMakeHeaderValue").finish()
-    }
-}
+use crate::set_header::{BoxedMakeHeaderValue, InsertHeaderMode, MakeHeaderValue};
 
 /// Metadata describing a response header to be set by [`SetMultipleResponseHeadersLayer`] or [`SetMultipleResponseHeader`].
 #[derive(Clone, Debug)]

--- a/tower-http/src/set_header/response/multiple_headers.rs
+++ b/tower-http/src/set_header/response/multiple_headers.rs
@@ -18,6 +18,7 @@ use crate::set_header::{HeaderInsertionConfig, HeaderMetadata, InsertHeaderMode}
 /// Layer that applies [`SetMultipleResponseHeader`] which adds multiple response headers.
 ///
 /// See [`SetMultipleResponseHeader`] for more details.
+#[derive(Clone)]
 pub struct SetMultipleResponseHeadersLayer<M> {
     headers: Vec<HeaderInsertionConfig<M>>,
 }

--- a/tower-http/src/set_header/response/multiple_headers.rs
+++ b/tower-http/src/set_header/response/multiple_headers.rs
@@ -22,10 +22,7 @@ pub struct SetMultipleResponseHeadersLayer<M> {
     headers: Vec<HeaderInsertionConfig<M>>,
 }
 
-impl<M> fmt::Debug for SetMultipleResponseHeadersLayer<M>
-where
-    M: Clone,
-{
+impl<M> fmt::Debug for SetMultipleResponseHeadersLayer<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SetMultipleResponseHeadersLayer")
             .field("headers", &self.headers)

--- a/tower-http/src/set_header/response/multiple_headers.rs
+++ b/tower-http/src/set_header/response/multiple_headers.rs
@@ -2,7 +2,7 @@
 //!
 //! See the root [`crate::set_header::response`] module for full documentation and usage examples.
 //!
-use http::{header::HeaderName, Request, Response};
+use http::{Request, Response};
 use pin_project_lite::pin_project;
 use std::{
     fmt,
@@ -13,85 +13,19 @@ use std::{
 use tower_layer::Layer;
 use tower_service::Service;
 
-use crate::set_header::{BoxedMakeHeaderValue, InsertHeaderMode, MakeHeaderValue};
-
-/// Metadata describing a response header to be set by [`SetMultipleResponseHeadersLayer`] or [`SetMultipleResponseHeader`].
-#[derive(Clone, Debug)]
-pub struct HeaderMetadata<T> {
-    /// The name of the header to set.
-    header_name: HeaderName,
-    /// The value or value factory for the header.
-    make: BoxedMakeHeaderValue<T>,
-}
-
-impl<T> HeaderMetadata<T> {
-    /// Create a new HeaderMetadata with the given header name and value factory.
-    fn new<M: MakeHeaderValue<T> + Clone + 'static + Send + Sync>(
-        header_name: HeaderName,
-        make: M,
-    ) -> Self {
-        Self {
-            header_name,
-            make: BoxedMakeHeaderValue::new(make),
-        }
-    }
-
-    /// Convert this metadata into a [`HeaderInsertionConfig`] with the given insertion mode.
-    fn build_config(self, mode: InsertHeaderMode) -> HeaderInsertionConfig<T> {
-        HeaderInsertionConfig {
-            header_name: self.header_name,
-            make: self.make,
-            mode,
-        }
-    }
-}
-
-impl<T, M> From<(HeaderName, M)> for HeaderMetadata<T>
-where
-    M: MakeHeaderValue<T> + Clone + 'static + Send + Sync,
-{
-    fn from((header_name, make): (HeaderName, M)) -> Self {
-        HeaderMetadata::new(header_name, make)
-    }
-}
-
-struct HeaderInsertionConfig<T> {
-    header_name: HeaderName,
-    make: BoxedMakeHeaderValue<T>,
-    mode: InsertHeaderMode,
-}
-
-impl<T> Clone for HeaderInsertionConfig<T>
-where
-    BoxedMakeHeaderValue<T>: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            header_name: self.header_name.clone(),
-            make: self.make.clone(),
-            mode: self.mode,
-        }
-    }
-}
-
-impl<T> fmt::Debug for HeaderInsertionConfig<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("HeaderInsertionConfig")
-            .field("header_name", &self.header_name)
-            .field("mode", &self.mode)
-            .field("make", &"BoxedMakeHeaderValue")
-            .finish()
-    }
-}
+use crate::set_header::{HeaderInsertionConfig, HeaderMetadata, InsertHeaderMode};
 
 /// Layer that applies [`SetMultipleResponseHeader`] which adds multiple response headers.
 ///
 /// See [`SetMultipleResponseHeader`] for more details.
-pub struct SetMultipleResponseHeadersLayer<T> {
-    headers: Vec<HeaderInsertionConfig<T>>,
+pub struct SetMultipleResponseHeadersLayer<M> {
+    headers: Vec<HeaderInsertionConfig<M>>,
 }
 
-impl<T> fmt::Debug for SetMultipleResponseHeadersLayer<T> {
+impl<M> fmt::Debug for SetMultipleResponseHeadersLayer<M>
+where
+    M: Clone,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SetMultipleResponseHeadersLayer")
             .field("headers", &self.headers)
@@ -99,12 +33,12 @@ impl<T> fmt::Debug for SetMultipleResponseHeadersLayer<T> {
     }
 }
 
-impl<T> SetMultipleResponseHeadersLayer<T> {
+impl<M> SetMultipleResponseHeadersLayer<M> {
     /// Create a new [`SetMultipleResponseHeadersLayer`] that overrides any existing values for the same header.
     ///
     /// If any previous value exists for the same header, it is removed and replaced with the new matching header value.
-    pub fn overriding(metadata: Vec<HeaderMetadata<T>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+    pub fn overriding(metadata: Vec<HeaderMetadata<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
             .into_iter()
             .map(|m| m.build_config(InsertHeaderMode::Override))
             .collect();
@@ -115,8 +49,8 @@ impl<T> SetMultipleResponseHeadersLayer<T> {
     /// Create a new [`SetMultipleResponseHeadersLayer`] that appends header values.
     ///
     /// The new header is always added, preserving any existing values. If previous values exist, the header will have multiple values.
-    pub fn appending(metadata: Vec<HeaderMetadata<T>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+    pub fn appending(metadata: Vec<HeaderMetadata<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
             .into_iter()
             .map(|m| m.build_config(InsertHeaderMode::Append))
             .collect();
@@ -127,8 +61,8 @@ impl<T> SetMultipleResponseHeadersLayer<T> {
     /// Create a new [`SetMultipleResponseHeadersLayer`] that only inserts if the header is not already present.
     ///
     /// If a previous value exists for the header, the new value is not inserted.
-    pub fn if_not_present(metadata: Vec<HeaderMetadata<T>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+    pub fn if_not_present(metadata: Vec<HeaderMetadata<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
             .into_iter()
             .map(|m| m.build_config(InsertHeaderMode::IfNotPresent))
             .collect();
@@ -137,13 +71,13 @@ impl<T> SetMultipleResponseHeadersLayer<T> {
     }
 
     /// Internal constructor for a new [`SetMultipleResponseHeadersLayer`] from a list of headers.
-    fn new(headers: Vec<HeaderInsertionConfig<T>>) -> Self {
+    fn new(headers: Vec<HeaderInsertionConfig<M>>) -> Self {
         Self { headers }
     }
 }
 
-impl<S, T> Layer<S> for SetMultipleResponseHeadersLayer<T> {
-    type Service = SetMultipleResponseHeader<S, T>;
+impl<S, M> Layer<S> for SetMultipleResponseHeadersLayer<M> {
+    type Service = SetMultipleResponseHeader<S, M>;
 
     fn layer(&self, inner: S) -> Self::Service {
         SetMultipleResponseHeader {
@@ -156,17 +90,17 @@ impl<S, T> Layer<S> for SetMultipleResponseHeadersLayer<T> {
 /// Middleware that sets multiple headers on the response.
 
 #[derive(Clone)]
-pub struct SetMultipleResponseHeader<S, T> {
+pub struct SetMultipleResponseHeader<S, M> {
     inner: S,
-    headers: Vec<HeaderInsertionConfig<T>>,
+    headers: Vec<HeaderInsertionConfig<M>>,
 }
 
-impl<S, T> SetMultipleResponseHeader<S, T> {
+impl<S, M> SetMultipleResponseHeader<S, M> {
     /// Create a new [`SetMultipleResponseHeader`] that overrides any existing values for the same header.
     ///
     /// If a previous value exists for the same header, it is removed and replaced with the new header value.
-    pub fn overriding(inner: S, metadata: Vec<HeaderMetadata<T>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+    pub fn overriding(inner: S, metadata: Vec<HeaderMetadata<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
             .into_iter()
             .map(|m| m.build_config(InsertHeaderMode::Override))
             .collect();
@@ -177,8 +111,8 @@ impl<S, T> SetMultipleResponseHeader<S, T> {
     /// Create a new [`SetMultipleResponseHeader`] that appends header values.
     ///
     /// The new header is always added, preserving any existing values. If previous values exist, the header will have multiple values.
-    pub fn appending(inner: S, metadata: Vec<HeaderMetadata<T>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+    pub fn appending(inner: S, metadata: Vec<HeaderMetadata<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
             .into_iter()
             .map(|m| m.build_config(InsertHeaderMode::Append))
             .collect();
@@ -189,8 +123,8 @@ impl<S, T> SetMultipleResponseHeader<S, T> {
     /// Create a new [`SetMultipleResponseHeader`] that only inserts if the header is not already present.
     ///
     /// If a previous value exists for the header, the new value is not inserted.
-    pub fn if_not_present(inner: S, metadata: Vec<HeaderMetadata<T>>) -> Self {
-        let headers: Vec<HeaderInsertionConfig<T>> = metadata
+    pub fn if_not_present(inner: S, metadata: Vec<HeaderMetadata<M>>) -> Self {
+        let headers: Vec<HeaderInsertionConfig<M>> = metadata
             .into_iter()
             .map(|m| m.build_config(InsertHeaderMode::IfNotPresent))
             .collect();
@@ -199,14 +133,14 @@ impl<S, T> SetMultipleResponseHeader<S, T> {
     }
 
     /// Internal constructor for a new [`SetMultipleResponseHeader`] from an inner service and a list of headers.
-    fn new(inner: S, headers: Vec<HeaderInsertionConfig<T>>) -> Self {
+    fn new(inner: S, headers: Vec<HeaderInsertionConfig<M>>) -> Self {
         Self { inner, headers }
     }
 
     define_inner_service_accessors!();
 }
 
-impl<S, T> fmt::Debug for SetMultipleResponseHeader<S, T>
+impl<S, M> fmt::Debug for SetMultipleResponseHeader<S, M>
 where
     S: fmt::Debug,
 {
@@ -244,10 +178,10 @@ where
 pin_project! {
     /// Response future for [`SetMultipleResponseHeader`].
     #[derive(Debug)]
-    pub struct ResponseFuture<F, T> {
+    pub struct ResponseFuture<F, M> {
         #[pin]
         future: F,
-        headers: Vec<HeaderInsertionConfig<T>>,
+        headers: Vec<HeaderInsertionConfig<M>>,
     }
 }
 
@@ -275,8 +209,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::Body;
-    use http::{header, HeaderValue};
+    use crate::{
+        set_header::{BoxedMakeHeaderValue, MakeHeaderValue as _},
+        test_helpers::Body,
+    };
+    use http::{header, HeaderName, HeaderValue};
     use std::convert::Infallible;
     use tower::{service_fn, ServiceExt};
 


### PR DESCRIPTION
## Motivation

Fixes #676

Adds native support for inserting multiple header middleware per layer

## Solution

For better code organisation, the request.rs file, which handles the request, is now a module and split into two files. One for setting a single header and the other for multiple, while still maintaining the current API structure.

The functions handling setting headers take a dynamic variable that implements HeaderMetadataGenerator. The newly created HeaderMetadata and a tuple of (HeaderName, M), currently implemented in `M`, can be HeaderValue (A test case covers this). This also helps with maintainability.

It also includes tests

The PR also moved some reused code into the root module for easy access by both request and response headers
