### PR TITLE
Implement `Default` for `limit::ResponseBody`

### DIFF
--- a/tower-http/src/limit/body.rs
+++ b/tower-http/src/limit/body.rs
@@ -32,6 +32,17 @@ impl<B> ResponseBody<B> {
     }
 }
 
+impl<B> Default for ResponseBody<B>
+where
+    B: Default,
+{
+    fn default() -> Self {
+        Self {
+            inner: ResponseBodyInner::Body { body: B::default() },
+        }
+    }
+}
+
 pin_project! {
     #[project = BodyProj]
     enum ResponseBodyInner<B> {


### PR DESCRIPTION
Implement `Default` for `limit::ResponseBody`

Summary:
This adds a `Default` implementation to `limit::ResponseBody` if the wrapped
body also implements `Default`

This allows combining services as follows:

```
ServiceBudiler::new()
  .layer(CorsLayer::very_permissive())
  .layer(RequestBodyLimitLayer::new(limit))
```
