### PR TITLE
feat!: remove no-op tokio and async-compression features

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Changed
+
+- The implicit `tokio` and `async-compression` features are removed (BREAKING).
+  These were kept as no-op features in 0.6.x for backwards compatibility after
+  the switch to `dep:` syntax in [#642]. Downstream crates that activate
+  `tower-http/tokio` or `tower-http/async-compression` should remove those
+  feature entries; the underlying dependencies are still pulled in transitively
+  by the features that need them (e.g. `compression-gzip`, `fs`, `timeout`).
+  ([#628])
+
+[#628]: https://github.com/tower-rs/tower-http/pull/628
+[#642]: https://github.com/tower-rs/tower-http/pull/642
+
 # 0.6.11
 
 ## Added

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -120,11 +120,6 @@ decompression-full = ["decompression-br", "decompression-deflate", "decompressio
 decompression-gzip = ["dep:async-compression", "async-compression?/gzip", "futures-core", "dep:http-body", "dep:http-body-util", "tokio-util", "dep:tokio"]
 decompression-zstd = ["dep:async-compression", "async-compression?/zstd", "futures-core", "dep:http-body", "dep:http-body-util", "tokio-util", "dep:tokio"]
 
-# FIXME: rip this out come 0.7.0.
-# ref: https://github.com/tower-rs/tower-http/pull/666#issuecomment-4382555061
-tokio = []
-async-compression = []
-
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Closes #628, companion to #642.

I'm prepping a breaking release so sweeping this up now.

## Motivation

In 0.6.x, the switch to `dep:` syntax for `tokio` and `async-compression` accidentally removed the implicit features that downstream crates may have been activating. #667 restored them as empty no-op features with a FIXME to remove in 0.7.0.

## Solution

Remove the no-op `tokio = []` and `async-compression = []` features. This is a breaking change: downstream crates activating `tower-http/tokio` or `tower-http/async-compression` will get a compile error and should simply remove those feature entries.
