### PR TITLE
feat(body): add UnsyncBoxBody::new constructor and From<ResponseBody>

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#628]: https://github.com/tower-rs/tower-http/pull/628
 [#642]: https://github.com/tower-rs/tower-http/pull/642
 
+## Added
+
+- `body`: `UnsyncBoxBody::new()` constructor and `From<ServeFileSystemResponseBody>` conversion to avoid double-boxing when combining `ServeDir` responses with other body types ([#537])
+
 # 0.6.11
 
 ## Added

--- a/tower-http/src/body.rs
+++ b/tower-http/src/body.rs
@@ -105,8 +105,29 @@ where
 
 impl<D, E> UnsyncBoxBody<D, E> {
     #[allow(dead_code)]
-    pub(crate) fn new(inner: http_body_util::combinators::UnsyncBoxBody<D, E>) -> Self {
+    pub(crate) fn from_inner(inner: http_body_util::combinators::UnsyncBoxBody<D, E>) -> Self {
         Self { inner }
+    }
+}
+
+impl<D, E> UnsyncBoxBody<D, E>
+where
+    D: Buf + 'static,
+{
+    /// Create a new `UnsyncBoxBody` by erasing the type of the given body.
+    ///
+    /// This is useful when you need a common body type across different response branches
+    /// without double-boxing bodies that are already boxed (like [`ServeDir`]'s response body,
+    /// which has a [`From`] impl for zero-cost conversion).
+    ///
+    /// [`ServeDir`]: crate::services::ServeDir
+    pub fn new<B>(body: B) -> Self
+    where
+        B: Body<Data = D, Error = E> + Send + 'static,
+    {
+        Self {
+            inner: http_body_util::combinators::UnsyncBoxBody::new(body),
+        }
     }
 }
 

--- a/tower-http/src/catch_panic.rs
+++ b/tower-http/src/catch_panic.rs
@@ -267,11 +267,9 @@ where
                 future,
                 panic_handler,
             } => match ready!(future.poll(cx)) {
-                Ok(Ok(res)) => {
-                    Poll::Ready(Ok(res.map(|body| {
-                        UnsyncBoxBody::new(body.map_err(Into::into).boxed_unsync())
-                    })))
-                }
+                Ok(Ok(res)) => Poll::Ready(Ok(res.map(|body| {
+                    UnsyncBoxBody::from_inner(body.map_err(Into::into).boxed_unsync())
+                }))),
                 Ok(Err(svc_err)) => Poll::Ready(Err(svc_err)),
                 Err(panic_err) => Poll::Ready(Ok(response_for_panic(
                     panic_handler
@@ -295,7 +293,7 @@ where
 {
     panic_handler
         .response_for_panic(err)
-        .map(|body| UnsyncBoxBody::new(body.map_err(Into::into).boxed_unsync()))
+        .map(|body| UnsyncBoxBody::from_inner(body.map_err(Into::into).boxed_unsync()))
 }
 
 /// Trait for creating responses from panics.

--- a/tower-http/src/decompression/request/future.rs
+++ b/tower-http/src/decompression/request/future.rs
@@ -76,7 +76,7 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.project().kind.project() {
             StateProj::Inner { fut } => fut.poll(cx).map_ok(|res| {
-                res.map(|body| UnsyncBoxBody::new(body.map_err(Into::into).boxed_unsync()))
+                res.map(|body| UnsyncBoxBody::from_inner(body.map_err(Into::into).boxed_unsync()))
             }),
             StateProj::Unsupported { accept } => {
                 let res = Response::builder()
@@ -87,7 +87,7 @@ where
                             .unwrap_or(HeaderValue::from_static("identity")),
                     )
                     .status(StatusCode::UNSUPPORTED_MEDIA_TYPE)
-                    .body(UnsyncBoxBody::new(
+                    .body(UnsyncBoxBody::from_inner(
                         Empty::new().map_err(Into::into).boxed_unsync(),
                     ))
                     .unwrap();

--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -208,7 +208,7 @@ where
         .map_ok(|response| {
             response
                 .map(|body| {
-                    UnsyncBoxBody::new(
+                    UnsyncBoxBody::from_inner(
                         body.map_err(|err| match err.into().downcast::<io::Error>() {
                             Ok(err) => *err,
                             Err(err) => io::Error::new(io::ErrorKind::Other, err),
@@ -258,7 +258,7 @@ fn build_response(output: FileOpened) -> Response<ResponseBody> {
                 } else {
                     let body = if let Some(file) = maybe_file {
                         let range_size = range.end() - range.start() + 1;
-                        ResponseBody::new(UnsyncBoxBody::new(
+                        ResponseBody::new(UnsyncBoxBody::from_inner(
                             AsyncReadBody::with_capacity_limited(
                                 file,
                                 output.chunk_size,
@@ -306,7 +306,7 @@ fn build_response(output: FileOpened) -> Response<ResponseBody> {
         // Not a range request
         None => {
             let body = if let Some(file) = maybe_file {
-                ResponseBody::new(UnsyncBoxBody::new(
+                ResponseBody::new(UnsyncBoxBody::from_inner(
                     AsyncReadBody::with_capacity(file, output.chunk_size).boxed_unsync(),
                 ))
             } else {
@@ -323,10 +323,10 @@ fn build_response(output: FileOpened) -> Response<ResponseBody> {
 
 fn body_from_bytes(bytes: Bytes) -> ResponseBody {
     let body = Full::from(bytes).map_err(|err| match err {}).boxed_unsync();
-    ResponseBody::new(UnsyncBoxBody::new(body))
+    ResponseBody::new(UnsyncBoxBody::from_inner(body))
 }
 
 fn empty_body() -> ResponseBody {
     let body = Empty::new().map_err(|err| match err {}).boxed_unsync();
-    ResponseBody::new(UnsyncBoxBody::new(body))
+    ResponseBody::new(UnsyncBoxBody::from_inner(body))
 }

--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -415,7 +415,7 @@ where
                     #[cfg(feature = "tracing")]
                     tracing::error!(error = %_err, "Failed to read file");
 
-                    let body = ResponseBody::new(UnsyncBoxBody::new(
+                    let body = ResponseBody::new(UnsyncBoxBody::from_inner(
                         Empty::new().map_err(|err| match err {}).boxed_unsync(),
                     ));
                     Response::builder()
@@ -611,6 +611,12 @@ opaque_body! {
     /// Response body for [`ServeDir`] and [`ServeFile`][super::ServeFile].
     #[derive(Default)]
     pub type ResponseBody = UnsyncBoxBody<Bytes, io::Error>;
+}
+
+impl From<ResponseBody> for UnsyncBoxBody<Bytes, io::Error> {
+    fn from(body: ResponseBody) -> Self {
+        body.inner
+    }
 }
 
 /// The default fallback service used with [`ServeDir`].

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -1131,3 +1131,33 @@ async fn identity_encoding_does_not_strip_extension_head_request() {
 
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 }
+
+#[tokio::test]
+async fn unsync_box_body_new() {
+    use crate::body::UnsyncBoxBody;
+    use http_body_util::Full;
+
+    let body: UnsyncBoxBody<Bytes, Infallible> =
+        UnsyncBoxBody::new(Full::new(Bytes::from("hello")));
+    let collected = body.collect().await.unwrap().to_bytes();
+    assert_eq!(collected, "hello");
+}
+
+#[tokio::test]
+async fn response_body_into_unsync_box_body() {
+    use crate::body::UnsyncBoxBody;
+
+    let svc = ServeDir::new("..");
+    let req = Request::builder()
+        .uri("/README.md")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    // Convert the ServeDir response body into UnsyncBoxBody without double-boxing
+    let boxed: UnsyncBoxBody<Bytes, std::io::Error> = res.into_body().into();
+    let collected = boxed.collect().await.unwrap().to_bytes();
+
+    let expected = std::fs::read_to_string("../README.md").unwrap();
+    assert_eq!(collected, expected);
+}


### PR DESCRIPTION
Supersedes: #537

## Motivation

Users who return responses with different body types (e.g., from multiple match branches) need to box them into a common type. When one branch uses `ServeDir`/`ServeFile`, the response body is already internally boxed, but wrapping it in `UnsyncBoxBody::new()` causes double-boxing (double allocation + double indirection).

PR #537 by @nanoqsh added `From` impls directly on `http_body_util::combinators::UnsyncBoxBody`, but tower-http has a policy of not leaking `http_body_util` types in its public API.

## Solution

Expose tower-http's own `UnsyncBoxBody` wrapper with:

1. A public `new()` constructor that type-erases any `Body` impl (analogous to `http_body_util::combinators::UnsyncBoxBody::new`)
2. A `From<ServeFileSystemResponseBody>` impl that unwraps the already-boxed inner body without re-boxing

Usage becomes:

```rust
// Before (double-boxing):
.map(|res| res.map(UnsyncBoxBody::new))

// After (zero-cost conversion from ServeDir response):
.map(|res| res.map(UnsyncBoxBody::from))
```

The internal `pub(crate) fn new()` that previously accepted the raw `http_body_util` inner type was renamed to `from_inner()` to avoid ambiguity with the new public constructor.

Tests verify that `UnsyncBoxBody::new` correctly boxes a body and that the `From<ResponseBody>` conversion produces a valid, readable body from a real `ServeDir` response. The conversion is zero-cost by construction (it just moves the inner field), so correctness is primarily a compile-time guarantee.
