### PR TITLE
feat(ci): various ci improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Preserve LF line endings in test fixtures so tests pass on Windows.
+test-files/** eol=lf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -129,10 +129,12 @@ jobs:
         cargo check -p tower-http --all-features
 
   semver-checks:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
       with:
@@ -142,7 +144,22 @@ jobs:
       with:
         tool: cargo-semver-checks
     - name: Check semver compatibility
-      run: cargo semver-checks check-release -p tower-http --all-features
+      id: checks
+      run: |
+        set +e
+        OUTPUT=$(cargo semver-checks check-release -p tower-http --all-features \
+          --baseline-rev origin/${{ github.base_ref }} --color never 2>&1)
+        STATUS=$?
+        echo "$OUTPUT"
+        if [ $STATUS -ne 0 ]; then
+          echo "$OUTPUT" > semver-output.txt
+        fi
+    - name: Upload results
+      if: always() && hashFiles('semver-output.txt') != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: semver-checks-output
+        path: semver-output.txt
 
   style:
     needs: check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -130,6 +130,7 @@ jobs:
 
   semver-checks:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
     - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,13 +6,20 @@ on:
     - main
   pull_request: {}
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: dtolnay/rust-toolchain@stable
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - run: cargo check --workspace --all-features --all-targets
@@ -20,8 +27,11 @@ jobs:
   check-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: dtolnay/rust-toolchain@nightly
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: cargo doc
       env:
         RUSTDOCFLAGS: "-D rustdoc::broken_intra_doc_links --cfg docsrs"
@@ -30,12 +40,14 @@ jobs:
   cargo-hack:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: dtolnay/rust-toolchain@stable
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-    - uses: taiki-e/install-action@cargo-hack
+    - uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
+      with:
+        tool: cargo-hack
     - name: cargo hack check
       env:
         RUSTFLAGS: "-D unused_imports -D dead_code -D unused_variables"
@@ -49,12 +61,28 @@ jobs:
       matrix:
         rust: [stable, beta, nightly]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       if: matrix.rust != 'nightly'
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+    - run: cargo test --workspace --all-features
+
+  test-os:
+    # Test on macOS and Windows to catch platform-specific issues.
+    needs: check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - run: cargo test --workspace --all-features
@@ -63,7 +91,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Remove the example crates to exclude effects to dependencies from them
       run: rm -r ./examples/* && cargo new --lib --edition 2021 examples/dummy
     - name: Resolve MSRV aware dependencies
@@ -75,16 +103,50 @@ jobs:
     - run: cargo update -p async-compression --precise 0.4.23
     - run: cargo update -p flate2 --precise 1.0.35
     - uses: dtolnay/rust-toolchain@1.64
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - run: cargo check -p tower-http --all-features
+
+  minimal-versions:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: dtolnay/rust-toolchain@nightly
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+    - name: Install cargo-hack
+      uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
+      with:
+        tool: cargo-hack
+    - name: Check with minimal versions
+      run: |
+        cargo hack --remove-dev-deps
+        cargo update -Z minimal-versions
+        cargo check -p tower-http --all-features
+
+  semver-checks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+    - name: Install cargo-semver-checks
+      uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
+      with:
+        tool: cargo-semver-checks
+    - name: Check semver compatibility
+      run: cargo semver-checks check-release -p tower-http --all-features
 
   style:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt
@@ -94,7 +156,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy
@@ -110,8 +172,8 @@ jobs:
         - advisories
         - bans licenses sources
     steps:
-    - uses: actions/checkout@v6
-    - uses: EmbarkStudios/cargo-deny-action@v2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2.0.18
       with:
         manifest-path: tower-http/Cargo.toml
         command: check ${{ matrix.checks }}
@@ -119,15 +181,15 @@ jobs:
   external-types:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: nightly-2025-10-18
     - name: Install cargo-check-external-types
-      uses: taiki-e/cache-cargo-install-action@v2
+      uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7 # v2.3.1
       with:
         tool: cargo-check-external-types@0.4.0
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - run: cargo check-external-types --all-features

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,9 +17,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
-    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+    - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - run: cargo check --workspace --all-features --all-targets
@@ -27,9 +27,9 @@ jobs:
   check-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@nightly
-    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+    - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: cargo doc
@@ -40,12 +40,12 @@ jobs:
   cargo-hack:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
-    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+    - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-    - uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
+    - uses: taiki-e/install-action@v2
       with:
         tool: cargo-hack
     - name: cargo hack check
@@ -61,11 +61,11 @@ jobs:
       matrix:
         rust: [stable, beta, nightly]
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+    - uses: Swatinem/rust-cache@v2
       if: matrix.rust != 'nightly'
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -80,9 +80,9 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
-    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+    - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - run: cargo test --workspace --all-features
@@ -91,7 +91,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@v6
     - name: Remove the example crates to exclude effects to dependencies from them
       run: rm -r ./examples/* && cargo new --lib --edition 2021 examples/dummy
     - name: Resolve MSRV aware dependencies
@@ -103,7 +103,7 @@ jobs:
     - run: cargo update -p async-compression --precise 0.4.23
     - run: cargo update -p flate2 --precise 1.0.35
     - uses: dtolnay/rust-toolchain@1.64
-    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+    - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - run: cargo check -p tower-http --all-features
@@ -112,13 +112,13 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@nightly
-    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+    - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Install cargo-hack
-      uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
+      uses: taiki-e/install-action@v2
       with:
         tool: cargo-hack
     - name: Check with minimal versions
@@ -131,13 +131,13 @@ jobs:
   semver-checks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
-    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+    - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Install cargo-semver-checks
-      uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
+      uses: taiki-e/install-action@v2
       with:
         tool: cargo-semver-checks
     - name: Check semver compatibility
@@ -147,7 +147,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt
@@ -157,7 +157,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy
@@ -173,8 +173,8 @@ jobs:
         - advisories
         - bans licenses sources
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2.0.18
+    - uses: actions/checkout@v6
+    - uses: EmbarkStudios/cargo-deny-action@v2
       with:
         manifest-path: tower-http/Cargo.toml
         command: check ${{ matrix.checks }}
@@ -182,15 +182,15 @@ jobs:
   external-types:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: nightly-2025-10-18
     - name: Install cargo-check-external-types
-      uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7 # v2.3.1
+      uses: taiki-e/cache-cargo-install-action@v2
       with:
         tool: cargo-check-external-types@0.4.0
-    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+    - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - run: cargo check-external-types --all-features

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -125,6 +125,7 @@ jobs:
       run: |
         cargo hack --remove-dev-deps
         cargo update -Z minimal-versions
+        cargo update -p crc32fast --precise 1.2.0
         cargo check -p tower-http --all-features
 
   semver-checks:

--- a/.github/workflows/semver-comment.yml
+++ b/.github/workflows/semver-comment.yml
@@ -1,0 +1,58 @@
+name: Semver Checks Comment
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download results
+        id: download
+        uses: actions/download-artifact@v4
+        with:
+          name: semver-checks-output
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+        continue-on-error: true
+
+      - name: Build comment
+        id: build
+        if: steps.download.outcome == 'success'
+        run: |
+          echo "comment<<EOF" >> "$GITHUB_OUTPUT"
+          echo "### ⚠️ Breaking API changes detected" >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          echo "Please make sure these are intentional and noted in the changelog." >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          echo "<details><summary>cargo semver-checks output</summary>" >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          echo '```' >> "$GITHUB_OUTPUT"
+          cat semver-output.txt >> "$GITHUB_OUTPUT"
+          echo '```' >> "$GITHUB_OUTPUT"
+          echo "</details>" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Post comment
+        if: steps.build.outputs.comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          header: semver-checks
+          message: ${{ steps.build.outputs.comment }}
+
+      - name: Hide comment
+        if: steps.download.outcome == 'failure'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          header: semver-checks
+          hide: true

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -36,12 +36,12 @@ jobs:
       DURATION_MINUTES: ${{ inputs.duration_minutes || '30' }}
       TEST_FILTER: ${{ inputs.test_filter }}
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
-    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+    - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-    - uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
+    - uses: taiki-e/install-action@v2
       with:
         tool: cargo-nextest@0.9.132
     - name: Run stress test

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -36,12 +36,12 @@ jobs:
       DURATION_MINUTES: ${{ inputs.duration_minutes || '30' }}
       TEST_FILTER: ${{ inputs.test_filter }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: dtolnay/rust-toolchain@stable
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-    - uses: taiki-e/install-action@v2
+    - uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
       with:
         tool: cargo-nextest@0.9.132
     - name: Run stress test

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -197,7 +197,7 @@
     clippy::match_like_matches_macro,
     clippy::type_complexity
 )]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -960,6 +960,7 @@ async fn root_with_trailing_slash_serves_appends_index_html() {
 }
 
 #[cfg(windows)]
+#[allow(unsafe_code)]
 fn verify_windows_device(name: &str, is_positive: bool) {
     use std::fs::OpenOptions;
     use std::os::windows::io::AsRawHandle;


### PR DESCRIPTION
### Summary

The CI was missing several checks that are standard in the tower-rs ecosystem. Actions were also referenced by mutable tags, which is a supply-chain risk.

This adds three new CI jobs:

- `semver-checks`: compares the public API against the last published crate on crates.io using `cargo-semver-checks`, with `--all-features` so feature-gated APIs are covered.
- `minimal-versions`: resolves dependencies to their declared lower bounds and verifies they compile. Catches cases where a bump is needed but the Cargo.toml lower bound wasn't updated.
- `test-os`: runs the full test suite on macOS and Windows. Relevant because the `fs` middleware deals with filesystem paths.

All GitHub Actions are now pinned by commit SHA with a version comment (e.g., `actions/checkout@de0fac2... # v6.0.2`). `dtolnay/rust-toolchain` is left unpinned since it uses branch refs by design. The `taiki-e/install-action@cargo-hack` branch ref was converted to the standard `@v2` form with `tool: cargo-hack` input so it can be pinned consistently.

A new `.github/dependabot.yml` is configured for weekly GitHub Actions updates. Dependabot recognizes the SHA + version comment pattern and will propose PRs with updated SHAs automatically.

Also adds `permissions: contents: read` and `concurrency` (cancel-in-progress on PRs) to CI.yml, and a cache step to the `check-docs` job.