### PR TITLE
Add configurable Backend trait for ServeDir

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,7 +102,7 @@ jobs:
     # Still better to maintain fewer manual version overrides though.
     - run: cargo update -p async-compression --precise 0.4.23
     - run: cargo update -p flate2 --precise 1.0.35
-    - uses: dtolnay/rust-toolchain@1.64
+    - uses: dtolnay/rust-toolchain@1.65
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The [examples] folder contains various examples of how to use Tower HTTP:
 
 ## Minimum supported Rust version
 
-tower-http's MSRV is 1.66.
+tower-http's MSRV is 1.65.
 
 ## Getting Help
 

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   feature entries; the underlying dependencies are still pulled in transitively
   by the features that need them (e.g. `compression-gzip`, `fs`, `timeout`).
   ([#628])
+- MSRV bumped from 1.64 to 1.65.
 
 [#215]: https://github.com/tower-rs/tower-http/issues/215
 [#628]: https://github.com/tower-rs/tower-http/pull/628
@@ -40,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 - `body`: `UnsyncBoxBody::new()` constructor and `From<ServeFileSystemResponseBody>` conversion to avoid double-boxing when combining `ServeDir` responses with other body types ([#537])
+- `fs`: Add `Backend` trait to make `ServeDir` work with non-filesystem sources. The default `TokioBackend` preserves existing behavior. Use `ServeDir::with_backend()` to plug in custom implementations.
 
 # 0.6.11
 

--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/tower-rs/tower-http"
 homepage = "https://github.com/tower-rs/tower-http"
 categories = ["asynchronous", "network-programming", "web-programming"]
 keywords = ["io", "async", "futures", "service", "http"]
-rust-version = "1.64"
+rust-version = "1.65"
 
 [dependencies]
 bitflags = "2.0.2"

--- a/tower-http/src/services/fs/mod.rs
+++ b/tower-http/src/services/fs/mod.rs
@@ -18,10 +18,15 @@ mod serve_file;
 pub use self::{
     serve_dir::{
         future::ResponseFuture as ServeFileSystemResponseFuture,
+        Backend,
         DefaultServeDirFallback,
+        File,
+        Metadata,
         // The response body and future are used for both ServeDir and ServeFile
         ResponseBody as ServeFileSystemResponseBody,
         ServeDir,
+        TokioBackend,
+        TokioFile,
     },
     serve_file::ServeFile,
 };

--- a/tower-http/src/services/fs/serve_dir/backend.rs
+++ b/tower-http/src/services/fs/serve_dir/backend.rs
@@ -29,7 +29,7 @@ pub trait Metadata: Send + 'static {
 ///
 /// Must support async reading and seeking (for HTTP range requests).
 /// In-memory backends can use [`std::io::Cursor`] to satisfy the `AsyncSeek` requirement.
-pub trait File: AsyncRead + AsyncSeek + Unpin + Send {
+pub trait File: AsyncRead + AsyncSeek + Unpin + Send + Sync {
     /// The metadata type returned by this file.
     type Metadata: Metadata;
 
@@ -65,8 +65,6 @@ pub trait Backend: Clone + Send + Sync + 'static {
     /// Retrieve metadata for the given path without opening the file.
     fn metadata(&self, path: PathBuf) -> Self::MetadataFuture;
 }
-
-// --- TokioBackend implementation ---
 
 /// Default [`Backend`] implementation using `tokio::fs`.
 #[derive(Clone, Debug, Default)]

--- a/tower-http/src/services/fs/serve_dir/backend.rs
+++ b/tower-http/src/services/fs/serve_dir/backend.rs
@@ -1,0 +1,142 @@
+//! Pluggable backend trait for [`ServeDir`](super::ServeDir).
+//!
+//! The [`Backend`] trait abstracts file system operations so that `ServeDir` can serve
+//! files from sources other than the local filesystem (e.g. rust-embed, include_dir, S3).
+
+use std::{future::Future, io, path::PathBuf, pin::Pin, time::SystemTime};
+use tokio::io::{AsyncRead, AsyncSeek};
+
+/// Trait for file metadata.
+///
+/// This is the information `ServeDir` needs about a file or directory without opening it.
+pub trait Metadata: Send + 'static {
+    /// Returns `true` if this metadata refers to a directory.
+    fn is_dir(&self) -> bool;
+
+    /// Returns the last modification time, if available.
+    fn modified(&self) -> io::Result<SystemTime>;
+
+    /// Returns the size of the file in bytes.
+    fn len(&self) -> u64;
+
+    /// Returns `true` if the file is empty (zero bytes).
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Trait for an opened file.
+///
+/// Must support async reading and seeking (for HTTP range requests).
+/// In-memory backends can use [`std::io::Cursor`] to satisfy the `AsyncSeek` requirement.
+pub trait File: AsyncRead + AsyncSeek + Unpin + Send {
+    /// The metadata type returned by this file.
+    type Metadata: Metadata;
+
+    /// Future returned by [`File::metadata`].
+    type MetadataFuture<'a>: Future<Output = io::Result<Self::Metadata>> + Send
+    where
+        Self: 'a;
+
+    /// Returns metadata for this opened file.
+    fn metadata(&self) -> Self::MetadataFuture<'_>;
+}
+
+/// Trait abstracting filesystem operations for [`ServeDir`](super::ServeDir).
+///
+/// Implement this trait to serve files from non-filesystem sources.
+/// The default implementation ([`TokioBackend`]) wraps `tokio::fs`.
+pub trait Backend: Clone + Send + Sync + 'static {
+    /// The file type returned by [`Backend::open`].
+    type File: File<Metadata = Self::Metadata>;
+
+    /// The metadata type returned by [`Backend::metadata`].
+    type Metadata: Metadata;
+
+    /// Future returned by [`Backend::open`].
+    type OpenFuture: Future<Output = io::Result<Self::File>> + Send;
+
+    /// Future returned by [`Backend::metadata`].
+    type MetadataFuture: Future<Output = io::Result<Self::Metadata>> + Send;
+
+    /// Open a file at the given path.
+    fn open(&self, path: PathBuf) -> Self::OpenFuture;
+
+    /// Retrieve metadata for the given path without opening the file.
+    fn metadata(&self, path: PathBuf) -> Self::MetadataFuture;
+}
+
+// --- TokioBackend implementation ---
+
+/// Default [`Backend`] implementation using `tokio::fs`.
+#[derive(Clone, Debug, Default)]
+pub struct TokioBackend;
+
+impl Backend for TokioBackend {
+    type File = TokioFile;
+    type Metadata = std::fs::Metadata;
+    type OpenFuture = Pin<Box<dyn Future<Output = io::Result<TokioFile>> + Send>>;
+    type MetadataFuture = Pin<Box<dyn Future<Output = io::Result<std::fs::Metadata>> + Send>>;
+
+    fn open(&self, path: PathBuf) -> Self::OpenFuture {
+        Box::pin(async move {
+            let file = tokio::fs::File::open(&path).await?;
+            Ok(TokioFile(file))
+        })
+    }
+
+    fn metadata(&self, path: PathBuf) -> Self::MetadataFuture {
+        Box::pin(async move { tokio::fs::metadata(&path).await })
+    }
+}
+
+/// Wrapper around [`tokio::fs::File`] implementing the [`File`] trait.
+#[derive(Debug)]
+pub struct TokioFile(tokio::fs::File);
+
+impl AsyncRead for TokioFile {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        Pin::new(&mut self.0).poll_read(cx, buf)
+    }
+}
+
+impl AsyncSeek for TokioFile {
+    fn start_seek(mut self: Pin<&mut Self>, position: io::SeekFrom) -> io::Result<()> {
+        Pin::new(&mut self.0).start_seek(position)
+    }
+
+    fn poll_complete(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<io::Result<u64>> {
+        Pin::new(&mut self.0).poll_complete(cx)
+    }
+}
+
+impl File for TokioFile {
+    type Metadata = std::fs::Metadata;
+    type MetadataFuture<'a> =
+        Pin<Box<dyn Future<Output = io::Result<std::fs::Metadata>> + Send + 'a>>;
+
+    fn metadata(&self) -> Self::MetadataFuture<'_> {
+        Box::pin(async move { self.0.metadata().await })
+    }
+}
+
+impl Metadata for std::fs::Metadata {
+    fn is_dir(&self) -> bool {
+        self.is_dir()
+    }
+
+    fn modified(&self) -> io::Result<SystemTime> {
+        self.modified()
+    }
+
+    fn len(&self) -> u64 {
+        self.len()
+    }
+}

--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -239,8 +239,8 @@ where
 
 fn build_response(output: FileOpened) -> Response<ResponseBody> {
     let (maybe_file, size) = match output.extent {
-        FileRequestExtent::Full(file, meta) => (Some(file), meta.len()),
-        FileRequestExtent::Head(meta) => (None, meta.len()),
+        FileRequestExtent::Full(file, size) => (Some(file), size),
+        FileRequestExtent::Head(size) => (None, size),
     };
 
     let mut builder = Response::builder()

--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -444,21 +444,17 @@ impl<F, B: Backend> ServeDir<F, B> {
         )
         .collect();
 
-        let open_file_config = open_file::OpenFileConfig {
+        let open_file_future = Box::pin(open_file::open_file(open_file::OpenFileRequest {
             variant: self.variant.clone(),
             redirect_path_prefix,
-            buf_chunk_size,
-            precompression_configured,
-            backend: self.backend.clone(),
-        };
-
-        let open_file_future = Box::pin(open_file::open_file(
-            open_file_config,
             path_to_file,
             req,
             negotiated_encodings,
             range_header,
-        ));
+            buf_chunk_size,
+            precompression_configured,
+            backend: self.backend.clone(),
+        }));
 
         ResponseFuture::open_file_future(open_file_future, fallback_and_request)
     }

--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -17,12 +17,15 @@ use std::{
 };
 use tower_service::Service;
 
+mod backend;
 pub(crate) mod future;
 mod headers;
 mod open_file;
 
 #[cfg(test)]
 mod tests;
+
+pub use self::backend::{Backend, File, Metadata, TokioBackend, TokioFile};
 
 // default capacity 64KiB
 const DEFAULT_CAPACITY: usize = 65536;
@@ -50,7 +53,7 @@ const DEFAULT_CAPACITY: usize = 65536;
 /// let service = ServeDir::new("assets");
 /// ```
 #[derive(Clone, Debug)]
-pub struct ServeDir<F = DefaultServeDirFallback> {
+pub struct ServeDir<F = DefaultServeDirFallback, B = TokioBackend> {
     base: PathBuf,
     redirect_path_prefix: String,
     buf_chunk_size: usize,
@@ -60,6 +63,7 @@ pub struct ServeDir<F = DefaultServeDirFallback> {
     variant: ServeVariant,
     fallback: Option<F>,
     call_fallback_on_method_not_allowed: bool,
+    backend: B,
 }
 
 impl ServeDir<DefaultServeDirFallback> {
@@ -82,6 +86,7 @@ impl ServeDir<DefaultServeDirFallback> {
             },
             fallback: None,
             call_fallback_on_method_not_allowed: false,
+            backend: TokioBackend,
         }
     }
 
@@ -97,11 +102,39 @@ impl ServeDir<DefaultServeDirFallback> {
             variant: ServeVariant::SingleFile { mime },
             fallback: None,
             call_fallback_on_method_not_allowed: false,
+            backend: TokioBackend,
         }
     }
 }
 
-impl<F> ServeDir<F> {
+impl<B: Backend> ServeDir<DefaultServeDirFallback, B> {
+    /// Create a new [`ServeDir`] with a custom [`Backend`].
+    ///
+    /// This allows serving files from sources other than the local filesystem.
+    pub fn with_backend<P>(path: P, backend: B) -> Self
+    where
+        P: AsRef<Path>,
+    {
+        let mut base = PathBuf::from(".");
+        base.push(path.as_ref());
+
+        ServeDir {
+            base,
+            buf_chunk_size: DEFAULT_CAPACITY,
+            precompressed_variants: None,
+            variant: ServeVariant::Directory {
+                append_index_html_on_directories: true,
+                html_as_default_extension: false,
+            },
+            fallback: None,
+            call_fallback_on_method_not_allowed: false,
+            redirect_path_prefix: String::new(),
+            backend,
+        }
+    }
+}
+
+impl<F, B: Backend> ServeDir<F, B> {
     /// If the requested path is a directory append `index.html`.
     ///
     /// This is useful for static sites.
@@ -243,7 +276,7 @@ impl<F> ServeDir<F> {
     ///     // respond with `not_found.html` for missing files
     ///     .fallback(ServeFile::new("assets/not_found.html"));
     /// ```
-    pub fn fallback<F2>(self, new_fallback: F2) -> ServeDir<F2> {
+    pub fn fallback<F2>(self, new_fallback: F2) -> ServeDir<F2, B> {
         ServeDir {
             redirect_path_prefix: self.redirect_path_prefix,
             base: self.base,
@@ -252,6 +285,7 @@ impl<F> ServeDir<F> {
             variant: self.variant,
             fallback: Some(new_fallback),
             call_fallback_on_method_not_allowed: self.call_fallback_on_method_not_allowed,
+            backend: self.backend,
         }
     }
 
@@ -272,7 +306,7 @@ impl<F> ServeDir<F> {
     /// ```
     ///
     /// Setups like this are often found in single page applications.
-    pub fn not_found_service<F2>(self, new_fallback: F2) -> ServeDir<SetStatus<F2>> {
+    pub fn not_found_service<F2>(self, new_fallback: F2) -> ServeDir<SetStatus<F2>, B> {
         self.fallback(SetStatus::new(new_fallback, StatusCode::NOT_FOUND))
     }
 
@@ -415,6 +449,7 @@ impl<F> ServeDir<F> {
             redirect_path_prefix,
             buf_chunk_size,
             precompression_configured,
+            backend: self.backend.clone(),
         };
 
         let open_file_future = Box::pin(open_file::open_file(
@@ -429,12 +464,13 @@ impl<F> ServeDir<F> {
     }
 }
 
-impl<ReqBody, F, FResBody> Service<Request<ReqBody>> for ServeDir<F>
+impl<ReqBody, F, FResBody, B> Service<Request<ReqBody>> for ServeDir<F, B>
 where
     F: Service<Request<ReqBody>, Response = Response<FResBody>, Error = Infallible> + Clone,
     F::Future: Send + 'static,
     FResBody: http_body::Body<Data = Bytes> + Send + 'static,
     FResBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    B: Backend,
 {
     type Response = Response<ResponseBody>;
     type Error = Infallible;

--- a/tower-http/src/services/fs/serve_dir/open_file.rs
+++ b/tower-http/src/services/fs/serve_dir/open_file.rs
@@ -47,29 +47,32 @@ pub(super) enum FileRequestExtent {
     Head(u64),
 }
 
-pub(super) struct OpenFileConfig<B: Backend> {
+pub(super) struct OpenFileRequest<B> {
     pub(super) variant: ServeVariant,
     pub(super) redirect_path_prefix: String,
+    pub(super) path_to_file: PathBuf,
+    pub(super) req: Request<Empty<Bytes>>,
+    pub(super) negotiated_encodings: Vec<(Encoding, QValue)>,
+    pub(super) range_header: Option<String>,
     pub(super) buf_chunk_size: usize,
     pub(super) precompression_configured: bool,
     pub(super) backend: B,
 }
 
 pub(super) async fn open_file<B: Backend>(
-    config: OpenFileConfig<B>,
-    mut path_to_file: PathBuf,
-    req: Request<Empty<Bytes>>,
-    negotiated_encodings: Vec<(Encoding, QValue)>,
-    range_header: Option<String>,
+    request: OpenFileRequest<B>,
 ) -> io::Result<OpenFileOutput> {
-    let OpenFileConfig {
+    let OpenFileRequest {
         variant,
         redirect_path_prefix,
+        mut path_to_file,
+        req,
+        negotiated_encodings,
+        range_header,
         buf_chunk_size,
         precompression_configured,
         backend,
-    } = config;
-
+    } = request;
     let preconditions = Preconditions {
         if_match: req
             .headers()

--- a/tower-http/src/services/fs/serve_dir/open_file.rs
+++ b/tower-http/src/services/fs/serve_dir/open_file.rs
@@ -1,4 +1,5 @@
 use super::{
+    backend::{Backend, File as _, Metadata as _},
     headers::{ETag, IfMatch, IfModifiedSince, IfNoneMatch, IfUnmodifiedSince, LastModified},
     ServeVariant,
 };
@@ -9,12 +10,11 @@ use http_body_util::Empty;
 use http_range_header::RangeUnsatisfiableError;
 use std::{
     ffi::OsStr,
-    fs::Metadata,
     io::{self, ErrorKind, SeekFrom},
     ops::RangeInclusive,
     path::{Path, PathBuf},
 };
-use tokio::{fs::File, io::AsyncSeekExt};
+use tokio::io::AsyncSeekExt;
 
 pub(super) enum OpenFileOutput {
     FileOpened(Box<FileOpened>),
@@ -43,19 +43,20 @@ pub(super) struct FileOpened {
 }
 
 pub(super) enum FileRequestExtent {
-    Full(File, Metadata),
-    Head(Metadata),
+    Full(Box<dyn tokio::io::AsyncRead + Unpin + Send>, u64),
+    Head(u64),
 }
 
-pub(super) struct OpenFileConfig {
+pub(super) struct OpenFileConfig<B: Backend> {
     pub(super) variant: ServeVariant,
     pub(super) redirect_path_prefix: String,
     pub(super) buf_chunk_size: usize,
     pub(super) precompression_configured: bool,
+    pub(super) backend: B,
 }
 
-pub(super) async fn open_file(
-    config: OpenFileConfig,
+pub(super) async fn open_file<B: Backend>(
+    config: OpenFileConfig<B>,
     mut path_to_file: PathBuf,
     req: Request<Empty<Bytes>>,
     negotiated_encodings: Vec<(Encoding, QValue)>,
@@ -66,6 +67,7 @@ pub(super) async fn open_file(
         redirect_path_prefix,
         buf_chunk_size,
         precompression_configured,
+        backend,
     } = config;
 
     let preconditions = Preconditions {
@@ -101,6 +103,7 @@ pub(super) async fn open_file(
                 req.uri(),
                 append_index_html_on_directories,
                 html_as_default_extension,
+                &backend,
             )
             .await
             {
@@ -122,7 +125,7 @@ pub(super) async fn open_file(
         #[cfg(feature = "tracing")]
         let _path_str = path_to_file.display().to_string();
         let (meta, maybe_encoding) =
-            file_metadata_with_fallback(path_to_file, negotiated_encodings).await?;
+            file_metadata_with_fallback(&backend, path_to_file, negotiated_encodings).await?;
 
         let last_modified = meta.modified().ok().map(LastModified::from);
         let etag = meta
@@ -145,7 +148,7 @@ pub(super) async fn open_file(
         let maybe_range = try_parse_range(range_header.as_deref(), meta.len());
 
         Ok(OpenFileOutput::FileOpened(Box::new(FileOpened {
-            extent: FileRequestExtent::Head(meta),
+            extent: FileRequestExtent::Head(meta.len()),
             chunk_size: buf_chunk_size,
             mime_header_value: mime,
             maybe_encoding,
@@ -158,7 +161,7 @@ pub(super) async fn open_file(
         #[cfg(feature = "tracing")]
         let _path_str = path_to_file.display().to_string();
         let (mut file, maybe_encoding) =
-            match open_file_with_fallback(path_to_file, negotiated_encodings).await {
+            match open_file_with_fallback(&backend, path_to_file, negotiated_encodings).await {
                 Ok(result) => result,
 
                 Err(err) if is_invalid_filename_error(&err) => {
@@ -187,7 +190,8 @@ pub(super) async fn open_file(
             return Ok(output);
         }
 
-        let maybe_range = try_parse_range(range_header.as_deref(), meta.len());
+        let size = meta.len();
+        let maybe_range = try_parse_range(range_header.as_deref(), size);
         if let Some(Ok(ranges)) = maybe_range.as_ref() {
             // if there is any other amount of ranges than 1 we'll return an
             // unsatisfiable later as there isn't yet support for multipart ranges
@@ -197,7 +201,7 @@ pub(super) async fn open_file(
         }
 
         Ok(OpenFileOutput::FileOpened(Box::new(FileOpened {
-            extent: FileRequestExtent::Full(file, meta),
+            extent: FileRequestExtent::Full(Box::new(file), size),
             chunk_size: buf_chunk_size,
             mime_header_value: mime,
             maybe_encoding,
@@ -336,14 +340,15 @@ fn preferred_encoding(
 // Attempts to open the file with any of the possible negotiated_encodings in the
 // preferred order. If none of the negotiated_encodings have a corresponding precompressed
 // file the uncompressed file is used as a fallback.
-async fn open_file_with_fallback(
+async fn open_file_with_fallback<B: Backend>(
+    backend: &B,
     mut path: PathBuf,
     mut negotiated_encoding: Vec<(Encoding, QValue)>,
-) -> io::Result<(File, Option<Encoding>)> {
+) -> io::Result<(B::File, Option<Encoding>)> {
     let (file, encoding) = loop {
         // Get the preferred encoding among the negotiated ones.
         let encoding = preferred_encoding(&mut path, &negotiated_encoding);
-        match (File::open(&path).await, encoding) {
+        match (backend.open(path.clone()).await, encoding) {
             (Ok(file), maybe_encoding) => break (file, maybe_encoding),
             (Err(err), Some(encoding))
                 if err.kind() == io::ErrorKind::NotFound && encoding != Encoding::Identity =>
@@ -364,15 +369,16 @@ async fn open_file_with_fallback(
 // Attempts to get the file metadata with any of the possible negotiated_encodings in the
 // preferred order. If none of the negotiated_encodings have a corresponding precompressed
 // file the uncompressed file is used as a fallback.
-async fn file_metadata_with_fallback(
+async fn file_metadata_with_fallback<B: Backend>(
+    backend: &B,
     mut path: PathBuf,
     mut negotiated_encoding: Vec<(Encoding, QValue)>,
-) -> io::Result<(Metadata, Option<Encoding>)> {
-    let (file, encoding) = loop {
+) -> io::Result<(B::Metadata, Option<Encoding>)> {
+    let (meta, encoding) = loop {
         // Get the preferred encoding among the negotiated ones.
         let encoding = preferred_encoding(&mut path, &negotiated_encoding);
-        match (tokio::fs::metadata(&path).await, encoding) {
-            (Ok(file), maybe_encoding) => break (file, maybe_encoding),
+        match (backend.metadata(path.clone()).await, encoding) {
+            (Ok(meta), maybe_encoding) => break (meta, maybe_encoding),
             (Err(err), Some(encoding))
                 if err.kind() == io::ErrorKind::NotFound && encoding != Encoding::Identity =>
             {
@@ -386,19 +392,20 @@ async fn file_metadata_with_fallback(
             (Err(err), _) => return Err(err),
         }
     };
-    Ok((file, encoding))
+    Ok((meta, encoding))
 }
 
-async fn maybe_redirect_or_append_path(
+async fn maybe_redirect_or_append_path<B: Backend>(
     redirect_path_prefix: &str,
     path_to_file: &mut PathBuf,
     uri: &Uri,
     append_index_html_on_directories: bool,
     html_as_default_extension: bool,
+    backend: &B,
 ) -> Option<OpenFileOutput> {
     let uri_path = uri.path();
 
-    let is_directory = is_dir(path_to_file).await;
+    let is_directory = is_dir(path_to_file, backend).await;
 
     if uri_path.ends_with('/') && uri_path != "/" && is_directory != Some(true) {
         return Some(OpenFileOutput::FileNotFound);
@@ -441,8 +448,9 @@ fn try_parse_range(
     })
 }
 
-async fn is_dir(path_to_file: &Path) -> Option<bool> {
-    tokio::fs::metadata(path_to_file)
+async fn is_dir<B: Backend>(path_to_file: &Path, backend: &B) -> Option<bool> {
+    backend
+        .metadata(path_to_file.to_owned())
         .await
         .ok()
         .map(|meta_data| meta_data.is_dir())

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -1684,3 +1684,254 @@ async fn if_modified_since_304_includes_etag() {
         &last_modified
     );
 }
+
+mod memory_backend {
+    use super::*;
+    use crate::services::fs::serve_dir::backend::{Backend, File, Metadata};
+    use std::{
+        collections::HashMap, future::Future, io, path::PathBuf, pin::Pin, sync::Arc,
+        time::SystemTime,
+    };
+    use tokio::io::{AsyncRead, AsyncSeek};
+
+    /// In-memory file metadata.
+    #[derive(Clone)]
+    struct MemMetadata {
+        is_dir: bool,
+        len: u64,
+        modified: SystemTime,
+    }
+
+    impl Metadata for MemMetadata {
+        fn is_dir(&self) -> bool {
+            self.is_dir
+        }
+
+        fn modified(&self) -> io::Result<SystemTime> {
+            Ok(self.modified)
+        }
+
+        fn len(&self) -> u64 {
+            self.len
+        }
+    }
+
+    /// In-memory file backed by a Cursor.
+    struct MemFile {
+        cursor: std::io::Cursor<Vec<u8>>,
+        meta: MemMetadata,
+    }
+
+    impl AsyncRead for MemFile {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<io::Result<()>> {
+            Pin::new(&mut self.cursor).poll_read(cx, buf)
+        }
+    }
+
+    impl AsyncSeek for MemFile {
+        fn start_seek(mut self: Pin<&mut Self>, position: io::SeekFrom) -> io::Result<()> {
+            Pin::new(&mut self.cursor).start_seek(position)
+        }
+
+        fn poll_complete(
+            mut self: Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<io::Result<u64>> {
+            Pin::new(&mut self.cursor).poll_complete(cx)
+        }
+    }
+
+    impl File for MemFile {
+        type Metadata = MemMetadata;
+        type MetadataFuture<'a> = std::future::Ready<io::Result<MemMetadata>>;
+
+        fn metadata(&self) -> Self::MetadataFuture<'_> {
+            std::future::ready(Ok(self.meta.clone()))
+        }
+    }
+
+    /// In-memory backend storing files in a HashMap.
+    #[derive(Clone)]
+    struct MemBackend {
+        files: Arc<HashMap<PathBuf, Vec<u8>>>,
+        dirs: Arc<Vec<PathBuf>>,
+    }
+
+    impl MemBackend {
+        fn new() -> Self {
+            Self {
+                files: Arc::new(HashMap::new()),
+                dirs: Arc::new(Vec::new()),
+            }
+        }
+
+        fn with_file(mut self, path: impl Into<PathBuf>, content: impl Into<Vec<u8>>) -> Self {
+            Arc::get_mut(&mut self.files)
+                .unwrap()
+                .insert(path.into(), content.into());
+            self
+        }
+
+        fn with_dir(mut self, path: impl Into<PathBuf>) -> Self {
+            Arc::get_mut(&mut self.dirs).unwrap().push(path.into());
+            self
+        }
+    }
+
+    impl Backend for MemBackend {
+        type File = MemFile;
+        type Metadata = MemMetadata;
+        type OpenFuture = Pin<Box<dyn Future<Output = io::Result<MemFile>> + Send>>;
+        type MetadataFuture = Pin<Box<dyn Future<Output = io::Result<MemMetadata>> + Send>>;
+
+        fn open(&self, path: PathBuf) -> Self::OpenFuture {
+            let files = self.files.clone();
+            Box::pin(async move {
+                match files.get(&path) {
+                    Some(data) => Ok(MemFile {
+                        meta: MemMetadata {
+                            is_dir: false,
+                            len: data.len() as u64,
+                            modified: SystemTime::UNIX_EPOCH,
+                        },
+                        cursor: std::io::Cursor::new(data.clone()),
+                    }),
+                    None => Err(io::Error::new(io::ErrorKind::NotFound, "not found")),
+                }
+            })
+        }
+
+        fn metadata(&self, path: PathBuf) -> Self::MetadataFuture {
+            let files = self.files.clone();
+            let dirs = self.dirs.clone();
+            Box::pin(async move {
+                if dirs.contains(&path) {
+                    return Ok(MemMetadata {
+                        is_dir: true,
+                        len: 0,
+                        modified: SystemTime::UNIX_EPOCH,
+                    });
+                }
+                match files.get(&path) {
+                    Some(data) => Ok(MemMetadata {
+                        is_dir: false,
+                        len: data.len() as u64,
+                        modified: SystemTime::UNIX_EPOCH,
+                    }),
+                    None => Err(io::Error::new(io::ErrorKind::NotFound, "not found")),
+                }
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn serve_file_from_memory() {
+        let backend = MemBackend::new().with_file("./assets/hello.txt", "Hello, world!");
+
+        let svc = ServeDir::with_backend("assets", backend);
+
+        let req = Request::builder()
+            .uri("/hello.txt")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.headers()["content-type"], "text/plain");
+
+        let body = body_into_text(res.into_body()).await;
+        assert_eq!(body, "Hello, world!");
+    }
+
+    #[tokio::test]
+    async fn not_found_from_memory() {
+        let backend = MemBackend::new();
+
+        let svc = ServeDir::with_backend("assets", backend);
+
+        let req = Request::builder()
+            .uri("/missing.txt")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn head_request_from_memory() {
+        let backend = MemBackend::new().with_file("./assets/hello.txt", "Hello, world!");
+
+        let svc = ServeDir::with_backend("assets", backend);
+
+        let req = Request::builder()
+            .method(Method::HEAD)
+            .uri("/hello.txt")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.headers()["content-length"], "13");
+
+        // HEAD should have empty body
+        let body = body_into_text(res.into_body()).await;
+        assert!(body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn range_request_from_memory() {
+        let backend = MemBackend::new().with_file("./assets/hello.txt", "Hello, world!");
+
+        let svc = ServeDir::with_backend("assets", backend);
+
+        let req = Request::builder()
+            .uri("/hello.txt")
+            .header("range", "bytes=0-4")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::PARTIAL_CONTENT);
+        assert_eq!(res.headers()["content-range"], "bytes 0-4/13");
+
+        let body = body_into_text(res.into_body()).await;
+        assert_eq!(body, "Hello");
+    }
+
+    #[tokio::test]
+    async fn directory_redirect_from_memory() {
+        let backend = MemBackend::new()
+            .with_dir("./assets/sub")
+            .with_file("./assets/sub/index.html", "<h1>Index</h1>");
+
+        let svc = ServeDir::with_backend("assets", backend);
+
+        // Request without trailing slash should redirect
+        let req = Request::builder().uri("/sub").body(Body::empty()).unwrap();
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::TEMPORARY_REDIRECT);
+        assert_eq!(res.headers()["location"], "/sub/");
+    }
+
+    #[tokio::test]
+    async fn directory_serves_index_html_from_memory() {
+        let backend = MemBackend::new()
+            .with_dir("./assets/sub")
+            .with_file("./assets/sub/index.html", "<h1>Index</h1>");
+
+        let svc = ServeDir::with_backend("assets", backend);
+
+        let req = Request::builder().uri("/sub/").body(Body::empty()).unwrap();
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = body_into_text(res.into_body()).await;
+        assert_eq!(body, "<h1>Index</h1>");
+    }
+}


### PR DESCRIPTION
Builds on #313 (draft by @davidpdrsn, dormant since Dec 2022). Closes #309.

### Summary

`ServeDir` is hardcoded to `tokio::fs`. This adds a `Backend` trait so it can serve from other sources (rust-embed, include_dir, S3, etc.).

`ServeDir<F, B>` gains a second generic defaulting to `TokioBackend`, so existing code compiles unchanged. A new `ServeDir::with_backend(path, backend)` constructor accepts custom implementations.

The trait surface is `open(PathBuf) -> File` and `metadata(PathBuf) -> Metadata`. ServeDir still owns compression fallback, range handling, trailing slash logic, and index.html appending. Backends just map paths to files.

Divergences from the #313 draft:

- Methods take `PathBuf` rather than `AsRef<Path>`. Since the returned futures must be `'static`, every implementation would clone anyway. Owning the path makes that cost explicit and avoids a hidden allocation.
- GATs are stable now but only used on `File::MetadataFuture<'a>` (where borrowing from self is needed). `Backend` futures are `'static` so GATs would add complexity with no benefit.
- No new feature flag. The trait is small and ships under the existing `fs` feature.

MSRV bumped from 1.64 to 1.65 (GATs require 1.65). This will go out in a breaking release since we are pre-msrv-aware-resolver.

### Testing

- Existing `ServeDir` and `ServeFile` test suites pass unchanged against `TokioBackend`.
- New tests with a mock in-memory backend exercise the full request lifecycle: GET, HEAD, range requests, directory handling, and missing paths.
- Verified pre-compressed file fallback works through a custom backend (ServeDir probes suffixed paths like `.br`/`.gz`/`.zst` via `open()`).
