### PR TITLE
Fix compression dropping gRPC status trailers

### DIFF
--- a/tower-http/src/compression/mod.rs
+++ b/tower-http/src/compression/mod.rs
@@ -94,6 +94,7 @@ mod tests {
     use super::*;
     use crate::test_helpers::{Body, WithTrailers};
     use async_compression::tokio::write::{BrotliDecoder, BrotliEncoder};
+    use bytes::Bytes;
     use flate2::read::GzDecoder;
     use http::header::{
         ACCEPT_ENCODING, ACCEPT_RANGES, CONTENT_ENCODING, CONTENT_RANGE, CONTENT_TYPE, RANGE,
@@ -106,7 +107,7 @@ mod tests {
     use std::sync::{Arc, RwLock};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio_util::io::StreamReader;
-    use tower::{service_fn, Service, ServiceExt};
+    use tower::{service_fn, BoxError, Service, ServiceExt};
 
     // Compression filter allows every other request to be compressed
     #[derive(Clone)]
@@ -520,6 +521,88 @@ mod tests {
         assert!(!headers.contains_key(ACCEPT_RANGES));
         assert_eq!(headers[CONTENT_ENCODING], "gzip");
         assert_eq!(decompressed, "Hello, World!");
+    }
+
+    #[tokio::test]
+    async fn trailers_with_empty_body() {
+        let svc = service_fn(|_req: Request<Body>| async {
+            let mut trailers = HeaderMap::new();
+            trailers.insert("grpc-status", "0".parse().unwrap());
+            trailers.insert("grpc-message", "OK".parse().unwrap());
+            let body = Body::empty().with_trailers(trailers);
+            Ok::<_, Infallible>(Response::builder().body(body).unwrap())
+        });
+        let mut svc = Compression::new(svc).compress_when(Always);
+
+        let req = Request::builder()
+            .header("accept-encoding", "gzip")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.ready().await.unwrap().call(req).await.unwrap();
+
+        let collected = res.into_body().collect().await.unwrap();
+        let trailers = collected.trailers().cloned().unwrap();
+        assert_eq!(trailers["grpc-status"], "0");
+        assert_eq!(trailers["grpc-message"], "OK");
+    }
+
+    #[tokio::test]
+    async fn trailers_with_streamed_body() {
+        // Simulate a gRPC-like streamed response: multiple data frames followed by trailers
+        let svc = service_fn(|_req: Request<Body>| async {
+            let stream = futures_util::stream::iter(vec![
+                Ok::<_, BoxError>(Bytes::from("chunk1")),
+                Ok(Bytes::from("chunk2")),
+                Ok(Bytes::from("chunk3")),
+            ]);
+            let mut trailers = HeaderMap::new();
+            trailers.insert("grpc-status", "0".parse().unwrap());
+            let body = Body::from_stream(stream).with_trailers(trailers);
+            Ok::<_, Infallible>(Response::builder().body(body).unwrap())
+        });
+        let mut svc = Compression::new(svc).compress_when(Always);
+
+        let req = Request::builder()
+            .header("accept-encoding", "gzip")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.ready().await.unwrap().call(req).await.unwrap();
+
+        let collected = res.into_body().collect().await.unwrap();
+        let trailers = collected.trailers().cloned().unwrap();
+        let compressed_data = collected.to_bytes();
+
+        let mut decoder = GzDecoder::new(&compressed_data[..]);
+        let mut decompressed = String::new();
+        decoder.read_to_string(&mut decompressed).unwrap();
+
+        assert_eq!(decompressed, "chunk1chunk2chunk3");
+        assert_eq!(trailers["grpc-status"], "0");
+    }
+
+    #[tokio::test]
+    async fn trailers_with_grpc_web_content_type() {
+        let svc = service_fn(|_req: Request<Body>| async {
+            let mut trailers = HeaderMap::new();
+            trailers.insert("grpc-status", "0".parse().unwrap());
+            let body = Body::from("a".repeat((SizeAbove::DEFAULT_MIN_SIZE * 2) as usize))
+                .with_trailers(trailers);
+            let mut res = Response::new(body);
+            res.headers_mut()
+                .insert(CONTENT_TYPE, "application/grpc-web+proto".parse().unwrap());
+            Ok::<_, Infallible>(res)
+        });
+        let mut svc = Compression::new(svc).compress_when(Always);
+
+        let req = Request::builder()
+            .header("accept-encoding", "gzip")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.ready().await.unwrap().call(req).await.unwrap();
+
+        let collected = res.into_body().collect().await.unwrap();
+        let trailers = collected.trailers().cloned().unwrap();
+        assert_eq!(trailers["grpc-status"], "0");
     }
 
     #[tokio::test]

--- a/tower-http/src/compression_utils.rs
+++ b/tower-http/src/compression_utils.rs
@@ -238,19 +238,9 @@ where
         // poll any remaining frames, such as trailers
         let body = M::get_pin_mut(this.read).get_pin_mut().get_pin_mut();
         match ready!(body.poll_frame(cx)) {
-            Some(Ok(frame)) if frame.is_trailers() => Poll::Ready(Some(Ok(
+            Some(Ok(frame)) => Poll::Ready(Some(Ok(
                 frame.map_data(|mut data| data.copy_to_bytes(data.remaining()))
             ))),
-            Some(Ok(frame)) => {
-                if let Ok(bytes) = frame.into_data() {
-                    if bytes.has_remaining() {
-                        return Poll::Ready(Some(Err(
-                            "there are extra bytes after body has been decompressed".into(),
-                        )));
-                    }
-                }
-                Poll::Ready(None)
-            }
             Some(Err(err)) => Poll::Ready(Some(Err(err.into()))),
             None => Poll::Ready(None),
         }


### PR DESCRIPTION
Closes #546

## Motivation

When `CompressionLayer` is applied to a gRPC (or grpc-web) service, response trailers containing `grpc-status` and `grpc-message` can be dropped. The client receives an empty trailers frame and errors with "server closed the stream without sending trailers." This became more impactful after #408 enabled compression for `application/grpc-web` responses.

## Solution

The root cause is a regression in the `WrapBody::poll_frame` trailer-forwarding logic introduced by #618 . After the compression encoder finishes, the code polls the inner body for remaining frames (trailers). The regression changed this section to only forward frames passing `is_trailers()`, returning `None` for any other frame type. This could terminate the body early before trailers were delivered.

The fix simplifies the post-compression section to forward all frames from the inner body unconditionally, matching the original behavior from v0.6.2. This is safe because after the encoder returns EOF, any remaining frames from the inner body are either trailers or should be passed through to the caller regardless.

Added regression tests covering trailer preservation through compression for empty bodies (common gRPC error responses), streamed multi-chunk bodies, and `application/grpc-web` content type responses.
