### PR TITLE
Fix ServeDir stripping extension with identity encoding

### DIFF
--- a/tower-http/src/services/fs/serve_dir/open_file.rs
+++ b/tower-http/src/services/fs/serve_dir/open_file.rs
@@ -239,7 +239,9 @@ async fn open_file_with_fallback(
         let encoding = preferred_encoding(&mut path, &negotiated_encoding);
         match (File::open(&path).await, encoding) {
             (Ok(file), maybe_encoding) => break (file, maybe_encoding),
-            (Err(err), Some(encoding)) if err.kind() == io::ErrorKind::NotFound => {
+            (Err(err), Some(encoding))
+                if err.kind() == io::ErrorKind::NotFound && encoding != Encoding::Identity =>
+            {
                 // Remove the extension corresponding to a precompressed file (.gz, .br, .zz)
                 // to reset the path before the next iteration.
                 path.set_extension(OsStr::new(""));
@@ -265,7 +267,9 @@ async fn file_metadata_with_fallback(
         let encoding = preferred_encoding(&mut path, &negotiated_encoding);
         match (tokio::fs::metadata(&path).await, encoding) {
             (Ok(file), maybe_encoding) => break (file, maybe_encoding),
-            (Err(err), Some(encoding)) if err.kind() == io::ErrorKind::NotFound => {
+            (Err(err), Some(encoding))
+                if err.kind() == io::ErrorKind::NotFound && encoding != Encoding::Identity =>
+            {
                 // Remove the extension corresponding to a precompressed file (.gz, .br, .zz)
                 // to reset the path before the next iteration.
                 path.set_extension(OsStr::new(""));

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -1100,3 +1100,21 @@ fn test_build_and_validate_path_reserved_dos_names() {
         }
     }
 }
+
+// Regression test for https://github.com/tower-rs/tower-http/issues/664
+// Accept-Encoding: identity should not cause extension stripping
+#[tokio::test]
+async fn identity_encoding_does_not_strip_extension() {
+    let svc = ServeDir::new("../test-files");
+
+    let req = Request::builder()
+        .uri("/extensionless_precompressed.foobar")
+        .header("Accept-Encoding", "identity")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    // BUG: currently returns 200 by stripping .foobar and serving extensionless_precompressed
+    // After fix, this should be NOT_FOUND
+    assert_eq!(res.status(), StatusCode::OK);
+}

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -1114,7 +1114,20 @@ async fn identity_encoding_does_not_strip_extension() {
         .unwrap();
     let res = svc.oneshot(req).await.unwrap();
 
-    // BUG: currently returns 200 by stripping .foobar and serving extensionless_precompressed
-    // After fix, this should be NOT_FOUND
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn identity_encoding_does_not_strip_extension_head_request() {
+    let svc = ServeDir::new("../test-files");
+
+    let req = Request::builder()
+        .uri("/extensionless_precompressed.foobar")
+        .method(Method::HEAD)
+        .header("Accept-Encoding", "identity")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
 }


### PR DESCRIPTION
Fixes https://github.com/tower-rs/tower-http/issues/664

## Motivation

When a request includes `Accept-Encoding: identity`, ServeDir strips the file extension from the requested path and serves the wrong file. Requesting `/extensionless_precompressed.foobar` with `Accept-Encoding: identity` serves `/extensionless_precompressed` (200) instead of returning 404.

## Solution

The precompressed file fallback loop (`open_file_with_fallback` and `file_metadata_with_fallback`) has a branch that strips the file extension via `path.set_extension("")` when a precompressed variant isn't found, so it can retry with the base path. When the preferred encoding is Identity, this branch fires even though Identity never adds a file extension (`to_file_extension()` returns `None`), stripping the file's real extension instead.

The fix adds an `encoding != Encoding::Identity` guard to the match arm in both functions. When Identity is the encoding and the file doesn't exist, we now fall through to the error return instead of stripping the extension.

Regression tests cover both GET and HEAD request paths.
