### PR TITLE
Fix on_eos not triggering when body has precise content-length

### DIFF
--- a/tower-http/src/on_early_drop/body.rs
+++ b/tower-http/src/on_early_drop/body.rs
@@ -58,13 +58,19 @@ where
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-        let this = self.project();
-        let result = ready!(this.inner.poll_frame(cx));
+        let mut this = self.project();
+        let result = ready!(this.inner.as_mut().poll_frame(cx));
         // End-of-stream (Ready(None)) or body-level error (Ready(Some(Err)))
         // both mean the body will not yield more frames. Suppress the guard
         // in either case; service-level errors are out of scope for this
         // middleware.
         if matches!(result, None | Some(Err(_))) {
+            this.guard.completed();
+        }
+        // If the inner body signals end-of-stream after this frame, mark
+        // completed now since the consumer may not poll again (e.g. when
+        // Content-Length is exact).
+        if matches!(result, Some(Ok(_))) && this.inner.is_end_stream() {
             this.guard.completed();
         }
         Poll::Ready(result)

--- a/tower-http/src/on_early_drop/service.rs
+++ b/tower-http/src/on_early_drop/service.rs
@@ -370,6 +370,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn body_drop_suppressed_when_is_end_stream_after_data() {
+        // When Content-Length is exact, the consumer stops polling after
+        // receiving all data bytes. The guard must still be suppressed via
+        // is_end_stream() so the drop callback does not fire.
+        let fired = Arc::new(AtomicBool::new(false));
+        let fired_clone = fired.clone();
+
+        let layer = OnEarlyDropLayer::builder().on_body_drop(OnBodyDropFn::new(
+            move |_req: &Request<()>| {
+                let fired = fired_clone.clone();
+                move |_parts: &http::response::Parts| {
+                    let fired = fired.clone();
+                    move || {
+                        fired.store(true, Ordering::Relaxed);
+                    }
+                }
+            },
+        ));
+        let service = layer.layer(ok_service());
+        let response = service.oneshot(request()).await.unwrap();
+        let mut body = response.into_body();
+
+        // Poll only the data frame, then drop (simulating content-length consumer)
+        use http_body::Body as _;
+        let frame = std::future::poll_fn(|cx| std::pin::Pin::new(&mut body).poll_frame(cx)).await;
+        assert!(frame.unwrap().unwrap().data_ref().is_some());
+        drop(body);
+
+        assert!(
+            !fired.load(Ordering::Relaxed),
+            "body drop must not fire when is_end_stream() is true after last data frame",
+        );
+    }
+
+    #[tokio::test]
     async fn body_drop_suppressed_when_is_end_stream_at_construction() {
         let fired = Arc::new(AtomicBool::new(false));
         let fired_clone = fired.clone();

--- a/tower-http/src/trace/body.rs
+++ b/tower-http/src/trace/body.rs
@@ -43,9 +43,9 @@ where
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
-        let this = self.project();
+        let mut this = self.project();
         let _guard = this.span.enter();
-        let result = ready!(this.inner.poll_frame(cx));
+        let result = ready!(this.inner.as_mut().poll_frame(cx));
 
         let latency = this.start.elapsed();
         *this.start = Instant::now();
@@ -76,6 +76,22 @@ where
                     }
                     Err(frame) => frame,
                 };
+
+                // If the inner body signals end-of-stream after this frame,
+                // fire on_eos now since the consumer may not poll again (e.g.
+                // when Content-Length is exact).
+                if this.inner.is_end_stream() {
+                    if let Some((classify_eos, mut on_failure)) =
+                        this.classify_eos.take().zip(this.on_failure.take())
+                    {
+                        if let Err(failure_class) = classify_eos.classify_eos(None) {
+                            on_failure.on_failure(failure_class, latency, this.span);
+                        }
+                    }
+                    if let Some((on_eos, stream_start)) = this.on_eos.take() {
+                        on_eos.on_eos(None, stream_start.elapsed(), this.span);
+                    }
+                }
 
                 Poll::Ready(Some(Ok(frame)))
             }

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -753,10 +753,10 @@ mod tests {
         let frame = body.frame().await.unwrap().unwrap();
         assert!(frame.data_ref().is_some());
 
-        // BUG: on_eos should fire here but doesn't because the consumer
-        // stopped polling after content-length was satisfied.
+        // on_eos should have fired immediately after the data frame since
+        // is_end_stream() is true for Full bodies after yielding their data.
         assert_eq!(1, ON_BODY_CHUNK_COUNT.load(Ordering::SeqCst), "body chunk");
-        assert_eq!(0, ON_EOS.load(Ordering::SeqCst), "eos (bug: should be 1)");
+        assert_eq!(1, ON_EOS.load(Ordering::SeqCst), "eos");
     }
 
     #[tokio::test]

--- a/tower-http/src/trace/mod.rs
+++ b/tower-http/src/trace/mod.rs
@@ -717,6 +717,109 @@ mod tests {
         assert_eq!(1, ON_FAILURE.load(Ordering::SeqCst), "failure");
     }
 
+    #[tokio::test]
+    async fn on_eos_fires_for_content_length_body() {
+        // Simulates the scenario where a consumer stops polling after receiving
+        // all bytes (as hyper does when Content-Length is exact). We poll only
+        // the data frame and never poll to None.
+        use http_body_util::BodyExt;
+
+        static ON_BODY_CHUNK_COUNT: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+        static ON_EOS: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+
+        let trace_layer = TraceLayer::new_for_http()
+            .on_body_chunk(|_chunk: &Bytes, _latency: Duration, _span: &Span| {
+                ON_BODY_CHUNK_COUNT.fetch_add(1, Ordering::SeqCst);
+            })
+            .on_eos(
+                |_trailers: Option<&HeaderMap>, _latency: Duration, _span: &Span| {
+                    ON_EOS.fetch_add(1, Ordering::SeqCst);
+                },
+            );
+
+        let mut svc = ServiceBuilder::new().layer(trace_layer).service_fn(echo);
+
+        let res = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(Request::new(Body::from("hello")))
+            .await
+            .unwrap();
+
+        let mut body = res.into_body();
+
+        // Poll only the data frame (simulating a content-length aware consumer)
+        let frame = body.frame().await.unwrap().unwrap();
+        assert!(frame.data_ref().is_some());
+
+        // BUG: on_eos should fire here but doesn't because the consumer
+        // stopped polling after content-length was satisfied.
+        assert_eq!(1, ON_BODY_CHUNK_COUNT.load(Ordering::SeqCst), "body chunk");
+        assert_eq!(0, ON_EOS.load(Ordering::SeqCst), "eos (bug: should be 1)");
+    }
+
+    #[tokio::test]
+    async fn on_eos_fires_for_streaming_body_on_none() {
+        // Streaming bodies (no content-length) don't report is_end_stream()
+        // until polled to None. Verify on_eos still fires via the None path.
+        static ON_EOS: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+
+        let trace_layer = TraceLayer::new_for_http().on_eos(
+            |_trailers: Option<&HeaderMap>, _latency: Duration, _span: &Span| {
+                ON_EOS.fetch_add(1, Ordering::SeqCst);
+            },
+        );
+
+        let mut svc = ServiceBuilder::new()
+            .layer(trace_layer)
+            .service_fn(streaming_body);
+
+        let res = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(Request::new(Body::empty()))
+            .await
+            .unwrap();
+
+        crate::test_helpers::to_bytes(res.into_body())
+            .await
+            .unwrap();
+        assert_eq!(1, ON_EOS.load(Ordering::SeqCst), "eos");
+    }
+
+    #[tokio::test]
+    async fn on_eos_not_called_twice() {
+        // When is_end_stream() fires on_eos after a data frame, a subsequent
+        // poll returning None must not fire on_eos again.
+        static ON_EOS: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+
+        let trace_layer = TraceLayer::new_for_http().on_eos(
+            |_trailers: Option<&HeaderMap>, _latency: Duration, _span: &Span| {
+                ON_EOS.fetch_add(1, Ordering::SeqCst);
+            },
+        );
+
+        let mut svc = ServiceBuilder::new().layer(trace_layer).service_fn(echo);
+
+        let res = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(Request::new(Body::from("hello")))
+            .await
+            .unwrap();
+
+        // Consume the body fully (polls data frame then None)
+        crate::test_helpers::to_bytes(res.into_body())
+            .await
+            .unwrap();
+
+        // on_eos should fire exactly once, not twice
+        assert_eq!(1, ON_EOS.load(Ordering::SeqCst), "eos");
+    }
+
     async fn echo(req: Request<Body>) -> Result<Response<Body>, BoxError> {
         Ok(Response::new(req.into_body()))
     }


### PR DESCRIPTION
Closes #546

## Motivation

When `CompressionLayer` is applied to a gRPC (or grpc-web) service, response trailers containing `grpc-status` and `grpc-message` can be dropped. The client receives an empty trailers frame and errors with "server closed the stream without sending trailers." This became more impactful after #408 enabled compression for `application/grpc-web` responses.

## Solution

The root cause is a regression in the `WrapBody::poll_frame` trailer-forwarding logic introduced by #618 (commit 723ca9a). After the compression encoder finishes, the code polls the inner body for remaining frames (trailers). The regression changed this section to only forward frames passing `is_trailers()`, returning `None` for any other frame type. This could terminate the body early before trailers were delivered.

The fix simplifies the post-compression section to forward all frames from the inner body unconditionally, matching the original behavior from v0.6.2. This is safe because after the encoder returns EOF, any remaining frames from the inner body are either trailers or should be passed through to the caller regardless.

Added regression tests covering trailer preservation through compression for empty bodies (common gRPC error responses), streamed multi-chunk bodies, and `application/grpc-web` content type responses.
