### PR TITLE
Add DeadlineBody for non-resetting body timeouts

### DIFF
--- a/tower-http/src/timeout/absolute_body.rs
+++ b/tower-http/src/timeout/absolute_body.rs
@@ -1,0 +1,270 @@
+use crate::BoxError;
+use http_body::Body;
+use pin_project_lite::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{ready, Context, Poll},
+    time::Duration,
+};
+use tokio::time::{sleep, Sleep};
+
+pin_project! {
+    /// Wrapper around a [`Body`] that enforces an absolute timeout on the entire body transfer.
+    ///
+    /// Unlike [`TimeoutBody`][super::TimeoutBody], which resets its deadline each time a frame is
+    /// received, `AbsoluteTimeoutBody` starts a single timer at construction and returns a
+    /// [`TimeoutError`][super::TimeoutError] if the body is not fully consumed before the deadline.
+    ///
+    /// This is useful for public endpoints where you want to cap the total time spent on a
+    /// request, regardless of how frequently data arrives.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use http::{Request, Response};
+    /// use bytes::Bytes;
+    /// use http_body_util::Full;
+    /// use std::time::Duration;
+    /// use tower::ServiceBuilder;
+    /// use tower_http::timeout::RequestBodyAbsoluteTimeoutLayer;
+    ///
+    /// async fn handle(_: Request<Full<Bytes>>) -> Result<Response<Full<Bytes>>, std::convert::Infallible> {
+    ///     // ...
+    ///     # todo!()
+    /// }
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let svc = ServiceBuilder::new()
+    ///     // Timeout bodies after 30 seconds total
+    ///     .layer(RequestBodyAbsoluteTimeoutLayer::new(Duration::from_secs(30)))
+    ///     .service_fn(handle);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub struct AbsoluteTimeoutBody<B> {
+        #[pin]
+        sleep: Sleep,
+        #[pin]
+        body: B,
+    }
+}
+
+impl<B> AbsoluteTimeoutBody<B> {
+    /// Creates a new [`AbsoluteTimeoutBody`].
+    ///
+    /// The timeout starts immediately. If the body is not fully consumed within `timeout`,
+    /// subsequent `poll_frame` calls will return a [`TimeoutError`][super::TimeoutError].
+    pub fn new(timeout: Duration, body: B) -> Self {
+        AbsoluteTimeoutBody {
+            sleep: sleep(timeout),
+            body,
+        }
+    }
+}
+
+impl<B> Body for AbsoluteTimeoutBody<B>
+where
+    B: Body,
+    B::Error: Into<BoxError>,
+{
+    type Data = B::Data;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.project();
+
+        // Error if the absolute timeout has expired.
+        if let Poll::Ready(()) = this.sleep.poll(cx) {
+            return Poll::Ready(Some(Err(Box::new(super::TimeoutError(())))));
+        }
+
+        // Check for body data.
+        let frame = ready!(this.body.poll_frame(cx));
+
+        Poll::Ready(frame.transpose().map_err(Into::into).transpose())
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.body.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.body.size_hint()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bytes::Bytes;
+    use http_body::Frame;
+    use http_body_util::BodyExt;
+    use pin_project_lite::pin_project;
+    use std::{error::Error, fmt::Display};
+    use tokio::time::sleep;
+
+    #[derive(Debug)]
+    struct MockError;
+
+    impl Error for MockError {}
+
+    impl Display for MockError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "mock error")
+        }
+    }
+
+    pin_project! {
+        /// A body that yields a frame after a delay.
+        struct MockBody {
+            #[pin]
+            sleep: Sleep,
+        }
+    }
+
+    impl Body for MockBody {
+        type Data = Bytes;
+        type Error = MockError;
+
+        fn poll_frame(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+            let this = self.project();
+            this.sleep
+                .poll(cx)
+                .map(|_| Some(Ok(Frame::data(vec![].into()))))
+        }
+    }
+
+    pin_project! {
+        /// A body that yields multiple frames with a delay between each.
+        struct MultiFrameBody {
+            frames_remaining: usize,
+            frame_interval: Duration,
+            #[pin]
+            sleep: Option<Sleep>,
+        }
+    }
+
+    impl Body for MultiFrameBody {
+        type Data = Bytes;
+        type Error = MockError;
+
+        fn poll_frame(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+            let mut this = self.project();
+
+            if *this.frames_remaining == 0 {
+                return Poll::Ready(None);
+            }
+
+            // Start the sleep if not active.
+            let sleep_pinned = if let Some(s) = this.sleep.as_mut().as_pin_mut() {
+                s
+            } else {
+                this.sleep.set(Some(sleep(*this.frame_interval)));
+                this.sleep.as_mut().as_pin_mut().unwrap()
+            };
+
+            ready!(sleep_pinned.poll(cx));
+            this.sleep.set(None);
+            *this.frames_remaining -= 1;
+
+            Poll::Ready(Some(Ok(Frame::data(Bytes::from("chunk")))))
+        }
+    }
+
+    #[tokio::test]
+    async fn body_completes_within_timeout() {
+        let mock_body = MockBody {
+            sleep: sleep(Duration::from_millis(50)),
+        };
+        let timeout_body = AbsoluteTimeoutBody::new(Duration::from_millis(200), mock_body);
+
+        assert!(timeout_body
+            .boxed()
+            .frame()
+            .await
+            .expect("no frame")
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn body_exceeds_timeout() {
+        let mock_body = MockBody {
+            sleep: sleep(Duration::from_millis(200)),
+        };
+        let timeout_body = AbsoluteTimeoutBody::new(Duration::from_millis(50), mock_body);
+
+        let result = timeout_body.boxed().frame().await.unwrap();
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .downcast_ref::<super::super::TimeoutError>()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn absolute_timeout_fires_despite_steady_frames() {
+        // Each frame arrives every 30ms (well within an idle timeout of 100ms),
+        // but total transfer takes 5 * 30ms = 150ms, exceeding the 100ms absolute timeout.
+        let body = MultiFrameBody {
+            frames_remaining: 5,
+            frame_interval: Duration::from_millis(30),
+            sleep: None,
+        };
+        let timeout_body = AbsoluteTimeoutBody::new(Duration::from_millis(100), body);
+
+        let mut boxed = timeout_body.boxed();
+        let mut got_error = false;
+
+        loop {
+            match boxed.frame().await {
+                Some(Ok(_)) => {}
+                Some(Err(_)) => {
+                    got_error = true;
+                    break;
+                }
+                None => break,
+            }
+        }
+
+        assert!(
+            got_error,
+            "expected timeout error before all frames arrived"
+        );
+    }
+
+    #[tokio::test]
+    async fn all_frames_arrive_within_absolute_timeout() {
+        // Each frame arrives every 20ms, total = 3 * 20ms = 60ms, within 200ms timeout.
+        let body = MultiFrameBody {
+            frames_remaining: 3,
+            frame_interval: Duration::from_millis(20),
+            sleep: None,
+        };
+        let timeout_body = AbsoluteTimeoutBody::new(Duration::from_millis(200), body);
+
+        let mut boxed = timeout_body.boxed();
+        let mut frame_count = 0;
+
+        loop {
+            match boxed.frame().await {
+                Some(Ok(_)) => frame_count += 1,
+                Some(Err(e)) => panic!("unexpected error: {}", e),
+                None => break,
+            }
+        }
+
+        assert_eq!(frame_count, 3);
+    }
+}

--- a/tower-http/src/timeout/body.rs
+++ b/tower-http/src/timeout/body.rs
@@ -106,7 +106,7 @@ where
     }
 }
 
-/// Error for [`TimeoutBody`] and [`AbsoluteTimeoutBody`][super::AbsoluteTimeoutBody].
+/// Error for [`TimeoutBody`] and [`DeadlineBody`][super::DeadlineBody].
 #[derive(Debug)]
 pub struct TimeoutError(pub(super) ());
 

--- a/tower-http/src/timeout/body.rs
+++ b/tower-http/src/timeout/body.rs
@@ -106,9 +106,9 @@ where
     }
 }
 
-/// Error for [`TimeoutBody`].
+/// Error for [`TimeoutBody`] and [`AbsoluteTimeoutBody`][super::AbsoluteTimeoutBody].
 #[derive(Debug)]
-pub struct TimeoutError(());
+pub struct TimeoutError(pub(super) ());
 
 impl std::error::Error for TimeoutError {}
 

--- a/tower-http/src/timeout/deadline_body.rs
+++ b/tower-http/src/timeout/deadline_body.rs
@@ -10,10 +10,10 @@ use std::{
 use tokio::time::{sleep, Sleep};
 
 pin_project! {
-    /// Wrapper around a [`Body`] that enforces an absolute timeout on the entire body transfer.
+    /// Wrapper around a [`Body`] that enforces a hard deadline on the entire body transfer.
     ///
     /// Unlike [`TimeoutBody`][super::TimeoutBody], which resets its deadline each time a frame is
-    /// received, `AbsoluteTimeoutBody` starts a single timer at construction and returns a
+    /// received, `DeadlineBody` starts a single timer at construction and returns a
     /// [`TimeoutError`][super::TimeoutError] if the body is not fully consumed before the deadline.
     ///
     /// This is useful for public endpoints where you want to cap the total time spent on a
@@ -27,7 +27,7 @@ pin_project! {
     /// use http_body_util::Full;
     /// use std::time::Duration;
     /// use tower::ServiceBuilder;
-    /// use tower_http::timeout::RequestBodyAbsoluteTimeoutLayer;
+    /// use tower_http::timeout::RequestBodyDeadlineLayer;
     ///
     /// async fn handle(_: Request<Full<Bytes>>) -> Result<Response<Full<Bytes>>, std::convert::Infallible> {
     ///     // ...
@@ -38,12 +38,12 @@ pin_project! {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let svc = ServiceBuilder::new()
     ///     // Timeout bodies after 30 seconds total
-    ///     .layer(RequestBodyAbsoluteTimeoutLayer::new(Duration::from_secs(30)))
+    ///     .layer(RequestBodyDeadlineLayer::new(Duration::from_secs(30)))
     ///     .service_fn(handle);
     /// # Ok(())
     /// # }
     /// ```
-    pub struct AbsoluteTimeoutBody<B> {
+    pub struct DeadlineBody<B> {
         #[pin]
         sleep: Sleep,
         #[pin]
@@ -51,20 +51,20 @@ pin_project! {
     }
 }
 
-impl<B> AbsoluteTimeoutBody<B> {
-    /// Creates a new [`AbsoluteTimeoutBody`].
+impl<B> DeadlineBody<B> {
+    /// Creates a new [`DeadlineBody`].
     ///
     /// The timeout starts immediately. If the body is not fully consumed within `timeout`,
     /// subsequent `poll_frame` calls will return a [`TimeoutError`][super::TimeoutError].
     pub fn new(timeout: Duration, body: B) -> Self {
-        AbsoluteTimeoutBody {
+        DeadlineBody {
             sleep: sleep(timeout),
             body,
         }
     }
 }
 
-impl<B> Body for AbsoluteTimeoutBody<B>
+impl<B> Body for DeadlineBody<B>
 where
     B: Body,
     B::Error: Into<BoxError>,
@@ -188,7 +188,7 @@ mod tests {
         let mock_body = MockBody {
             sleep: sleep(Duration::from_millis(50)),
         };
-        let timeout_body = AbsoluteTimeoutBody::new(Duration::from_millis(200), mock_body);
+        let timeout_body = DeadlineBody::new(Duration::from_millis(200), mock_body);
 
         assert!(timeout_body
             .boxed()
@@ -203,7 +203,7 @@ mod tests {
         let mock_body = MockBody {
             sleep: sleep(Duration::from_millis(200)),
         };
-        let timeout_body = AbsoluteTimeoutBody::new(Duration::from_millis(50), mock_body);
+        let timeout_body = DeadlineBody::new(Duration::from_millis(50), mock_body);
 
         let result = timeout_body.boxed().frame().await.unwrap();
         assert!(result.is_err());
@@ -214,15 +214,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn absolute_timeout_fires_despite_steady_frames() {
+    async fn deadline_fires_despite_steady_frames() {
         // Each frame arrives every 30ms (well within an idle timeout of 100ms),
-        // but total transfer takes 5 * 30ms = 150ms, exceeding the 100ms absolute timeout.
+        // but total transfer takes 5 * 30ms = 150ms, exceeding the 100ms deadline.
         let body = MultiFrameBody {
             frames_remaining: 5,
             frame_interval: Duration::from_millis(30),
             sleep: None,
         };
-        let timeout_body = AbsoluteTimeoutBody::new(Duration::from_millis(100), body);
+        let timeout_body = DeadlineBody::new(Duration::from_millis(100), body);
 
         let mut boxed = timeout_body.boxed();
         let mut got_error = false;
@@ -245,14 +245,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn all_frames_arrive_within_absolute_timeout() {
-        // Each frame arrives every 20ms, total = 3 * 20ms = 60ms, within 200ms timeout.
+    async fn all_frames_arrive_within_deadline() {
+        // Each frame arrives every 20ms, total = 3 * 20ms = 60ms, within 200ms deadline.
         let body = MultiFrameBody {
             frames_remaining: 3,
             frame_interval: Duration::from_millis(20),
             sleep: None,
         };
-        let timeout_body = AbsoluteTimeoutBody::new(Duration::from_millis(200), body);
+        let timeout_body = DeadlineBody::new(Duration::from_millis(200), body);
 
         let mut boxed = timeout_body.boxed();
         let mut frame_count = 0;

--- a/tower-http/src/timeout/deadline_body.rs
+++ b/tower-http/src/timeout/deadline_body.rs
@@ -16,8 +16,22 @@ pin_project! {
     /// received, `DeadlineBody` starts a single timer at construction and returns a
     /// [`TimeoutError`][super::TimeoutError] if the body is not fully consumed before the deadline.
     ///
-    /// This is useful for public endpoints where you want to cap the total time spent on a
-    /// request, regardless of how frequently data arrives.
+    /// The deadline is **wall-clock time from construction**, not cumulative poll time. The
+    /// timer continues to count even if the consumer is not actively polling the body. If you
+    /// poll some frames, pause to do other work, and then resume, the elapsed pause time counts
+    /// toward the deadline.
+    ///
+    /// # When to use this
+    ///
+    /// This is primarily useful as middleware on public-facing endpoints where you want to bound
+    /// the total wall-clock time a single request can hold resources (task slots, memory for
+    /// buffering, etc.), regardless of how frequently data trickles in. A slow client sending
+    /// one byte per second will never trip [`TimeoutBody`][super::TimeoutBody]'s idle timeout,
+    /// but will correctly trip `DeadlineBody`.
+    ///
+    /// If you only need to detect stalled connections where no data flows for a period, use
+    /// [`TimeoutBody`][super::TimeoutBody] instead. The two can be stacked if you want both
+    /// an idle timeout and a hard deadline.
     ///
     /// # Example
     ///

--- a/tower-http/src/timeout/mod.rs
+++ b/tower-http/src/timeout/mod.rs
@@ -40,11 +40,14 @@
 //!
 //! [`Infallible`]: std::convert::Infallible
 
+mod absolute_body;
 mod body;
 mod service;
 
+pub use absolute_body::AbsoluteTimeoutBody;
 pub use body::{TimeoutBody, TimeoutError};
 pub use service::{
-    RequestBodyTimeout, RequestBodyTimeoutLayer, ResponseBodyTimeout, ResponseBodyTimeoutLayer,
-    Timeout, TimeoutLayer,
+    RequestBodyAbsoluteTimeout, RequestBodyAbsoluteTimeoutLayer, RequestBodyTimeout,
+    RequestBodyTimeoutLayer, ResponseBodyAbsoluteTimeout, ResponseBodyAbsoluteTimeoutLayer,
+    ResponseBodyTimeout, ResponseBodyTimeoutLayer, Timeout, TimeoutLayer,
 };

--- a/tower-http/src/timeout/mod.rs
+++ b/tower-http/src/timeout/mod.rs
@@ -13,6 +13,22 @@
 //! and the specified status code. That means if your service's error type is [`Infallible`], it will
 //! still be [`Infallible`] after applying this middleware.
 //!
+//! # Body timeouts
+//!
+//! Two body timeout wrappers are available for limiting how long a request or response body
+//! transfer can take:
+//!
+//! - [`TimeoutBody`] resets its deadline each time a frame is received. Use this to detect
+//!   idle connections where no data flows for a period of time.
+//! - [`AbsoluteTimeoutBody`] starts a single timer at construction and never resets it. Use
+//!   this to cap the total wall-clock time spent transferring a body, regardless of how
+//!   frequently data arrives.
+//!
+//! Both are applied via their corresponding layer types ([`RequestBodyTimeoutLayer`] /
+//! [`RequestBodyAbsoluteTimeoutLayer`] for request bodies, [`ResponseBodyTimeoutLayer`] /
+//! [`ResponseBodyAbsoluteTimeoutLayer`] for response bodies). They can be stacked if you
+//! want both an idle timeout and an absolute deadline.
+//!
 //! # Example
 //!
 //! ```

--- a/tower-http/src/timeout/mod.rs
+++ b/tower-http/src/timeout/mod.rs
@@ -20,13 +20,13 @@
 //!
 //! - [`TimeoutBody`] resets its deadline each time a frame is received. Use this to detect
 //!   idle connections where no data flows for a period of time.
-//! - [`AbsoluteTimeoutBody`] starts a single timer at construction and never resets it. Use
+//! - [`DeadlineBody`] starts a single timer at construction and never resets it. Use
 //!   this to cap the total wall-clock time spent transferring a body, regardless of how
 //!   frequently data arrives.
 //!
 //! Both are applied via their corresponding layer types ([`RequestBodyTimeoutLayer`] /
-//! [`RequestBodyAbsoluteTimeoutLayer`] for request bodies, [`ResponseBodyTimeoutLayer`] /
-//! [`ResponseBodyAbsoluteTimeoutLayer`] for response bodies). They can be stacked if you
+//! [`RequestBodyDeadlineLayer`] for request bodies, [`ResponseBodyTimeoutLayer`] /
+//! [`ResponseBodyDeadlineLayer`] for response bodies). They can be stacked if you
 //! want both an idle timeout and an absolute deadline.
 //!
 //! # Example
@@ -56,14 +56,14 @@
 //!
 //! [`Infallible`]: std::convert::Infallible
 
-mod absolute_body;
 mod body;
+mod deadline_body;
 mod service;
 
-pub use absolute_body::AbsoluteTimeoutBody;
 pub use body::{TimeoutBody, TimeoutError};
+pub use deadline_body::DeadlineBody;
 pub use service::{
-    RequestBodyAbsoluteTimeout, RequestBodyAbsoluteTimeoutLayer, RequestBodyTimeout,
-    RequestBodyTimeoutLayer, ResponseBodyAbsoluteTimeout, ResponseBodyAbsoluteTimeoutLayer,
-    ResponseBodyTimeout, ResponseBodyTimeoutLayer, Timeout, TimeoutLayer,
+    RequestBodyDeadline, RequestBodyDeadlineLayer, RequestBodyTimeout, RequestBodyTimeoutLayer,
+    ResponseBodyDeadline, ResponseBodyDeadlineLayer, ResponseBodyTimeout, ResponseBodyTimeoutLayer,
+    Timeout, TimeoutLayer,
 };

--- a/tower-http/src/timeout/service.rs
+++ b/tower-http/src/timeout/service.rs
@@ -307,6 +307,9 @@ where
 }
 
 /// Applies an [`AbsoluteTimeoutBody`] to the request body.
+///
+/// Unlike [`RequestBodyTimeoutLayer`], which resets on each frame, this enforces a hard
+/// deadline on the entire body transfer.
 #[derive(Clone, Debug)]
 pub struct RequestBodyAbsoluteTimeoutLayer {
     timeout: Duration,
@@ -372,6 +375,9 @@ where
 }
 
 /// Applies an [`AbsoluteTimeoutBody`] to the response body.
+///
+/// Unlike [`ResponseBodyTimeoutLayer`], which resets on each frame, this enforces a hard
+/// deadline on the entire body transfer.
 #[derive(Clone)]
 pub struct ResponseBodyAbsoluteTimeoutLayer {
     timeout: Duration,

--- a/tower-http/src/timeout/service.rs
+++ b/tower-http/src/timeout/service.rs
@@ -1,3 +1,4 @@
+use crate::timeout::absolute_body::AbsoluteTimeoutBody;
 use crate::timeout::body::TimeoutBody;
 use http::{Request, Response, StatusCode};
 use pin_project_lite::pin_project;
@@ -302,6 +303,161 @@ where
         let this = self.project();
         let res = ready!(this.inner.poll(cx))?;
         Poll::Ready(Ok(res.map(|body| TimeoutBody::new(timeout, body))))
+    }
+}
+
+/// Applies an [`AbsoluteTimeoutBody`] to the request body.
+#[derive(Clone, Debug)]
+pub struct RequestBodyAbsoluteTimeoutLayer {
+    timeout: Duration,
+}
+
+impl RequestBodyAbsoluteTimeoutLayer {
+    /// Creates a new [`RequestBodyAbsoluteTimeoutLayer`].
+    pub fn new(timeout: Duration) -> Self {
+        Self { timeout }
+    }
+}
+
+impl<S> Layer<S> for RequestBodyAbsoluteTimeoutLayer {
+    type Service = RequestBodyAbsoluteTimeout<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RequestBodyAbsoluteTimeout::new(inner, self.timeout)
+    }
+}
+
+/// Applies an [`AbsoluteTimeoutBody`] to the request body.
+#[derive(Clone, Debug)]
+pub struct RequestBodyAbsoluteTimeout<S> {
+    inner: S,
+    timeout: Duration,
+}
+
+impl<S> RequestBodyAbsoluteTimeout<S> {
+    /// Creates a new [`RequestBodyAbsoluteTimeout`].
+    pub fn new(service: S, timeout: Duration) -> Self {
+        Self {
+            inner: service,
+            timeout,
+        }
+    }
+
+    /// Returns a new [`Layer`] that wraps services with a [`RequestBodyAbsoluteTimeoutLayer`] middleware.
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(timeout: Duration) -> RequestBodyAbsoluteTimeoutLayer {
+        RequestBodyAbsoluteTimeoutLayer::new(timeout)
+    }
+
+    define_inner_service_accessors!();
+}
+
+impl<S, ReqBody> Service<Request<ReqBody>> for RequestBodyAbsoluteTimeout<S>
+where
+    S: Service<Request<AbsoluteTimeoutBody<ReqBody>>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let req = req.map(|body| AbsoluteTimeoutBody::new(self.timeout, body));
+        self.inner.call(req)
+    }
+}
+
+/// Applies an [`AbsoluteTimeoutBody`] to the response body.
+#[derive(Clone)]
+pub struct ResponseBodyAbsoluteTimeoutLayer {
+    timeout: Duration,
+}
+
+impl ResponseBodyAbsoluteTimeoutLayer {
+    /// Creates a new [`ResponseBodyAbsoluteTimeoutLayer`].
+    pub fn new(timeout: Duration) -> Self {
+        Self { timeout }
+    }
+}
+
+impl<S> Layer<S> for ResponseBodyAbsoluteTimeoutLayer {
+    type Service = ResponseBodyAbsoluteTimeout<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ResponseBodyAbsoluteTimeout::new(inner, self.timeout)
+    }
+}
+
+/// Applies an [`AbsoluteTimeoutBody`] to the response body.
+#[derive(Clone)]
+pub struct ResponseBodyAbsoluteTimeout<S> {
+    inner: S,
+    timeout: Duration,
+}
+
+impl<S> ResponseBodyAbsoluteTimeout<S> {
+    /// Creates a new [`ResponseBodyAbsoluteTimeout`].
+    pub fn new(service: S, timeout: Duration) -> Self {
+        Self {
+            inner: service,
+            timeout,
+        }
+    }
+
+    /// Returns a new [`Layer`] that wraps services with a [`ResponseBodyAbsoluteTimeoutLayer`] middleware.
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(timeout: Duration) -> ResponseBodyAbsoluteTimeoutLayer {
+        ResponseBodyAbsoluteTimeoutLayer::new(timeout)
+    }
+
+    define_inner_service_accessors!();
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for ResponseBodyAbsoluteTimeout<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = Response<AbsoluteTimeoutBody<ResBody>>;
+    type Error = S::Error;
+    type Future = ResponseBodyAbsoluteTimeoutFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        ResponseBodyAbsoluteTimeoutFuture {
+            inner: self.inner.call(req),
+            timeout: self.timeout,
+        }
+    }
+}
+
+pin_project! {
+    /// Response future for [`ResponseBodyAbsoluteTimeout`].
+    pub struct ResponseBodyAbsoluteTimeoutFuture<Fut> {
+        #[pin]
+        inner: Fut,
+        timeout: Duration,
+    }
+}
+
+impl<Fut, ResBody, E> Future for ResponseBodyAbsoluteTimeoutFuture<Fut>
+where
+    Fut: Future<Output = Result<Response<ResBody>, E>>,
+{
+    type Output = Result<Response<AbsoluteTimeoutBody<ResBody>>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let timeout = self.timeout;
+        let this = self.project();
+        let res = ready!(this.inner.poll(cx))?;
+        Poll::Ready(Ok(res.map(|body| AbsoluteTimeoutBody::new(timeout, body))))
     }
 }
 

--- a/tower-http/src/timeout/service.rs
+++ b/tower-http/src/timeout/service.rs
@@ -1,5 +1,5 @@
-use crate::timeout::absolute_body::AbsoluteTimeoutBody;
 use crate::timeout::body::TimeoutBody;
+use crate::timeout::deadline_body::DeadlineBody;
 use http::{Request, Response, StatusCode};
 use pin_project_lite::pin_project;
 use std::{
@@ -306,39 +306,39 @@ where
     }
 }
 
-/// Applies an [`AbsoluteTimeoutBody`] to the request body.
+/// Applies a [`DeadlineBody`] to the request body.
 ///
 /// Unlike [`RequestBodyTimeoutLayer`], which resets on each frame, this enforces a hard
 /// deadline on the entire body transfer.
 #[derive(Clone, Debug)]
-pub struct RequestBodyAbsoluteTimeoutLayer {
+pub struct RequestBodyDeadlineLayer {
     timeout: Duration,
 }
 
-impl RequestBodyAbsoluteTimeoutLayer {
-    /// Creates a new [`RequestBodyAbsoluteTimeoutLayer`].
+impl RequestBodyDeadlineLayer {
+    /// Creates a new [`RequestBodyDeadlineLayer`].
     pub fn new(timeout: Duration) -> Self {
         Self { timeout }
     }
 }
 
-impl<S> Layer<S> for RequestBodyAbsoluteTimeoutLayer {
-    type Service = RequestBodyAbsoluteTimeout<S>;
+impl<S> Layer<S> for RequestBodyDeadlineLayer {
+    type Service = RequestBodyDeadline<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        RequestBodyAbsoluteTimeout::new(inner, self.timeout)
+        RequestBodyDeadline::new(inner, self.timeout)
     }
 }
 
-/// Applies an [`AbsoluteTimeoutBody`] to the request body.
+/// Applies a [`DeadlineBody`] to the request body.
 #[derive(Clone, Debug)]
-pub struct RequestBodyAbsoluteTimeout<S> {
+pub struct RequestBodyDeadline<S> {
     inner: S,
     timeout: Duration,
 }
 
-impl<S> RequestBodyAbsoluteTimeout<S> {
-    /// Creates a new [`RequestBodyAbsoluteTimeout`].
+impl<S> RequestBodyDeadline<S> {
+    /// Creates a new [`RequestBodyDeadline`].
     pub fn new(service: S, timeout: Duration) -> Self {
         Self {
             inner: service,
@@ -346,19 +346,19 @@ impl<S> RequestBodyAbsoluteTimeout<S> {
         }
     }
 
-    /// Returns a new [`Layer`] that wraps services with a [`RequestBodyAbsoluteTimeoutLayer`] middleware.
+    /// Returns a new [`Layer`] that wraps services with a [`RequestBodyDeadlineLayer`] middleware.
     ///
     /// [`Layer`]: tower_layer::Layer
-    pub fn layer(timeout: Duration) -> RequestBodyAbsoluteTimeoutLayer {
-        RequestBodyAbsoluteTimeoutLayer::new(timeout)
+    pub fn layer(timeout: Duration) -> RequestBodyDeadlineLayer {
+        RequestBodyDeadlineLayer::new(timeout)
     }
 
     define_inner_service_accessors!();
 }
 
-impl<S, ReqBody> Service<Request<ReqBody>> for RequestBodyAbsoluteTimeout<S>
+impl<S, ReqBody> Service<Request<ReqBody>> for RequestBodyDeadline<S>
 where
-    S: Service<Request<AbsoluteTimeoutBody<ReqBody>>>,
+    S: Service<Request<DeadlineBody<ReqBody>>>,
 {
     type Response = S::Response;
     type Error = S::Error;
@@ -369,44 +369,44 @@ where
     }
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        let req = req.map(|body| AbsoluteTimeoutBody::new(self.timeout, body));
+        let req = req.map(|body| DeadlineBody::new(self.timeout, body));
         self.inner.call(req)
     }
 }
 
-/// Applies an [`AbsoluteTimeoutBody`] to the response body.
+/// Applies a [`DeadlineBody`] to the response body.
 ///
 /// Unlike [`ResponseBodyTimeoutLayer`], which resets on each frame, this enforces a hard
 /// deadline on the entire body transfer.
 #[derive(Clone)]
-pub struct ResponseBodyAbsoluteTimeoutLayer {
+pub struct ResponseBodyDeadlineLayer {
     timeout: Duration,
 }
 
-impl ResponseBodyAbsoluteTimeoutLayer {
-    /// Creates a new [`ResponseBodyAbsoluteTimeoutLayer`].
+impl ResponseBodyDeadlineLayer {
+    /// Creates a new [`ResponseBodyDeadlineLayer`].
     pub fn new(timeout: Duration) -> Self {
         Self { timeout }
     }
 }
 
-impl<S> Layer<S> for ResponseBodyAbsoluteTimeoutLayer {
-    type Service = ResponseBodyAbsoluteTimeout<S>;
+impl<S> Layer<S> for ResponseBodyDeadlineLayer {
+    type Service = ResponseBodyDeadline<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        ResponseBodyAbsoluteTimeout::new(inner, self.timeout)
+        ResponseBodyDeadline::new(inner, self.timeout)
     }
 }
 
-/// Applies an [`AbsoluteTimeoutBody`] to the response body.
+/// Applies a [`DeadlineBody`] to the response body.
 #[derive(Clone)]
-pub struct ResponseBodyAbsoluteTimeout<S> {
+pub struct ResponseBodyDeadline<S> {
     inner: S,
     timeout: Duration,
 }
 
-impl<S> ResponseBodyAbsoluteTimeout<S> {
-    /// Creates a new [`ResponseBodyAbsoluteTimeout`].
+impl<S> ResponseBodyDeadline<S> {
+    /// Creates a new [`ResponseBodyDeadline`].
     pub fn new(service: S, timeout: Duration) -> Self {
         Self {
             inner: service,
@@ -414,30 +414,30 @@ impl<S> ResponseBodyAbsoluteTimeout<S> {
         }
     }
 
-    /// Returns a new [`Layer`] that wraps services with a [`ResponseBodyAbsoluteTimeoutLayer`] middleware.
+    /// Returns a new [`Layer`] that wraps services with a [`ResponseBodyDeadlineLayer`] middleware.
     ///
     /// [`Layer`]: tower_layer::Layer
-    pub fn layer(timeout: Duration) -> ResponseBodyAbsoluteTimeoutLayer {
-        ResponseBodyAbsoluteTimeoutLayer::new(timeout)
+    pub fn layer(timeout: Duration) -> ResponseBodyDeadlineLayer {
+        ResponseBodyDeadlineLayer::new(timeout)
     }
 
     define_inner_service_accessors!();
 }
 
-impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for ResponseBodyAbsoluteTimeout<S>
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for ResponseBodyDeadline<S>
 where
     S: Service<Request<ReqBody>, Response = Response<ResBody>>,
 {
-    type Response = Response<AbsoluteTimeoutBody<ResBody>>;
+    type Response = Response<DeadlineBody<ResBody>>;
     type Error = S::Error;
-    type Future = ResponseBodyAbsoluteTimeoutFuture<S::Future>;
+    type Future = ResponseBodyDeadlineFuture<S::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        ResponseBodyAbsoluteTimeoutFuture {
+        ResponseBodyDeadlineFuture {
             inner: self.inner.call(req),
             timeout: self.timeout,
         }
@@ -445,25 +445,25 @@ where
 }
 
 pin_project! {
-    /// Response future for [`ResponseBodyAbsoluteTimeout`].
-    pub struct ResponseBodyAbsoluteTimeoutFuture<Fut> {
+    /// Response future for [`ResponseBodyDeadline`].
+    pub struct ResponseBodyDeadlineFuture<Fut> {
         #[pin]
         inner: Fut,
         timeout: Duration,
     }
 }
 
-impl<Fut, ResBody, E> Future for ResponseBodyAbsoluteTimeoutFuture<Fut>
+impl<Fut, ResBody, E> Future for ResponseBodyDeadlineFuture<Fut>
 where
     Fut: Future<Output = Result<Response<ResBody>, E>>,
 {
-    type Output = Result<Response<AbsoluteTimeoutBody<ResBody>>, E>;
+    type Output = Result<Response<DeadlineBody<ResBody>>, E>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let timeout = self.timeout;
         let this = self.project();
         let res = ready!(this.inner.poll(cx))?;
-        Poll::Ready(Ok(res.map(|body| AbsoluteTimeoutBody::new(timeout, body))))
+        Poll::Ready(Ok(res.map(|body| DeadlineBody::new(timeout, body))))
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/tower-rs/tower-http/issues/623

### Summary

Adds `AbsoluteTimeoutBody`, a body wrapper that enforces a hard deadline on the entire body transfer. Unlike `TimeoutBody` (which resets its timer each time a frame arrives), `AbsoluteTimeoutBody` starts a single `Sleep` at construction and never resets it. If the body isn't fully consumed before the deadline, `poll_frame` returns a `TimeoutError`.

This is useful for public endpoints where you want to cap total time spent on a request regardless of how frequently data trickles in. A slow client sending one byte per second would never trip `TimeoutBody`'s idle timeout, but will correctly trip `AbsoluteTimeoutBody`.

I went with a new standalone type rather than a config flag on `TimeoutBody`. This keeps the existing API unchanged and avoids branching in `TimeoutBody::poll_frame`. The corresponding `RequestBodyAbsoluteTimeout` and `ResponseBodyAbsoluteTimeout` service/layer types mirror the existing idle-timeout equivalents.

It's a bit verbose, but I think it's ok. Name bikeshedding is invited by reviewers.

Shares the existing `TimeoutError` type since the failure mode is the same: body data didn't arrive in time.

### Testing

Covers the two scenarios that distinguish this from `TimeoutBody`:
- Absolute timeout fires even when frames arrive steadily but total transfer exceeds the deadline
- Body completes successfully when all frames arrive within the absolute deadline

Also includes basic single-frame happy/error path tests, and verifies the error downcasts to `TimeoutError`.
