### PR TITLE
Add ETag support and fix conditional request handling in ServeDir

### DIFF
--- a/tower-http/src/macros.rs
+++ b/tower-http/src/macros.rs
@@ -103,3 +103,35 @@ macro_rules! opaque_future {
         }
     }
 }
+
+/// Evaluate `$call` at most once every `$interval` per call site.
+///
+/// Uses a monotonic clock and atomic timestamp to rate-limit without locks.
+/// Adapted from dial9-tokio-telemetry's rate_limit module.
+// TODO: Once MSRV >= 1.70, switch to OnceLock<Instant> for monotonic timing.
+// See: https://github.com/dial9-rs/dial9/blob/6772039/dial9-tokio-telemetry/src/rate_limit.rs
+#[allow(unused_macros)]
+macro_rules! rate_limited {
+    ($interval:expr, $call:expr) => {{
+        use std::sync::atomic::{AtomicU64, Ordering};
+        use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+        static NEXT_CALL: AtomicU64 = AtomicU64::new(0);
+
+        let interval: Duration = $interval;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+        let next = NEXT_CALL.load(Ordering::Relaxed);
+        if now >= next {
+            let new_next = now.saturating_add(interval.as_secs());
+            if NEXT_CALL
+                .compare_exchange(next, new_next, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                $call;
+            }
+        }
+    }};
+}

--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -119,8 +119,22 @@ where
                         )));
                     }
 
-                    Ok(OpenFileOutput::NotModified) => {
-                        break Poll::Ready(Ok(response_with_status(StatusCode::NOT_MODIFIED)));
+                    Ok(OpenFileOutput::NotModified {
+                        etag,
+                        last_modified,
+                    }) => {
+                        let mut res = response_with_status(StatusCode::NOT_MODIFIED);
+                        if let Some(etag) = etag {
+                            res.headers_mut()
+                                .insert(header::ETAG, etag.into_header_value());
+                        }
+                        if let Some(last_modified) = last_modified {
+                            res.headers_mut().insert(
+                                header::LAST_MODIFIED,
+                                HeaderValue::from_str(&last_modified.0.to_string()).unwrap(),
+                            );
+                        }
+                        break Poll::Ready(Ok(res));
                     }
 
                     Ok(OpenFileOutput::InvalidRedirectUri) => {
@@ -248,6 +262,10 @@ fn build_response(output: FileOpened) -> Response<ResponseBody> {
 
     if let Some(last_modified) = output.last_modified {
         builder = builder.header(header::LAST_MODIFIED, last_modified.0.to_string());
+    }
+
+    if let Some(etag) = output.etag {
+        builder = builder.header(header::ETAG, etag.into_header_value());
     }
 
     match output.maybe_range {

--- a/tower-http/src/services/fs/serve_dir/headers.rs
+++ b/tower-http/src/services/fs/serve_dir/headers.rs
@@ -2,6 +2,147 @@ use http::header::HeaderValue;
 use httpdate::HttpDate;
 use std::time::SystemTime;
 
+/// A strong ETag derived from file metadata (size + mtime with nanosecond precision).
+///
+/// Format is an implementation detail and may change between versions. Clients should
+/// treat ETags as opaque values per RFC 9110 §8.8.3.
+#[derive(Clone, Debug)]
+pub(super) struct ETag(HeaderValue);
+
+impl ETag {
+    /// Generate an ETag from file size and modification time.
+    ///
+    /// Returns `None` only for pre-epoch modification times, which are unsupported.
+    pub(super) fn from_metadata(size: u64, modified: SystemTime) -> Option<Self> {
+        let duration = modified.duration_since(SystemTime::UNIX_EPOCH).ok()?;
+        // NOTE: Changing this format is a cache-busting event for all clients,
+        // but is not a semver break (ETags are opaque per RFC 9110 §8.8.3).
+        let value = format!(
+            "\"{:x}.{:08x}-{:x}\"",
+            duration.as_secs(),
+            duration.subsec_nanos(),
+            size
+        );
+        HeaderValue::from_str(&value).ok().map(ETag)
+    }
+
+    pub(super) fn into_header_value(self) -> HeaderValue {
+        self.0
+    }
+
+    /// Strong comparison per RFC 9110 §8.8.3.2: both must not be weak,
+    /// and the opaque-tags must be identical.
+    fn strong_eq(&self, other: &[u8]) -> bool {
+        if other.starts_with(b"W/") {
+            return false;
+        }
+        self.0.as_bytes() == other
+    }
+
+    /// Weak comparison per RFC 9110 §8.8.3.2: ignore W/ prefix,
+    /// compare opaque-tags.
+    fn weak_eq(&self, other: &[u8]) -> bool {
+        let this = self.0.as_bytes();
+        let other = other.strip_prefix(b"W/").unwrap_or(other);
+        let this = this.strip_prefix(b"W/").unwrap_or(this);
+        this == other
+    }
+}
+
+/// Parsed `If-None-Match` header (RFC 9110 §13.1.2).
+pub(super) struct IfNoneMatch(HeaderValue);
+
+impl IfNoneMatch {
+    pub(super) fn from_header_value(value: &HeaderValue) -> Option<Self> {
+        // Reject empty values
+        if value.as_bytes().is_empty() {
+            return None;
+        }
+        Some(IfNoneMatch(value.clone()))
+    }
+
+    /// Returns true if the precondition passes (none of the ETags match).
+    /// A failed precondition (returns false) means we should return 304.
+    ///
+    /// Uses weak comparison per RFC 9110 §13.1.2.
+    pub(super) fn precondition_passes(&self, etag: &ETag) -> bool {
+        let bytes = self.0.as_bytes();
+        if bytes == b"*" {
+            return false;
+        }
+        !for_each_etag(bytes, |tag| etag.weak_eq(tag))
+    }
+}
+
+/// Parsed `If-Match` header (RFC 9110 §13.1.1).
+pub(super) struct IfMatch(HeaderValue);
+
+impl IfMatch {
+    pub(super) fn from_header_value(value: &HeaderValue) -> Option<Self> {
+        if value.as_bytes().is_empty() {
+            return None;
+        }
+        Some(IfMatch(value.clone()))
+    }
+
+    /// Returns true if the precondition passes (at least one ETag matches).
+    /// A failed precondition (returns false) means we should return 412.
+    ///
+    /// Uses strong comparison per RFC 9110 §13.1.1.
+    pub(super) fn precondition_passes(&self, etag: &ETag) -> bool {
+        let bytes = self.0.as_bytes();
+        if bytes == b"*" {
+            return true;
+        }
+        for_each_etag(bytes, |tag| etag.strong_eq(tag))
+    }
+}
+
+/// Iterate over comma-separated ETags in a header value, trimming OWS.
+/// Returns true if `predicate` returns true for any tag (short-circuits).
+///
+/// Handles commas inside quoted strings per RFC 9110 §8.8.3 (ETags are quoted).
+fn for_each_etag(header: &[u8], mut predicate: impl FnMut(&[u8]) -> bool) -> bool {
+    let mut start = 0;
+    let mut in_quotes = false;
+    for i in 0..header.len() {
+        match header[i] {
+            b'"' => in_quotes = !in_quotes,
+            b',' if !in_quotes => {
+                let trimmed = trim_ows(&header[start..i]);
+                if !trimmed.is_empty() && predicate(trimmed) {
+                    return true;
+                }
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    let trimmed = trim_ows(&header[start..]);
+    if !trimmed.is_empty() && predicate(trimmed) {
+        return true;
+    }
+    false
+}
+
+/// Trim leading/trailing OWS (SP / HTAB) per RFC 9110.
+fn trim_ows(bytes: &[u8]) -> &[u8] {
+    let start = bytes
+        .iter()
+        .position(|&b| b != b' ' && b != b'\t')
+        .unwrap_or(bytes.len());
+    let end = bytes
+        .iter()
+        .rposition(|&b| b != b' ' && b != b'\t')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    if start >= end {
+        &[]
+    } else {
+        &bytes[start..end]
+    }
+}
+
 pub(super) struct LastModified(pub(super) HttpDate);
 
 impl From<SystemTime> for LastModified {
@@ -41,5 +182,81 @@ impl IfUnmodifiedSince {
             .ok()
             .and_then(|value| httpdate::parse_http_date(value).ok())
             .map(|time| IfUnmodifiedSince(time.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: collect all ETags parsed from a header value.
+    fn collect_etags(header: &[u8]) -> Vec<Vec<u8>> {
+        let mut tags = Vec::new();
+        for_each_etag(header, |tag| {
+            tags.push(tag.to_vec());
+            false // don't short-circuit, collect all
+        });
+        tags
+    }
+
+    #[test]
+    fn for_each_etag_simple_list() {
+        let tags = collect_etags(b"\"foo\", \"bar\", \"baz\"");
+        assert_eq!(
+            tags,
+            vec![
+                b"\"foo\"".to_vec(),
+                b"\"bar\"".to_vec(),
+                b"\"baz\"".to_vec()
+            ]
+        );
+    }
+
+    #[test]
+    fn for_each_etag_comma_inside_quotes() {
+        // An ETag containing a comma inside the quoted string should not be split
+        let tags = collect_etags(b"\"foo,bar\", \"baz\"");
+        assert_eq!(tags, vec![b"\"foo,bar\"".to_vec(), b"\"baz\"".to_vec()]);
+    }
+
+    #[test]
+    fn for_each_etag_multiple_commas_inside_quotes() {
+        let tags = collect_etags(b"\"a,b,c\", \"d\"");
+        assert_eq!(tags, vec![b"\"a,b,c\"".to_vec(), b"\"d\"".to_vec()]);
+    }
+
+    #[test]
+    fn for_each_etag_weak_with_comma_inside() {
+        let tags = collect_etags(b"W/\"foo,bar\", \"baz\"");
+        assert_eq!(tags, vec![b"W/\"foo,bar\"".to_vec(), b"\"baz\"".to_vec()]);
+    }
+
+    #[test]
+    fn for_each_etag_single_tag() {
+        let tags = collect_etags(b"\"only\"");
+        assert_eq!(tags, vec![b"\"only\"".to_vec()]);
+    }
+
+    #[test]
+    fn for_each_etag_empty() {
+        let tags = collect_etags(b"");
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn for_each_etag_whitespace_only() {
+        let tags = collect_etags(b"  ,  , ");
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn for_each_etag_short_circuits() {
+        let mut count = 0;
+        let found = for_each_etag(b"\"a\", \"b\", \"c\"", |_tag| {
+            count += 1;
+            count == 2 // match on second tag
+        });
+        assert!(found);
+        assert_eq!(count, 2);
     }
 }

--- a/tower-http/src/services/fs/serve_dir/open_file.rs
+++ b/tower-http/src/services/fs/serve_dir/open_file.rs
@@ -1,5 +1,5 @@
 use super::{
-    headers::{IfModifiedSince, IfUnmodifiedSince, LastModified},
+    headers::{ETag, IfMatch, IfModifiedSince, IfNoneMatch, IfUnmodifiedSince, LastModified},
     ServeVariant,
 };
 use crate::content_encoding::{Encoding, QValue};
@@ -18,10 +18,15 @@ use tokio::{fs::File, io::AsyncSeekExt};
 
 pub(super) enum OpenFileOutput {
     FileOpened(Box<FileOpened>),
-    Redirect { location: HeaderValue },
+    Redirect {
+        location: HeaderValue,
+    },
     FileNotFound,
     PreconditionFailed,
-    NotModified,
+    NotModified {
+        etag: Option<ETag>,
+        last_modified: Option<LastModified>,
+    },
     InvalidRedirectUri,
     InvalidFilename,
 }
@@ -34,6 +39,7 @@ pub(super) struct FileOpened {
     pub(super) maybe_range: Option<Result<Vec<RangeInclusive<u64>>, RangeUnsatisfiableError>>,
     pub(super) last_modified: Option<LastModified>,
     pub(super) precompression_configured: bool,
+    pub(super) etag: Option<ETag>,
 }
 
 pub(super) enum FileRequestExtent {
@@ -50,15 +56,24 @@ pub(super) async fn open_file(
     buf_chunk_size: usize,
     precompression_configured: bool,
 ) -> io::Result<OpenFileOutput> {
-    let if_unmodified_since = req
-        .headers()
-        .get(header::IF_UNMODIFIED_SINCE)
-        .and_then(IfUnmodifiedSince::from_header_value);
-
-    let if_modified_since = req
-        .headers()
-        .get(header::IF_MODIFIED_SINCE)
-        .and_then(IfModifiedSince::from_header_value);
+    let preconditions = Preconditions {
+        if_match: req
+            .headers()
+            .get(header::IF_MATCH)
+            .and_then(IfMatch::from_header_value),
+        if_unmodified_since: req
+            .headers()
+            .get(header::IF_UNMODIFIED_SINCE)
+            .and_then(IfUnmodifiedSince::from_header_value),
+        if_none_match: req
+            .headers()
+            .get(header::IF_NONE_MATCH)
+            .and_then(IfNoneMatch::from_header_value),
+        if_modified_since: req
+            .headers()
+            .get(header::IF_MODIFIED_SINCE)
+            .and_then(IfModifiedSince::from_header_value),
+    };
 
     let mime = match variant {
         ServeVariant::Directory {
@@ -91,15 +106,26 @@ pub(super) async fn open_file(
     };
 
     if req.method() == Method::HEAD {
+        #[cfg(feature = "tracing")]
+        let _path_str = path_to_file.display().to_string();
         let (meta, maybe_encoding) =
             file_metadata_with_fallback(path_to_file, negotiated_encodings).await?;
 
         let last_modified = meta.modified().ok().map(LastModified::from);
-        if let Some(output) = check_modified_headers(
-            last_modified.as_ref(),
-            if_unmodified_since,
-            if_modified_since,
-        ) {
+        let etag = meta
+            .modified()
+            .ok()
+            .and_then(|mtime| ETag::from_metadata(meta.len(), mtime));
+
+        #[cfg(feature = "tracing")]
+        if etag.is_none() {
+            rate_limited!(
+                std::time::Duration::from_secs(60),
+                tracing::warn!(path = %_path_str, "ETag generation failed (mtime unavailable or pre-epoch)")
+            );
+        }
+
+        if let Some(output) = preconditions.check(etag.as_ref(), last_modified.as_ref()) {
             return Ok(output);
         }
 
@@ -113,8 +139,11 @@ pub(super) async fn open_file(
             maybe_range,
             last_modified,
             precompression_configured,
+            etag,
         })))
     } else {
+        #[cfg(feature = "tracing")]
+        let _path_str = path_to_file.display().to_string();
         let (mut file, maybe_encoding) =
             match open_file_with_fallback(path_to_file, negotiated_encodings).await {
                 Ok(result) => result,
@@ -128,11 +157,20 @@ pub(super) async fn open_file(
         let meta = file.metadata().await?;
 
         let last_modified = meta.modified().ok().map(LastModified::from);
-        if let Some(output) = check_modified_headers(
-            last_modified.as_ref(),
-            if_unmodified_since,
-            if_modified_since,
-        ) {
+        let etag = meta
+            .modified()
+            .ok()
+            .and_then(|mtime| ETag::from_metadata(meta.len(), mtime));
+
+        #[cfg(feature = "tracing")]
+        if etag.is_none() {
+            rate_limited!(
+                std::time::Duration::from_secs(60),
+                tracing::warn!(path = %_path_str, "ETag generation failed (mtime unavailable or pre-epoch)")
+            );
+        }
+
+        if let Some(output) = preconditions.check(etag.as_ref(), last_modified.as_ref()) {
             return Ok(output);
         }
 
@@ -153,6 +191,7 @@ pub(super) async fn open_file(
             maybe_range,
             last_modified,
             precompression_configured,
+            etag,
         })))
     }
 }
@@ -177,34 +216,82 @@ fn is_invalid_filename_error(err: &io::Error) -> bool {
     false
 }
 
-fn check_modified_headers(
-    modified: Option<&LastModified>,
+/// Precondition headers parsed from the request.
+struct Preconditions {
+    if_match: Option<IfMatch>,
     if_unmodified_since: Option<IfUnmodifiedSince>,
+    if_none_match: Option<IfNoneMatch>,
     if_modified_since: Option<IfModifiedSince>,
-) -> Option<OpenFileOutput> {
-    if let Some(since) = if_unmodified_since {
-        let precondition = modified
-            .as_ref()
-            .map(|time| since.precondition_passes(time))
-            .unwrap_or(false);
+}
 
-        if !precondition {
-            return Some(OpenFileOutput::PreconditionFailed);
+impl Preconditions {
+    /// Evaluate preconditions per [RFC 9110 §13.2.2](https://www.rfc-editor.org/rfc/rfc9110#section-13.2.2).
+    ///
+    /// Precedence order:
+    /// 1. If-Match (strong comparison) → 412 on failure
+    /// 2. If-Unmodified-Since (only if If-Match absent) → 412 on failure
+    /// 3. If-None-Match (weak comparison) → 304 on failure (for GET/HEAD)
+    /// 4. If-Modified-Since (only if If-None-Match absent) → 304 on failure
+    fn check(
+        self,
+        etag: Option<&ETag>,
+        last_modified: Option<&LastModified>,
+    ) -> Option<OpenFileOutput> {
+        // Step 1: If-Match
+        if let Some(if_match) = self.if_match {
+            // RFC 9110 §13.1.1: "If the field value is '*', the condition is FALSE
+            // if the origin server does not have a current representation."
+            // No ETag means no current representation → fail.
+            let passes = etag
+                .map(|etag| if_match.precondition_passes(etag))
+                .unwrap_or(false);
+            if !passes {
+                return Some(OpenFileOutput::PreconditionFailed);
+            }
+        } else {
+            // Step 2: If-Unmodified-Since (only when If-Match is absent)
+            // RFC 9110 §13.1.4: "MUST ignore if the resource does not have a
+            // modification date available."
+            if let Some(since) = self.if_unmodified_since {
+                let passes = last_modified
+                    .map(|lm| since.precondition_passes(lm))
+                    .unwrap_or(true);
+                if !passes {
+                    return Some(OpenFileOutput::PreconditionFailed);
+                }
+            }
         }
-    }
 
-    if let Some(since) = if_modified_since {
-        let unmodified = modified
-            .as_ref()
-            .map(|time| !since.is_modified(time))
-            // no last_modified means its always modified
-            .unwrap_or(false);
-        if unmodified {
-            return Some(OpenFileOutput::NotModified);
+        // Step 3: If-None-Match
+        if let Some(if_none_match) = self.if_none_match {
+            // No ETag available → condition is vacuously true (passes), serve normally.
+            let passes = etag
+                .map(|etag| if_none_match.precondition_passes(etag))
+                .unwrap_or(true);
+            if !passes {
+                return Some(OpenFileOutput::NotModified {
+                    etag: etag.cloned(),
+                    last_modified: last_modified.map(|lm| LastModified(lm.0)),
+                });
+            }
+        } else {
+            // Step 4: If-Modified-Since (only when If-None-Match is absent)
+            // No Last-Modified → treat as modified (serve normally).
+            if let Some(since) = self.if_modified_since {
+                let unmodified = last_modified
+                    .map(|lm| !since.is_modified(lm))
+                    .unwrap_or(false);
+                if unmodified {
+                    return Some(OpenFileOutput::NotModified {
+                        etag: etag.cloned(),
+                        last_modified: last_modified.map(|lm| LastModified(lm.0)),
+                    });
+                }
+            }
         }
-    }
 
-    None
+        None
+    }
 }
 
 // Returns the preferred_encoding encoding and modifies the path extension

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -1294,3 +1294,313 @@ async fn html_as_default_extension_does_not_apply_when_extension_present() {
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.headers()["content-type"], "text/plain");
 }
+
+#[tokio::test]
+async fn etag_is_set_on_response() {
+    let svc = ServeDir::new(REPO_ROOT);
+
+    let req = Request::builder()
+        .uri("/README.md")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    let etag = res
+        .headers()
+        .get(header::ETAG)
+        .expect("Missing ETag header");
+    let etag_str = etag.to_str().unwrap();
+    // Strong ETag format: "<hex>-<hex>"
+    assert!(etag_str.starts_with('"'));
+    assert!(etag_str.ends_with('"'));
+    assert!(!etag_str.starts_with("W/"));
+    assert!(etag_str.contains('-'));
+}
+
+#[tokio::test]
+async fn if_none_match_returns_304() {
+    let svc = ServeDir::new(REPO_ROOT);
+
+    // First request to get the ETag
+    let req = Request::builder()
+        .uri("/README.md")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let etag = res.headers().get(header::ETAG).unwrap().clone();
+    let last_modified = res.headers().get(header::LAST_MODIFIED).unwrap().clone();
+
+    // Second request with If-None-Match
+    let svc = ServeDir::new(REPO_ROOT);
+    let req = Request::builder()
+        .uri("/README.md")
+        .header(header::IF_NONE_MATCH, &etag)
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_MODIFIED);
+    // RFC 9110 §15.4.5: 304 MUST include validator headers
+    assert_eq!(res.headers().get(header::ETAG).unwrap(), &etag);
+    assert_eq!(
+        res.headers().get(header::LAST_MODIFIED).unwrap(),
+        &last_modified
+    );
+    assert!(res.into_body().frame().await.is_none());
+}
+
+#[tokio::test]
+async fn if_none_match_with_non_matching_etag_returns_200() {
+    let svc = ServeDir::new(REPO_ROOT);
+
+    let req = Request::builder()
+        .uri("/README.md")
+        .header(header::IF_NONE_MATCH, "\"not-a-real-etag\"")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn if_none_match_wildcard_returns_304() {
+    let svc = ServeDir::new(REPO_ROOT);
+
+    let req = Request::builder()
+        .uri("/README.md")
+        .header(header::IF_NONE_MATCH, "*")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_MODIFIED);
+}
+
+#[tokio::test]
+async fn if_match_with_matching_etag_succeeds() {
+    let svc = ServeDir::new(REPO_ROOT);
+
+    // First request to get the ETag
+    let req = Request::builder()
+        .uri("/README.md")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let etag = res.headers().get(header::ETAG).unwrap().clone();
+
+    // Second request with If-Match
+    let svc = ServeDir::new(REPO_ROOT);
+    let req = Request::builder()
+        .uri("/README.md")
+        .header(header::IF_MATCH, etag)
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn if_match_with_non_matching_etag_returns_412() {
+    let svc = ServeDir::new(REPO_ROOT);
+
+    let req = Request::builder()
+        .uri("/README.md")
+        .header(header::IF_MATCH, "\"not-a-real-etag\"")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::PRECONDITION_FAILED);
+}
+
+#[tokio::test]
+async fn if_none_match_takes_precedence_over_if_modified_since() {
+    // Per RFC 9110 §13.2.2, If-None-Match takes precedence over If-Modified-Since
+    let svc = ServeDir::new(REPO_ROOT);
+
+    // First request to get the ETag
+    let req = Request::builder()
+        .uri("/README.md")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let etag = res.headers().get(header::ETAG).unwrap().clone();
+
+    // Send both If-None-Match (matching) and If-Modified-Since (very old, would normally 200)
+    // If-None-Match should win and return 304
+    let svc = ServeDir::new(REPO_ROOT);
+    let req = Request::builder()
+        .uri("/README.md")
+        .header(header::IF_NONE_MATCH, etag)
+        .header(header::IF_MODIFIED_SINCE, "Fri, 09 Aug 1996 14:21:40 GMT")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_MODIFIED);
+}
+
+#[tokio::test]
+async fn if_match_takes_precedence_over_if_unmodified_since() {
+    // Per RFC 9110 §13.2.2, If-Match takes precedence over If-Unmodified-Since
+    let svc = ServeDir::new(REPO_ROOT);
+
+    // Send If-Match (non-matching, should 412) and If-Unmodified-Since (far future, would pass)
+    // If-Match should win and return 412
+    let req = Request::builder()
+        .uri("/README.md")
+        .header(header::IF_MATCH, "\"not-a-real-etag\"")
+        .header(header::IF_UNMODIFIED_SINCE, "Sun, 01 Jan 2100 00:00:00 GMT")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::PRECONDITION_FAILED);
+}
+
+#[tokio::test]
+async fn if_none_match_weak_comparison() {
+    // Weak comparison: W/"etag" should match "etag" for If-None-Match
+    let svc = ServeDir::new(REPO_ROOT);
+
+    // First request to get the ETag
+    let req = Request::builder()
+        .uri("/README.md")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let etag = res
+        .headers()
+        .get(header::ETAG)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    // Send with W/ prefix, should still match via weak comparison
+    let svc = ServeDir::new(REPO_ROOT);
+    let weak_etag = format!("W/{}", etag);
+    let req = Request::builder()
+        .uri("/README.md")
+        .header(header::IF_NONE_MATCH, &weak_etag)
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_MODIFIED);
+}
+
+#[tokio::test]
+async fn if_match_strong_comparison_rejects_weak_etag() {
+    // Strong comparison: W/"etag" should NOT match "etag" for If-Match
+    let svc = ServeDir::new(REPO_ROOT);
+
+    // First request to get the ETag
+    let req = Request::builder()
+        .uri("/README.md")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let etag = res
+        .headers()
+        .get(header::ETAG)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    // Send with W/ prefix for If-Match, should fail (strong comparison)
+    let svc = ServeDir::new(REPO_ROOT);
+    let weak_etag = format!("W/{}", etag);
+    let req = Request::builder()
+        .uri("/README.md")
+        .header(header::IF_MATCH, &weak_etag)
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::PRECONDITION_FAILED);
+}
+
+#[tokio::test]
+async fn if_none_match_multiple_etags() {
+    let svc = ServeDir::new(REPO_ROOT);
+
+    let req = Request::builder()
+        .uri("/README.md")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    let etag = res
+        .headers()
+        .get(header::ETAG)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    // One matching among several should still produce 304
+    let svc = ServeDir::new(REPO_ROOT);
+    let multi = format!("\"bogus\", {}, \"also-bogus\"", etag);
+    let req = Request::builder()
+        .uri("/README.md")
+        .header(header::IF_NONE_MATCH, &multi)
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_MODIFIED);
+}
+
+#[tokio::test]
+async fn if_match_wildcard_succeeds() {
+    let svc = ServeDir::new(REPO_ROOT);
+
+    let req = Request::builder()
+        .uri("/README.md")
+        .header(header::IF_MATCH, "*")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn etag_on_head_request() {
+    let svc = ServeDir::new(REPO_ROOT);
+
+    let req = Request::builder()
+        .uri("/README.md")
+        .method(Method::HEAD)
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert!(res.headers().get(header::ETAG).is_some());
+}
+
+#[tokio::test]
+async fn if_modified_since_304_includes_etag() {
+    let svc = ServeDir::new(REPO_ROOT);
+
+    let req = Request::builder()
+        .uri("/README.md")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    let last_modified = res.headers().get(header::LAST_MODIFIED).unwrap().clone();
+    let etag = res.headers().get(header::ETAG).unwrap().clone();
+
+    // Time-based 304 should also include ETag
+    let svc = ServeDir::new(REPO_ROOT);
+    let req = Request::builder()
+        .uri("/README.md")
+        .header(header::IF_MODIFIED_SINCE, &last_modified)
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(res.headers().get(header::ETAG).unwrap(), &etag);
+    assert_eq!(
+        res.headers().get(header::LAST_MODIFIED).unwrap(),
+        &last_modified
+    );
+}


### PR DESCRIPTION
Closes #324, closes #411

## Motivation

`ServeDir` only supports time-based conditional requests today. This causes real problems: if you roll back a deploy, files get an older mtime and clients keep getting 304s for stale content. HTTP dates also have 1-second granularity, so rapid redeploys within the same second are invisible to `If-Modified-Since`.

## Solution

Generate a strong ETag from file metadata (mtime with nanosecond precision + file size) and implement the full RFC 9110 §13.2.2 precondition evaluation order:

1. `If-Match` → 412 (enables safe range request resumption)
2. `If-Unmodified-Since` (when `If-Match` absent) → 412
3. `If-None-Match` → 304
4. `If-Modified-Since` (when `If-None-Match` absent) → 304

The ETag format is `"<hex_secs>.<hex_nanos>-<hex_size>"`. Similar to what nginx does (`<mtime>-<size>`) but with nanosecond precision. No content hashing, no extra I/O; we already call `metadata()` on every request.

304 responses now include `ETag` and `Last-Modified` headers per RFC 9110 §15.4.5 (previously they were bare, which was a spec violation).

No new public API surface. All new types are `pub(super)`. The ETag is always-on, matching the existing `Last-Modified` behavior.

## Testing

Covers: ETag presence on 200, `If-None-Match` producing 304 (exact match, wildcard, weak prefix), `If-Match` producing 412 (non-matching, weak prefix rejected by strong comparison), RFC precedence (ETag conditions override time-based when both present), and validator headers on 304 responses.
