### PR TITLE
Fix: Add Vary: Accept-Encoding header for precompressed file serving

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Fixed
+
+- `fs`: `ServeDir` and `ServeFile` now emit a `Vary: Accept-Encoding` response
+  header when precompressed serving is configured, ensuring caches correctly
+  distinguish between compressed and uncompressed variants.
+
 ## Changed
 
 - The implicit `tokio` and `async-compression` features are removed (BREAKING).

--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -240,6 +240,12 @@ fn build_response(output: FileOpened) -> Response<ResponseBody> {
         builder = builder.header(header::CONTENT_ENCODING, encoding.into_header_value());
     }
 
+    // Per RFC 9110 §12.5.3, Vary must be sent when the response could differ
+    // based on Accept-Encoding, even if this particular response is uncompressed.
+    if output.precompression_configured {
+        builder = builder.header(header::VARY, "accept-encoding");
+    }
+
     if let Some(last_modified) = output.last_modified {
         builder = builder.header(header::LAST_MODIFIED, last_modified.0.to_string());
     }

--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -366,6 +366,7 @@ impl<F> ServeDir<F> {
             .and_then(|value| value.to_str().ok())
             .map(|s| s.to_owned());
 
+        let precompression_configured = self.precompressed_variants.is_some();
         let negotiated_encodings: Vec<_> = encodings(
             req.headers(),
             self.precompressed_variants.unwrap_or_default(),
@@ -381,6 +382,7 @@ impl<F> ServeDir<F> {
             negotiated_encodings,
             range_header,
             buf_chunk_size,
+            precompression_configured,
         ));
 
         ResponseFuture::open_file_future(open_file_future, fallback_and_request)

--- a/tower-http/src/services/fs/serve_dir/open_file.rs
+++ b/tower-http/src/services/fs/serve_dir/open_file.rs
@@ -33,6 +33,7 @@ pub(super) struct FileOpened {
     pub(super) maybe_encoding: Option<Encoding>,
     pub(super) maybe_range: Option<Result<Vec<RangeInclusive<u64>>, RangeUnsatisfiableError>>,
     pub(super) last_modified: Option<LastModified>,
+    pub(super) precompression_configured: bool,
 }
 
 pub(super) enum FileRequestExtent {
@@ -47,6 +48,7 @@ pub(super) async fn open_file(
     negotiated_encodings: Vec<(Encoding, QValue)>,
     range_header: Option<String>,
     buf_chunk_size: usize,
+    precompression_configured: bool,
 ) -> io::Result<OpenFileOutput> {
     let if_unmodified_since = req
         .headers()
@@ -108,6 +110,7 @@ pub(super) async fn open_file(
             maybe_encoding,
             maybe_range,
             last_modified,
+            precompression_configured,
         })))
     } else {
         let (mut file, maybe_encoding) =
@@ -147,6 +150,7 @@ pub(super) async fn open_file(
             maybe_encoding,
             maybe_range,
             last_modified,
+            precompression_configured,
         })))
     }
 }

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -1158,9 +1158,7 @@ async fn precompressed_response_includes_vary_header() {
     let res = svc.oneshot(req).await.unwrap();
 
     assert_eq!(res.headers()["content-encoding"], "gzip");
-    // BUG: Vary header should be present but is missing.
-    // This assertion is inverted to demonstrate the bug; the next commit fixes it.
-    assert!(res.headers().get("vary").is_none());
+    assert_eq!(res.headers()["vary"], "accept-encoding");
 }
 
 #[tokio::test]
@@ -1190,7 +1188,35 @@ async fn vary_header_present_when_precompressed_configured_but_fallback_to_uncom
     let res = svc.oneshot(req).await.unwrap();
 
     assert!(res.headers().get("content-encoding").is_none());
-    // BUG: Vary header should be present but is missing.
-    // This assertion is inverted to demonstrate the bug; the next commit fixes it.
-    assert!(res.headers().get("vary").is_none());
+    assert_eq!(res.headers()["vary"], "accept-encoding");
+}
+
+#[tokio::test]
+async fn vary_header_present_when_precompressed_configured_but_no_accept_encoding() {
+    let svc = ServeDir::new(TEST_FILES_DIR).precompressed_gzip();
+
+    let req = Request::builder()
+        .uri("/precompressed.txt")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert!(res.headers().get("content-encoding").is_none());
+    assert_eq!(res.headers()["vary"], "accept-encoding");
+}
+
+#[tokio::test]
+async fn precompressed_head_request_includes_vary_header() {
+    let svc = ServeDir::new(TEST_FILES_DIR).precompressed_gzip();
+
+    let req = Request::builder()
+        .uri("/precompressed.txt")
+        .method(Method::HEAD)
+        .header("Accept-Encoding", "gzip")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(res.headers()["content-encoding"], "gzip");
+    assert_eq!(res.headers()["vary"], "accept-encoding");
 }

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -1145,3 +1145,52 @@ async fn identity_encoding_does_not_strip_extension_head_request() {
 
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 }
+
+#[tokio::test]
+async fn precompressed_response_includes_vary_header() {
+    let svc = ServeDir::new(TEST_FILES_DIR).precompressed_gzip();
+
+    let req = Request::builder()
+        .uri("/precompressed.txt")
+        .header("Accept-Encoding", "gzip")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(res.headers()["content-encoding"], "gzip");
+    // BUG: Vary header should be present but is missing.
+    // This assertion is inverted to demonstrate the bug; the next commit fixes it.
+    assert!(res.headers().get("vary").is_none());
+}
+
+#[tokio::test]
+async fn no_vary_header_without_precompressed_serving() {
+    let svc = ServeDir::new(REPO_ROOT);
+
+    let req = Request::builder()
+        .uri("/README.md")
+        .header("Accept-Encoding", "gzip")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    assert!(res.headers().get("vary").is_none());
+}
+
+#[tokio::test]
+async fn vary_header_present_when_precompressed_configured_but_fallback_to_uncompressed() {
+    let svc = ServeDir::new(TEST_FILES_DIR).precompressed_gzip();
+
+    let req = Request::builder()
+        .uri("/precompressed.txt")
+        .header("Accept-Encoding", "br")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert!(res.headers().get("content-encoding").is_none());
+    // BUG: Vary header should be present but is missing.
+    // This assertion is inverted to demonstrate the bug; the next commit fixes it.
+    assert!(res.headers().get("vary").is_none());
+}


### PR DESCRIPTION
## Motivation

When `ServeDir` or `ServeFile` is configured with `.precompressed_gzip()` (or br/deflate/zstd), it performs content negotiation based on the request's `Accept-Encoding` header. However, the response does not include a `Vary: Accept-Encoding` header. Per RFC 9110 §12.5.3, responses that vary based on `Accept-Encoding` must include this header so caches can correctly distinguish between compressed and uncompressed variants. Without it, a caching proxy could serve a gzip'd response to a client that doesn't support gzip.

## Solution

Add `Vary: Accept-Encoding` to responses whenever precompressed serving is configured, regardless of whether the specific response ended up compressed or not. Even when the response falls back to uncompressed (because the client didn't accept the available encoding, or the precompressed file didn't exist), a different `Accept-Encoding` value would produce a different response, so caches must be informed.

A `precompression_configured: bool` flag is threaded from `ServeDir` through `open_file` into `FileOpened`, so `build_response` can emit `Vary` in both the compressed and fallback-to-uncompressed cases.