### PR TITLE
Fix: Handle wildcard * in Accept-Encoding per RFC 9110 §12.5.3

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DefaultOnEos` now explicitly parent their tracing events to the request span
   rather than relying on the ambient span context. This fixes intermittent cases
   where events could appear without their request span attached ([#655])
+- **breaking:** `compression`: the middleware now handles the `*` wildcard and
+  `identity;q=0` in Accept-Encoding per RFC 9110 §12.5.3. Requests that
+  previously fell back to identity (e.g. `*;q=0` or `identity;q=0` with no
+  other acceptable encoding) now receive a 406 Not Acceptable response. Clients
+  that explicitly reject all encodings without listing an alternative will see
+  different behavior. ([#215])
 - The implicit `tokio` and `async-compression` features are removed (BREAKING).
   These were kept as no-op features in 0.6.x for backwards compatibility after
   the switch to `dep:` syntax in [#642]. Downstream crates that activate
@@ -27,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by the features that need them (e.g. `compression-gzip`, `fs`, `timeout`).
   ([#628])
 
+[#215]: https://github.com/tower-rs/tower-http/issues/215
 [#628]: https://github.com/tower-rs/tower-http/pull/628
 [#642]: https://github.com/tower-rs/tower-http/pull/642
 

--- a/tower-http/src/compression/future.rs
+++ b/tower-http/src/compression/future.rs
@@ -22,7 +22,7 @@ pin_project! {
     pub struct ResponseFuture<F, P> {
         #[pin]
         pub(crate) inner: F,
-        pub(crate) encoding: Encoding,
+        pub(crate) encoding: Option<Encoding>,
         pub(crate) predicate: P,
         pub(crate) quality: CompressionLevel,
     }
@@ -38,6 +38,33 @@ where
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let res = ready!(self.as_mut().project().inner.poll(cx)?);
+
+        let encoding = match self.encoding {
+            Some(enc) => enc,
+            None => {
+                // RFC 9110 §12.5.3: the server SHOULD respond with 406 Not Acceptable
+                // when no encoding is satisfiable. This middleware chooses to enforce it.
+                //
+                // Note: the inner service has already been called, so its response body and
+                // headers are passed through. Only the status code is overwritten.
+                let mut res = res;
+                *res.status_mut() = http::StatusCode::NOT_ACCEPTABLE;
+                if !res.headers().get_all(header::VARY).iter().any(|value| {
+                    contains_ignore_ascii_case(
+                        value.as_bytes(),
+                        header::ACCEPT_ENCODING.as_str().as_bytes(),
+                    )
+                }) {
+                    res.headers_mut()
+                        .append(header::VARY, header::ACCEPT_ENCODING.into());
+                }
+                let (parts, body) = res.into_parts();
+                return Poll::Ready(Ok(Response::from_parts(
+                    parts,
+                    CompressionBody::new(BodyInner::identity(body)),
+                )));
+            }
+        };
 
         // never recompress responses that are already compressed
         let should_compress = !res.headers().contains_key(header::CONTENT_ENCODING)
@@ -60,7 +87,7 @@ where
                 .append(header::VARY, header::ACCEPT_ENCODING.into());
         }
 
-        let body = match (should_compress, self.encoding) {
+        let body = match (should_compress, encoding) {
             // if compression is _not_ supported or the client doesn't accept it
             (false, _) | (_, Encoding::Identity) => {
                 return Poll::Ready(Ok(Response::from_parts(
@@ -114,7 +141,7 @@ where
 
         parts
             .headers
-            .insert(header::CONTENT_ENCODING, self.encoding.into_header_value());
+            .insert(header::CONTENT_ENCODING, encoding.into_header_value());
 
         let res = Response::from_parts(parts, body);
         Poll::Ready(Ok(res))

--- a/tower-http/src/compression/mod.rs
+++ b/tower-http/src/compression/mod.rs
@@ -616,4 +616,93 @@ mod tests {
         let body = res.into_body();
         assert_eq!(body.size_hint().exact().unwrap(), msg.len() as u64);
     }
+
+    #[tokio::test]
+    async fn wildcard_q_zero_returns_406() {
+        let svc = service_fn(handle);
+        let mut svc = Compression::new(svc).compress_when(Always);
+
+        let req = Request::builder()
+            .header("accept-encoding", "*;q=0")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.ready().await.unwrap().call(req).await.unwrap();
+
+        assert_eq!(res.status(), http::StatusCode::NOT_ACCEPTABLE);
+        assert!(res
+            .headers()
+            .get_all(http::header::VARY)
+            .iter()
+            .any(|v| v.to_str().unwrap().contains("accept-encoding")));
+    }
+
+    #[tokio::test]
+    async fn wildcard_q_zero_with_gzip_picks_gzip() {
+        let svc = service_fn(handle);
+        let mut svc = Compression::new(svc).compress_when(Always);
+
+        let req = Request::builder()
+            .header("accept-encoding", "*;q=0,gzip")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.ready().await.unwrap().call(req).await.unwrap();
+
+        assert_eq!(res.status(), http::StatusCode::OK);
+        assert_eq!(
+            res.headers()
+                .get("content-encoding")
+                .and_then(|v| v.to_str().ok()),
+            Some("gzip")
+        );
+    }
+
+    #[tokio::test]
+    async fn wildcard_alone_compresses() {
+        let svc = service_fn(handle);
+        let mut svc = Compression::new(svc).compress_when(Always);
+
+        let req = Request::builder()
+            .header("accept-encoding", "*")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.ready().await.unwrap().call(req).await.unwrap();
+
+        assert_eq!(res.status(), http::StatusCode::OK);
+        // Should pick the best supported encoding (not identity)
+        assert!(res.headers().contains_key(CONTENT_ENCODING));
+    }
+
+    #[tokio::test]
+    async fn identity_q_zero_alone_returns_406() {
+        let svc = service_fn(handle);
+        let mut svc = Compression::new(svc).compress_when(Always);
+
+        let req = Request::builder()
+            .header("accept-encoding", "identity;q=0")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.ready().await.unwrap().call(req).await.unwrap();
+
+        assert_eq!(res.status(), http::StatusCode::NOT_ACCEPTABLE);
+    }
+
+    #[tokio::test]
+    async fn identity_q_zero_with_gzip_picks_gzip() {
+        let svc = service_fn(handle);
+        let mut svc = Compression::new(svc).compress_when(Always);
+
+        let req = Request::builder()
+            .header("accept-encoding", "identity;q=0,gzip")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.ready().await.unwrap().call(req).await.unwrap();
+
+        assert_eq!(res.status(), http::StatusCode::OK);
+        assert_eq!(
+            res.headers()
+                .get("content-encoding")
+                .and_then(|v| v.to_str().ok()),
+            Some("gzip")
+        );
+    }
 }

--- a/tower-http/src/content_encoding.rs
+++ b/tower-http/src/content_encoding.rs
@@ -291,20 +291,23 @@ fn preferred_encoding_with_wildcard(
     // If there is no wildcard, use only the explicitly listed encodings.
     // Per RFC 9110 §12.5.3, if identity is excluded (q=0) and no other encoding is
     // acceptable, the server SHOULD respond with 406.
-    let Some(wildcard_q) = wildcard_q else {
-        let identity_rejected = explicit
-            .iter()
-            .any(|(enc, q)| *enc == Encoding::Identity && q.0 == 0);
-        return match Encoding::preferred_encoding(explicit.into_iter()) {
-            Some(enc) => Some(enc),
-            None => {
-                if identity_rejected {
-                    None
-                } else {
-                    Some(Encoding::Identity)
+    let wildcard_q = match wildcard_q {
+        Some(q) => q,
+        None => {
+            let identity_rejected = explicit
+                .iter()
+                .any(|(enc, q)| *enc == Encoding::Identity && q.0 == 0);
+            return match Encoding::preferred_encoding(explicit.into_iter()) {
+                Some(enc) => Some(enc),
+                None => {
+                    if identity_rejected {
+                        None
+                    } else {
+                        Some(Encoding::Identity)
+                    }
                 }
-            }
-        };
+            };
+        }
     };
 
     // Build the effective set of (encoding, qvalue) for all supported encodings.

--- a/tower-http/src/content_encoding.rs
+++ b/tower-http/src/content_encoding.rs
@@ -96,12 +96,14 @@ impl Encoding {
         feature = "compression-deflate",
     ))]
     // based on https://github.com/http-rs/accept-encoding
+    //
+    // Returns `Some(encoding)` for the best acceptable encoding, or `None` if the client's
+    // preferences cannot be satisfied (406 Not Acceptable per RFC 9110 §12.5.3).
     pub(crate) fn from_headers(
         headers: &http::HeaderMap,
         supported_encoding: impl SupportedEncodings,
-    ) -> Self {
-        Encoding::preferred_encoding(encodings(headers, supported_encoding))
-            .unwrap_or(Encoding::Identity)
+    ) -> Option<Self> {
+        preferred_encoding_with_wildcard(headers, supported_encoding)
     }
 
     #[cfg(any(
@@ -240,6 +242,132 @@ pub(crate) fn encodings<'a>(
         })
 }
 
+/// Extracts the q-value for the `*` wildcard from Accept-Encoding headers.
+/// Returns `None` if no wildcard is present.
+#[cfg(any(
+    feature = "compression-gzip",
+    feature = "compression-br",
+    feature = "compression-zstd",
+    feature = "compression-deflate",
+))]
+fn wildcard_qvalue(headers: &http::HeaderMap) -> Option<QValue> {
+    headers
+        .get_all(http::header::ACCEPT_ENCODING)
+        .iter()
+        .filter_map(|hval| hval.to_str().ok())
+        .flat_map(|s| s.split(','))
+        .find_map(|v| {
+            let mut v = v.splitn(2, ';');
+            let coding = v.next().unwrap().trim();
+            if coding != "*" {
+                return None;
+            }
+            let qval = if let Some(qval) = v.next() {
+                QValue::parse(qval.trim())?
+            } else {
+                QValue::one()
+            };
+            Some(qval)
+        })
+}
+
+/// Selects the preferred encoding considering the `*` wildcard per RFC 9110 §12.5.3.
+///
+/// The wildcard applies its q-value to any encoding not explicitly listed. If all acceptable
+/// encodings (including identity) are excluded, returns `None` to signal 406 Not Acceptable.
+#[cfg(any(
+    feature = "compression-gzip",
+    feature = "compression-br",
+    feature = "compression-zstd",
+    feature = "compression-deflate",
+))]
+fn preferred_encoding_with_wildcard(
+    headers: &http::HeaderMap,
+    supported_encoding: impl SupportedEncodings,
+) -> Option<Encoding> {
+    let explicit: Vec<(Encoding, QValue)> = encodings(headers, supported_encoding).collect();
+    let wildcard_q = wildcard_qvalue(headers);
+
+    // If there is no wildcard, use only the explicitly listed encodings.
+    // Per RFC 9110 §12.5.3, if identity is excluded (q=0) and no other encoding is
+    // acceptable, the server SHOULD respond with 406.
+    let Some(wildcard_q) = wildcard_q else {
+        let identity_rejected = explicit
+            .iter()
+            .any(|(enc, q)| *enc == Encoding::Identity && q.0 == 0);
+        return match Encoding::preferred_encoding(explicit.into_iter()) {
+            Some(enc) => Some(enc),
+            None => {
+                if identity_rejected {
+                    None
+                } else {
+                    Some(Encoding::Identity)
+                }
+            }
+        };
+    };
+
+    // Build the effective set of (encoding, qvalue) for all supported encodings.
+    // For each supported encoding, use its explicit q-value if listed, otherwise the wildcard
+    // q-value.
+    let all_supported = all_supported_encodings(supported_encoding);
+
+    let effective = all_supported.iter().filter_map(|e| *e).map(|enc| {
+        let q = explicit
+            .iter()
+            .find(|(e, _)| *e == enc)
+            .map(|(_, q)| *q)
+            .unwrap_or(wildcard_q);
+        (enc, q)
+    });
+
+    Encoding::preferred_encoding(effective)
+}
+
+/// Returns all encodings the server supports (including Identity) in a fixed-capacity array.
+#[cfg(any(
+    feature = "compression-gzip",
+    feature = "compression-br",
+    feature = "compression-zstd",
+    feature = "compression-deflate",
+))]
+fn all_supported_encodings(supported_encoding: impl SupportedEncodings) -> [Option<Encoding>; 5] {
+    let mut out: [Option<Encoding>; 5] = [None; 5];
+    let mut n = 0;
+
+    macro_rules! push {
+        ($enc:expr) => {
+            out[n] = Some($enc);
+            n += 1;
+        };
+    }
+
+    push!(Encoding::Identity);
+
+    #[cfg(any(feature = "fs", feature = "compression-gzip"))]
+    if supported_encoding.gzip() {
+        push!(Encoding::Gzip);
+    }
+
+    #[cfg(any(feature = "fs", feature = "compression-deflate"))]
+    if supported_encoding.deflate() {
+        push!(Encoding::Deflate);
+    }
+
+    #[cfg(any(feature = "fs", feature = "compression-br"))]
+    if supported_encoding.br() {
+        push!(Encoding::Brotli);
+    }
+
+    #[cfg(any(feature = "fs", feature = "compression-zstd"))]
+    if supported_encoding.zstd() {
+        push!(Encoding::Zstd);
+    }
+
+    let _ = n;
+    out
+}
+
 #[cfg(all(
     test,
     feature = "compression-gzip",
@@ -274,7 +402,7 @@ mod tests {
     #[test]
     fn no_accept_encoding_header() {
         let encoding = Encoding::from_headers(&http::HeaderMap::new(), SupportedEncodingsAll);
-        assert_eq!(Encoding::Identity, encoding);
+        assert_eq!(Some(Encoding::Identity), encoding);
     }
 
     #[test]
@@ -285,7 +413,7 @@ mod tests {
             http::HeaderValue::from_static("gzip"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Gzip, encoding);
+        assert_eq!(Some(Encoding::Gzip), encoding);
     }
 
     #[test]
@@ -296,7 +424,7 @@ mod tests {
             http::HeaderValue::from_static("gzip,br"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Brotli, encoding);
+        assert_eq!(Some(Encoding::Brotli), encoding);
     }
 
     #[test]
@@ -307,7 +435,7 @@ mod tests {
             http::HeaderValue::from_static("gzip,x-gzip"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Gzip, encoding);
+        assert_eq!(Some(Encoding::Gzip), encoding);
     }
 
     #[test]
@@ -318,7 +446,7 @@ mod tests {
             http::HeaderValue::from_static("deflate,x-gzip"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Gzip, encoding);
+        assert_eq!(Some(Encoding::Gzip), encoding);
     }
 
     #[test]
@@ -329,7 +457,7 @@ mod tests {
             http::HeaderValue::from_static("gzip,deflate,br"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Brotli, encoding);
+        assert_eq!(Some(Encoding::Brotli), encoding);
     }
 
     #[test]
@@ -340,7 +468,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=0.5,br"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Brotli, encoding);
+        assert_eq!(Some(Encoding::Brotli), encoding);
     }
 
     #[test]
@@ -351,7 +479,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=0.5,deflate,br"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Brotli, encoding);
+        assert_eq!(Some(Encoding::Brotli), encoding);
     }
 
     #[test]
@@ -366,7 +494,7 @@ mod tests {
             http::HeaderValue::from_static("br"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Brotli, encoding);
+        assert_eq!(Some(Encoding::Brotli), encoding);
     }
 
     #[test]
@@ -381,7 +509,7 @@ mod tests {
             http::HeaderValue::from_static("br"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Brotli, encoding);
+        assert_eq!(Some(Encoding::Brotli), encoding);
     }
 
     #[test]
@@ -400,7 +528,7 @@ mod tests {
             http::HeaderValue::from_static("br"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Brotli, encoding);
+        assert_eq!(Some(Encoding::Brotli), encoding);
     }
 
     #[test]
@@ -411,7 +539,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=0.5,br;q=0.8"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Brotli, encoding);
+        assert_eq!(Some(Encoding::Brotli), encoding);
 
         let mut headers = http::HeaderMap::new();
         headers.append(
@@ -419,7 +547,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=0.8,br;q=0.5"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Gzip, encoding);
+        assert_eq!(Some(Encoding::Gzip), encoding);
 
         let mut headers = http::HeaderMap::new();
         headers.append(
@@ -427,7 +555,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=0.995,br;q=0.999"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Brotli, encoding);
+        assert_eq!(Some(Encoding::Brotli), encoding);
     }
 
     #[test]
@@ -438,7 +566,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=0.5,deflate;q=0.6,br;q=0.8"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Brotli, encoding);
+        assert_eq!(Some(Encoding::Brotli), encoding);
 
         let mut headers = http::HeaderMap::new();
         headers.append(
@@ -446,7 +574,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=0.8,deflate;q=0.6,br;q=0.5"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Gzip, encoding);
+        assert_eq!(Some(Encoding::Gzip), encoding);
 
         let mut headers = http::HeaderMap::new();
         headers.append(
@@ -454,7 +582,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=0.6,deflate;q=0.8,br;q=0.5"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Deflate, encoding);
+        assert_eq!(Some(Encoding::Deflate), encoding);
 
         let mut headers = http::HeaderMap::new();
         headers.append(
@@ -462,7 +590,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=0.995,deflate;q=0.997,br;q=0.999"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Brotli, encoding);
+        assert_eq!(Some(Encoding::Brotli), encoding);
     }
 
     #[test]
@@ -473,7 +601,7 @@ mod tests {
             http::HeaderValue::from_static("invalid,gzip"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Gzip, encoding);
+        assert_eq!(Some(Encoding::Gzip), encoding);
     }
 
     #[test]
@@ -484,7 +612,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=0"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Identity, encoding);
+        assert_eq!(Some(Encoding::Identity), encoding);
 
         let mut headers = http::HeaderMap::new();
         headers.append(
@@ -492,7 +620,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=0."),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Identity, encoding);
+        assert_eq!(Some(Encoding::Identity), encoding);
 
         let mut headers = http::HeaderMap::new();
         headers.append(
@@ -500,7 +628,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=0,br;q=0.5"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Brotli, encoding);
+        assert_eq!(Some(Encoding::Brotli), encoding);
     }
 
     #[test]
@@ -511,7 +639,7 @@ mod tests {
             http::HeaderValue::from_static("gZiP"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Gzip, encoding);
+        assert_eq!(Some(Encoding::Gzip), encoding);
 
         let mut headers = http::HeaderMap::new();
         headers.append(
@@ -519,7 +647,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=0.5,br;Q=0.8"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Brotli, encoding);
+        assert_eq!(Some(Encoding::Brotli), encoding);
     }
 
     #[test]
@@ -530,7 +658,7 @@ mod tests {
             http::HeaderValue::from_static(" gzip\t; q=0.5 ,\tbr ;\tq=0.8\t"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Brotli, encoding);
+        assert_eq!(Some(Encoding::Brotli), encoding);
     }
 
     #[test]
@@ -541,7 +669,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q =0.5"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Identity, encoding);
+        assert_eq!(Some(Encoding::Identity), encoding);
 
         let mut headers = http::HeaderMap::new();
         headers.append(
@@ -549,7 +677,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q= 0.5"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Identity, encoding);
+        assert_eq!(Some(Encoding::Identity), encoding);
     }
 
     #[test]
@@ -560,7 +688,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=-0.1"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Identity, encoding);
+        assert_eq!(Some(Encoding::Identity), encoding);
 
         let mut headers = http::HeaderMap::new();
         headers.append(
@@ -568,7 +696,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=00.5"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Identity, encoding);
+        assert_eq!(Some(Encoding::Identity), encoding);
 
         let mut headers = http::HeaderMap::new();
         headers.append(
@@ -576,7 +704,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=0.5000"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Identity, encoding);
+        assert_eq!(Some(Encoding::Identity), encoding);
 
         let mut headers = http::HeaderMap::new();
         headers.append(
@@ -584,7 +712,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=.5"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Identity, encoding);
+        assert_eq!(Some(Encoding::Identity), encoding);
 
         let mut headers = http::HeaderMap::new();
         headers.append(
@@ -592,7 +720,7 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=1.01"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Identity, encoding);
+        assert_eq!(Some(Encoding::Identity), encoding);
 
         let mut headers = http::HeaderMap::new();
         headers.append(
@@ -600,6 +728,146 @@ mod tests {
             http::HeaderValue::from_static("gzip;q=1.001"),
         );
         let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
-        assert_eq!(Encoding::Identity, encoding);
+        assert_eq!(Some(Encoding::Identity), encoding);
+    }
+
+    #[test]
+    fn wildcard_alone_picks_best_supported() {
+        let mut headers = http::HeaderMap::new();
+        headers.append(
+            http::header::ACCEPT_ENCODING,
+            http::HeaderValue::from_static("*"),
+        );
+        let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
+        // * with q=1 means all encodings are acceptable; picks the highest-priority supported
+        assert_eq!(Some(Encoding::Zstd), encoding);
+    }
+
+    #[test]
+    fn wildcard_q_zero_with_nothing_else_returns_not_satisfiable() {
+        let mut headers = http::HeaderMap::new();
+        headers.append(
+            http::header::ACCEPT_ENCODING,
+            http::HeaderValue::from_static("*;q=0"),
+        );
+        let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
+        // *;q=0 rejects everything, including identity
+        assert_eq!(None, encoding);
+    }
+
+    #[test]
+    fn wildcard_q_zero_with_gzip_picks_gzip() {
+        let mut headers = http::HeaderMap::new();
+        headers.append(
+            http::header::ACCEPT_ENCODING,
+            http::HeaderValue::from_static("*;q=0,gzip"),
+        );
+        let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
+        assert_eq!(Some(Encoding::Gzip), encoding);
+    }
+
+    #[test]
+    fn identity_q_zero_alone_returns_not_satisfiable() {
+        let mut headers = http::HeaderMap::new();
+        headers.append(
+            http::header::ACCEPT_ENCODING,
+            http::HeaderValue::from_static("identity;q=0"),
+        );
+        let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
+        // identity;q=0 with no other encoding explicitly listed: the server cannot
+        // determine what the client accepts, so 406 per RFC 9110 §12.5.3
+        assert_eq!(None, encoding);
+    }
+
+    #[test]
+    fn identity_q_zero_with_gzip_picks_gzip() {
+        let mut headers = http::HeaderMap::new();
+        headers.append(
+            http::header::ACCEPT_ENCODING,
+            http::HeaderValue::from_static("identity;q=0,gzip"),
+        );
+        let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
+        assert_eq!(Some(Encoding::Gzip), encoding);
+    }
+
+    #[test]
+    fn wildcard_q_zero_identity_q_zero_no_compression_returns_not_satisfiable() {
+        // *;q=0,identity;q=0 with no explicit compression listed
+        let mut headers = http::HeaderMap::new();
+        headers.append(
+            http::header::ACCEPT_ENCODING,
+            http::HeaderValue::from_static("*;q=0,identity;q=0"),
+        );
+        let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
+        // Both wildcard and identity are q=0, and no explicit encoding is listed with q>0
+        assert_eq!(None, encoding);
+    }
+
+    #[test]
+    fn wildcard_with_low_qvalue() {
+        let mut headers = http::HeaderMap::new();
+        headers.append(
+            http::header::ACCEPT_ENCODING,
+            http::HeaderValue::from_static("*;q=0.5,gzip;q=1"),
+        );
+        let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
+        // gzip is explicitly q=1, everything else gets q=0.5 from wildcard
+        assert_eq!(Some(Encoding::Gzip), encoding);
+    }
+
+    #[test]
+    fn wildcard_q_zero_with_identity_picks_identity() {
+        let mut headers = http::HeaderMap::new();
+        headers.append(
+            http::header::ACCEPT_ENCODING,
+            http::HeaderValue::from_static("*;q=0,identity"),
+        );
+        let encoding = Encoding::from_headers(&headers, SupportedEncodingsAll);
+        // *;q=0 rejects all, but identity is explicitly listed with q=1
+        assert_eq!(Some(Encoding::Identity), encoding);
+    }
+
+    #[derive(Copy, Clone)]
+    struct SupportedGzipOnly;
+
+    impl SupportedEncodings for SupportedGzipOnly {
+        fn gzip(&self) -> bool {
+            true
+        }
+        fn deflate(&self) -> bool {
+            false
+        }
+        fn br(&self) -> bool {
+            false
+        }
+        fn zstd(&self) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn wildcard_with_partial_server_support_picks_best_available() {
+        let mut headers = http::HeaderMap::new();
+        headers.append(
+            http::header::ACCEPT_ENCODING,
+            http::HeaderValue::from_static("*"),
+        );
+        let encoding = Encoding::from_headers(&headers, SupportedGzipOnly);
+        // Server only supports gzip, so * should pick gzip (not zstd/br)
+        assert_eq!(Some(Encoding::Gzip), encoding);
+    }
+
+    #[test]
+    fn wildcard_q_zero_with_unsupported_encoding_returns_not_satisfiable() {
+        let mut headers = http::HeaderMap::new();
+        headers.append(
+            http::header::ACCEPT_ENCODING,
+            http::HeaderValue::from_static("*;q=0,br"),
+        );
+        let encoding = Encoding::from_headers(&headers, SupportedGzipOnly);
+        // Client wants br, but server only supports gzip. br is not in the
+        // supported set so it's ignored by encodings(). Wildcard rejects
+        // everything else. Result: 406.
+        assert_eq!(None, encoding);
     }
 }


### PR DESCRIPTION
Closes: https://github.com/tower-rs/tower-http/issues/215 (the remaining case in it as best I can tell)

## Motivation

The compression middleware silently ignores the `*` wildcard in Accept-Encoding headers. This means requests like `*;q=0,gzip` (which per RFC 9110 §12.5.3 should select gzip and reject everything else) fall back to identity encoding instead.

Similarly, `identity;q=0` with no other encoding listed should signal that the client cannot accept an uncompressed response, but the middleware happily sends one anyway.

## Solution

`Encoding::from_headers` now returns `Option<Encoding>` where `None` signals that no encoding is satisfiable. A new `preferred_encoding_with_wildcard` function handles the negotiation: when a wildcard is present, its q-value applies as the default for any encoding not explicitly listed. When the resulting acceptable set is empty, the middleware returns 406 Not Acceptable.

The `ResponseFuture` handles the `None` case by overwriting the response status to 406 while passing through the inner service's body unchanged. This avoids introducing a new error type or changing the middleware's `Service` output type.

The `fs` module is unaffected since it uses `preferred_encoding()` directly with its own encoding negotiation logic.

Note: this is a behavioral change for clients sending `identity;q=0` without any other encoding. Previously the middleware would silently return an uncompressed response; now it returns 406. This matches the RFC semantics (the client explicitly rejected the only encoding the server can provide without a compression match) but may surprise users who relied on the old fallback.

That said, we are anyway preparing a breaking change, so we can document this behavior change as part of this.