### PR TITLE
feat(csrf): add cross-origin protection middleware

### DIFF
--- a/tower-http/Cargo.toml
+++ b/tower-http/Cargo.toml
@@ -64,6 +64,7 @@ full = [
     "catch-panic",
     "compression-full",
     "cors",
+    "csrf",
     "decompression-full",
     "follow-redirect",
     "fs",
@@ -89,6 +90,7 @@ add-extension = []
 auth = ["base64", "validate-request"]
 catch-panic = ["tracing", "futures-util/std", "dep:http-body", "dep:http-body-util"]
 cors = []
+csrf = []
 follow-redirect = ["futures-util", "dep:http-body", "dep:url", "tower/util"]
 fs = ["dep:tokio", "tokio?/fs", "tokio?/io-util", "futures-core", "futures-util", "dep:http-body", "dep:http-body-util", "tokio-util/io", "dep:http-range-header", "mime_guess", "mime", "httpdate", "set-status", "futures-util/alloc"]
 limit = ["dep:http-body", "dep:http-body-util"]

--- a/tower-http/src/csrf/future.rs
+++ b/tower-http/src/csrf/future.rs
@@ -56,7 +56,7 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.project().kind.project() {
             KindProj::Future { future } => future.poll(cx),
-            KindProj::Rejected { error, _body } => {
+            KindProj::Rejected { error, .. } => {
                 let error = error
                     .take()
                     .expect("ResponseFuture polled after completion");

--- a/tower-http/src/csrf/future.rs
+++ b/tower-http/src/csrf/future.rs
@@ -1,72 +1,71 @@
 use std::future::Future;
-use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use http::{Response, StatusCode};
 use pin_project_lite::pin_project;
-
-use super::ProtectionError;
 
 pin_project! {
     /// Response future for [`Csrf`].
     ///
     /// [`Csrf`]: super::Csrf
-    pub struct ResponseFuture<F, ResBody> {
+    pub struct ResponseFuture<F>
+    where
+        F: Future,
+    {
         #[pin]
-        kind: Kind<F, ResBody>,
+        kind: Kind<F>,
     }
 }
 
 pin_project! {
     #[project = KindProj]
-    enum Kind<F, ResBody> {
-        Future { #[pin] future: F },
+    enum Kind<F>
+    where
+        F: Future,
+    {
+        Future {
+            #[pin]
+            future: F,
+        },
         Rejected {
-            error: Option<ProtectionError>,
-            _body: PhantomData<ResBody>,
+            response: Option<F::Output>,
         },
     }
 }
 
-impl<F, ResBody> ResponseFuture<F, ResBody> {
+impl<F> ResponseFuture<F>
+where
+    F: Future,
+{
     pub(super) fn future(future: F) -> Self {
         Self {
             kind: Kind::Future { future },
         }
     }
 
-    pub(super) fn rejected(error: ProtectionError) -> Self {
+    pub(super) fn rejected(response: F::Output) -> Self {
         Self {
             kind: Kind::Rejected {
-                error: Some(error),
-                _body: PhantomData,
+                response: Some(response),
             },
         }
     }
 }
 
-impl<F, E, ResBody> Future for ResponseFuture<F, ResBody>
+impl<F> Future for ResponseFuture<F>
 where
-    F: Future<Output = Result<Response<ResBody>, E>>,
-    ResBody: Default,
+    F: Future,
 {
-    type Output = Result<Response<ResBody>, E>;
+    type Output = F::Output;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.project().kind.project() {
             KindProj::Future { future } => future.poll(cx),
-            KindProj::Rejected { error, .. } => {
-                let error = error
+            KindProj::Rejected { response } => Poll::Ready(
+                response
                     .take()
-                    .expect("ResponseFuture polled after completion");
-                let mut response = Response::new(ResBody::default());
-
-                *response.status_mut() = StatusCode::FORBIDDEN;
-                response.extensions_mut().insert(error);
-
-                Poll::Ready(Ok(response))
-            }
+                    .expect("ResponseFuture polled after completion"),
+            ),
         }
     }
 }

--- a/tower-http/src/csrf/future.rs
+++ b/tower-http/src/csrf/future.rs
@@ -1,0 +1,72 @@
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use http::{Response, StatusCode};
+use pin_project_lite::pin_project;
+
+use super::ProtectionError;
+
+pin_project! {
+    /// Response future for [`Csrf`].
+    ///
+    /// [`Csrf`]: super::Csrf
+    pub struct ResponseFuture<F, ResBody> {
+        #[pin]
+        kind: Kind<F, ResBody>,
+    }
+}
+
+pin_project! {
+    #[project = KindProj]
+    enum Kind<F, ResBody> {
+        Future { #[pin] future: F },
+        Rejected {
+            error: Option<ProtectionError>,
+            _body: PhantomData<ResBody>,
+        },
+    }
+}
+
+impl<F, ResBody> ResponseFuture<F, ResBody> {
+    pub(super) fn future(future: F) -> Self {
+        Self {
+            kind: Kind::Future { future },
+        }
+    }
+
+    pub(super) fn rejected(error: ProtectionError) -> Self {
+        Self {
+            kind: Kind::Rejected {
+                error: Some(error),
+                _body: PhantomData,
+            },
+        }
+    }
+}
+
+impl<F, E, ResBody> Future for ResponseFuture<F, ResBody>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+    ResBody: Default,
+{
+    type Output = Result<Response<ResBody>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project().kind.project() {
+            KindProj::Future { future } => future.poll(cx),
+            KindProj::Rejected { error, _body } => {
+                let error = error
+                    .take()
+                    .expect("ResponseFuture polled after completion");
+                let mut response = Response::new(ResBody::default());
+
+                *response.status_mut() = StatusCode::FORBIDDEN;
+                response.extensions_mut().insert(error);
+
+                Poll::Ready(Ok(response))
+            }
+        }
+    }
+}

--- a/tower-http/src/csrf/layer.rs
+++ b/tower-http/src/csrf/layer.rs
@@ -5,7 +5,7 @@ use http::{Method, Uri};
 use tower_layer::Layer;
 
 use super::service::Csrf;
-use super::url::TrustedOrigin;
+use super::url::UriExt;
 use super::{BypassFn, ConfigError, DebugFn, DefaultResponseForProtectionError, Origins};
 
 /// Layer that applies the [`Csrf`] middleware.
@@ -51,19 +51,43 @@ impl CsrfLayer {
 }
 
 impl<T> CsrfLayer<T> {
-    /// Adds a trusted origin that allows all requests with an `Origin` header
-    /// exactly matching the given value.
+    /// Adds a trusted origin that allows all requests whose `Origin` header
+    /// matches the given value.
     ///
-    /// Origin values are of the form `scheme://host[:port]`. Default ports
-    /// (`80` for `http`, `443` for `https`) and casing are normalized; paths,
-    /// queries, and fragments are rejected.
+    /// The value is matched **byte-for-byte** against the request's `Origin`
+    /// header — there is no normalization (this mirrors the Go reference). It
+    /// must therefore be written exactly as a browser sends it:
+    ///
+    /// - form `scheme://host[:port]`, where `scheme` is `http` or `https`;
+    /// - the host lowercased (browsers lowercase it; IDN hosts must be given in
+    ///   punycode, e.g. `xn--exmple-cua.com`);
+    /// - **default ports omitted** — browsers drop `:80`/`:443`, so an explicit
+    ///   default port (e.g. `https://example.com:443`) will never match;
+    /// - **no trailing slash**, path, query, or fragment.
+    ///
+    /// Inputs that can't represent a browser `Origin` are rejected with a
+    /// [`ConfigError`]; inputs that parse but aren't in the canonical browser
+    /// form above are accepted but will silently never match.
+    ///
+    /// ```
+    /// # use tower_http::csrf::CsrfLayer;
+    /// // Matches `Origin: https://example.com`:
+    /// let layer = CsrfLayer::new().add_trusted_origin("https://example.com")?;
+    ///
+    /// // Accepted, but never matches a browser Origin (explicit default port):
+    /// let layer = CsrfLayer::new().add_trusted_origin("https://example.com:443")?;
+    /// # Ok::<_, tower_http::csrf::ConfigError>(())
+    /// ```
     pub fn add_trusted_origin<S: AsRef<str>>(mut self, origin: S) -> Result<Self, ConfigError> {
-        let normalized = TrustedOrigin::parse(origin.as_ref())?.into_canonical();
+        let origin = origin.as_ref();
+
+        // validate the form; the origin is stored and matched verbatim.
+        Uri::parse_origin(origin)?;
 
         #[cfg(feature = "tracing")]
-        tracing::debug!(origin = %normalized, "added trusted origin");
+        tracing::debug!(origin = %origin, "added trusted origin");
 
-        self.trusted_origins.insert(normalized);
+        self.trusted_origins.insert(origin.to_owned());
 
         Ok(self)
     }

--- a/tower-http/src/csrf/layer.rs
+++ b/tower-http/src/csrf/layer.rs
@@ -114,9 +114,10 @@ impl<T> CsrfLayer<T> {
     ///
     /// Accepts any type that implements [`ResponseForProtectionError`](super::ResponseForProtectionError),
     /// including a `FnMut(ProtectionError) -> Response<B> + Clone` closure.
-    /// The default builder returns a `403 Forbidden` with an empty body and
-    /// the [`ProtectionError`](super::ProtectionError) attached to the
-    /// response's extensions.
+    /// The default builder returns a `403 Forbidden` with an empty body.
+    /// Regardless of the builder, [`Csrf`](super::Csrf) attaches the
+    /// [`ProtectionError`](super::ProtectionError) to the response's extensions,
+    /// so a custom builder need not re-attach it.
     pub fn with_rejection_response<R>(self, rejection_response: R) -> CsrfLayer<R>
     where
         R: Clone,

--- a/tower-http/src/csrf/layer.rs
+++ b/tower-http/src/csrf/layer.rs
@@ -1,0 +1,85 @@
+use std::fmt::{self, Debug, Formatter};
+use std::sync::Arc;
+
+use http::{Method, Uri};
+use tower_layer::Layer;
+
+use super::service::Csrf;
+use super::url::TrustedOrigin;
+use super::{BypassFn, ConfigError, DebugFn, Origins};
+
+/// Layer that applies the [`Csrf`] middleware.
+///
+/// See the [module docs](crate::csrf) for an example.
+#[derive(Clone, Default)]
+#[must_use]
+pub struct CsrfLayer {
+    insecure_bypass: Option<Arc<BypassFn>>,
+    trusted_origins: Origins,
+}
+
+impl Debug for CsrfLayer {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CsrfLayer")
+            .field(
+                "insecure_bypass",
+                &self.insecure_bypass.as_ref().map(|_| DebugFn),
+            )
+            .field("trusted_origins", &self.trusted_origins)
+            .finish()
+    }
+}
+
+impl CsrfLayer {
+    /// Creates a new `CsrfLayer` with no trusted origins and no bypass.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a trusted origin that allows all requests with an `Origin` header
+    /// exactly matching the given value.
+    ///
+    /// Origin values are of the form `scheme://host[:port]`. Default ports
+    /// (`80` for `http`, `443` for `https`) and casing are normalized; paths,
+    /// queries, and fragments are rejected.
+    pub fn add_trusted_origin<S: AsRef<str>>(mut self, origin: S) -> Result<Self, ConfigError> {
+        let normalized = TrustedOrigin::parse(origin.as_ref())?.into_canonical();
+
+        #[cfg(feature = "tracing")]
+        tracing::debug!(origin = %normalized, "added trusted origin");
+
+        self.trusted_origins.insert(normalized);
+
+        Ok(self)
+    }
+
+    /// Adds a bypass predicate that returns `true` for requests which should
+    /// skip CSRF protection.
+    ///
+    /// This is an escape hatch for endpoints that legitimately need to accept
+    /// cross-origin POSTs (e.g. webhook receivers). Bypassed endpoints must
+    /// have their own protection (signed payloads, authentication tokens,
+    /// etc.) — otherwise they are CSRF-vulnerable.
+    pub fn with_insecure_bypass<F>(mut self, predicate: F) -> CsrfLayer
+    where
+        F: Fn(&Method, &Uri) -> bool + Send + Sync + 'static,
+    {
+        #[cfg(feature = "tracing")]
+        tracing::debug!("added insecure bypass");
+
+        self.insecure_bypass = Some(Arc::new(predicate));
+        self
+    }
+}
+
+impl<S> Layer<S> for CsrfLayer {
+    type Service = Csrf<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Csrf::new(
+            inner,
+            self.insecure_bypass.clone(),
+            self.trusted_origins.clone(),
+        )
+    }
+}

--- a/tower-http/src/csrf/layer.rs
+++ b/tower-http/src/csrf/layer.rs
@@ -6,19 +6,30 @@ use tower_layer::Layer;
 
 use super::service::Csrf;
 use super::url::TrustedOrigin;
-use super::{BypassFn, ConfigError, DebugFn, Origins};
+use super::{BypassFn, ConfigError, DebugFn, DefaultResponseForProtectionError, Origins};
 
 /// Layer that applies the [`Csrf`] middleware.
 ///
 /// See the [module docs](crate::csrf) for an example.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 #[must_use]
-pub struct CsrfLayer {
+pub struct CsrfLayer<T = DefaultResponseForProtectionError> {
     insecure_bypass: Option<Arc<BypassFn>>,
+    rejection_response: T,
     trusted_origins: Origins,
 }
 
-impl Debug for CsrfLayer {
+impl Default for CsrfLayer {
+    fn default() -> Self {
+        Self {
+            insecure_bypass: None,
+            rejection_response: DefaultResponseForProtectionError,
+            trusted_origins: Origins::default(),
+        }
+    }
+}
+
+impl<T> Debug for CsrfLayer<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("CsrfLayer")
             .field(
@@ -26,16 +37,20 @@ impl Debug for CsrfLayer {
                 &self.insecure_bypass.as_ref().map(|_| DebugFn),
             )
             .field("trusted_origins", &self.trusted_origins)
+            .field("rejection_response", &DebugFn)
             .finish()
     }
 }
 
 impl CsrfLayer {
-    /// Creates a new `CsrfLayer` with no trusted origins and no bypass.
+    /// Creates a new `CsrfLayer` with no trusted origins, no bypass, and the
+    /// default rejection response.
     pub fn new() -> Self {
         Self::default()
     }
+}
 
+impl<T> CsrfLayer<T> {
     /// Adds a trusted origin that allows all requests with an `Origin` header
     /// exactly matching the given value.
     ///
@@ -60,7 +75,7 @@ impl CsrfLayer {
     /// cross-origin POSTs (e.g. webhook receivers). Bypassed endpoints must
     /// have their own protection (signed payloads, authentication tokens,
     /// etc.) — otherwise they are CSRF-vulnerable.
-    pub fn with_insecure_bypass<F>(mut self, predicate: F) -> CsrfLayer
+    pub fn with_insecure_bypass<F>(mut self, predicate: F) -> Self
     where
         F: Fn(&Method, &Uri) -> bool + Send + Sync + 'static,
     {
@@ -70,15 +85,34 @@ impl CsrfLayer {
         self.insecure_bypass = Some(Arc::new(predicate));
         self
     }
+
+    /// Replaces the response builder used when a request is rejected.
+    ///
+    /// Accepts any type that implements [`ResponseForProtectionError`],
+    /// including a `FnMut(ProtectionError) -> Response<B> + Clone` closure.
+    /// The default builder returns a `403 Forbidden` with an empty body and
+    /// the [`ProtectionError`](super::ProtectionError) attached to the
+    /// response's extensions.
+    pub fn with_rejection_response<R>(self, rejection_response: R) -> CsrfLayer<R> {
+        CsrfLayer {
+            insecure_bypass: self.insecure_bypass,
+            trusted_origins: self.trusted_origins,
+            rejection_response,
+        }
+    }
 }
 
-impl<S> Layer<S> for CsrfLayer {
-    type Service = Csrf<S>;
+impl<S, T> Layer<S> for CsrfLayer<T>
+where
+    T: Clone,
+{
+    type Service = Csrf<S, T>;
 
     fn layer(&self, inner: S) -> Self::Service {
         Csrf::new(
             inner,
             self.insecure_bypass.clone(),
+            self.rejection_response.clone(),
             self.trusted_origins.clone(),
         )
     }

--- a/tower-http/src/csrf/layer.rs
+++ b/tower-http/src/csrf/layer.rs
@@ -88,7 +88,7 @@ impl<T> CsrfLayer<T> {
 
     /// Replaces the response builder used when a request is rejected.
     ///
-    /// Accepts any type that implements [`ResponseForProtectionError`],
+    /// Accepts any type that implements [`ResponseForProtectionError`](super::ResponseForProtectionError),
     /// including a `FnMut(ProtectionError) -> Response<B> + Clone` closure.
     /// The default builder returns a `403 Forbidden` with an empty body and
     /// the [`ProtectionError`](super::ProtectionError) attached to the

--- a/tower-http/src/csrf/layer.rs
+++ b/tower-http/src/csrf/layer.rs
@@ -117,7 +117,10 @@ impl<T> CsrfLayer<T> {
     /// The default builder returns a `403 Forbidden` with an empty body and
     /// the [`ProtectionError`](super::ProtectionError) attached to the
     /// response's extensions.
-    pub fn with_rejection_response<R>(self, rejection_response: R) -> CsrfLayer<R> {
+    pub fn with_rejection_response<R>(self, rejection_response: R) -> CsrfLayer<R>
+    where
+        R: Clone,
+    {
         CsrfLayer {
             insecure_bypass: self.insecure_bypass,
             trusted_origins: self.trusted_origins,

--- a/tower-http/src/csrf/mod.rs
+++ b/tower-http/src/csrf/mod.rs
@@ -330,10 +330,40 @@ mod tests {
         let res = svc.oneshot(req).await.unwrap();
 
         assert_eq!(res.status(), StatusCode::IM_A_TEAPOT);
+        assert_ne!(res.status(), StatusCode::OK);
         assert!(res.extensions().get::<ProtectionError>().is_none());
 
         let body = to_bytes(res.into_body()).await.unwrap();
         assert_eq!(&body[..], b"denied");
+    }
+
+    #[tokio::test]
+    async fn test_service_custom_rejection_response_not_invoked_when_allowed() {
+        let svc = CsrfLayer::new()
+            .add_trusted_origin("https://example.com")
+            .unwrap()
+            .with_rejection_response(|_err: ProtectionError| {
+                let mut res = Response::new(Body::from("denied"));
+                *res.status_mut() = StatusCode::IM_A_TEAPOT;
+                res
+            })
+            .layer(echo_service());
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/bar")
+            .header("origin", "https://example.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_ne!(res.status(), StatusCode::IM_A_TEAPOT);
+        assert!(res.extensions().get::<ProtectionError>().is_none());
+
+        let body = to_bytes(res.into_body()).await.unwrap();
+        assert_eq!(&body[..], b"bar");
     }
 
     #[test]

--- a/tower-http/src/csrf/mod.rs
+++ b/tower-http/src/csrf/mod.rs
@@ -11,8 +11,8 @@
 //! 2. The `Origin` header byte-for-byte matches an allow-listed trusted origin.
 //! 3. `Sec-Fetch-Site` is `same-origin` or `none`.
 //! 4. Neither `Sec-Fetch-Site` nor `Origin` is present.
-//! 5. The `Origin`'s authority (host and any port) matches the `Host` header
-//!    byte-for-byte.
+//! 5. The `Origin`'s authority (host and any port) matches the request's effective
+//!    host byte-for-byte (the request-target authority if present, else `Host`).
 //!
 //! Rejected requests receive a `403 Forbidden` response. The originating
 //! [`ProtectionError`] is attached to the response's extensions — on every
@@ -615,13 +615,32 @@ mod tests {
                 )),
             },
             Test {
-                // The Host header is compared verbatim when present (no fallback
-                // to the URI authority, no validation), so a malformed Host can
-                // never match a well-formed Origin authority.
+                // No request-target authority, so the Host header is the effective
+                // host, compared verbatim — a malformed Host never matches an Origin.
                 name: "malformed host header compared verbatim",
-                uri: "https://example.com/path",
+                uri: "/path",
                 host: Some("not a valid authority"),
                 origin: "https://example.com",
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+                )),
+            },
+            Test {
+                // RFC 7230 §5.3 / Go parity: the request-target authority is the
+                // effective host (Host header ignored); here it matches Origin.
+                name: "request-target authority wins over host header (match)",
+                uri: "https://example.com/path",
+                host: Some("other.example"),
+                origin: "https://example.com",
+                result: Ok(()),
+            },
+            Test {
+                // Security-relevant: Origin matches the Host header but not the
+                // winning request-target authority, so it stays cross-origin.
+                name: "origin matching host header but not authority is rejected",
+                uri: "https://example.com/path",
+                host: Some("other.example"),
+                origin: "https://other.example",
                 result: Err(ProtectionError::new(
                     ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
                 )),

--- a/tower-http/src/csrf/mod.rs
+++ b/tower-http/src/csrf/mod.rs
@@ -15,10 +15,10 @@
 //!    byte-for-byte.
 //!
 //! Rejected requests receive a `403 Forbidden` response. The originating
-//! [`ProtectionError`] is attached to the response's extensions so handlers can
-//! distinguish between explicit cross-origin rejections and conservative
-//! fallback rejections (e.g. requests from old browsers without
-//! `Sec-Fetch-Site`). Use
+//! [`ProtectionError`] is attached to the response's extensions — on every
+//! rejection, including those from a custom builder — so surrounding layers can
+//! distinguish explicit cross-origin rejections from conservative fallback
+//! rejections (e.g. requests from old browsers without `Sec-Fetch-Site`). Use
 //! [`CsrfLayer::with_rejection_response`](CsrfLayer::with_rejection_response)
 //! to replace the rejection response with a custom builder.
 //!
@@ -167,9 +167,10 @@ impl std::error::Error for ConfigError {}
 
 /// Reason a request was rejected by [`Csrf`].
 ///
-/// Retrieve the category with [`ProtectionError::kind`]. Attached to the
-/// `403 Forbidden` response's extensions so handlers can distinguish explicit
-/// cross-origin rejections from conservative fallback rejections.
+/// Retrieve the category with [`ProtectionError::kind`]. [`Csrf`] attaches it to
+/// every `403 Forbidden` rejection response's extensions so surrounding layers
+/// can distinguish explicit cross-origin rejections from conservative fallback
+/// rejections.
 ///
 /// This is an opaque struct rather than an enum so future variants can carry
 /// additional context without a breaking change; match on [`kind`] instead.
@@ -373,7 +374,14 @@ mod tests {
 
         assert_eq!(res.status(), StatusCode::IM_A_TEAPOT);
         assert_ne!(res.status(), StatusCode::OK);
-        assert!(res.extensions().get::<ProtectionError>().is_none());
+        // The middleware attaches the error even though a custom builder
+        // produced the response.
+        assert_eq!(
+            res.extensions().get::<ProtectionError>(),
+            Some(&ProtectionError::new(
+                ProtectionErrorKind::CrossOriginRequestFromOldBrowser
+            )),
+        );
 
         let body = to_bytes(res.into_body()).await.unwrap();
         assert_eq!(&body[..], b"denied");

--- a/tower-http/src/csrf/mod.rs
+++ b/tower-http/src/csrf/mod.rs
@@ -17,7 +17,9 @@
 //! [`ProtectionError`] is attached to the response's extensions so handlers can
 //! distinguish between explicit cross-origin rejections and conservative
 //! fallback rejections (e.g. requests from old browsers without
-//! `Sec-Fetch-Site`).
+//! `Sec-Fetch-Site`). Use
+//! [`CsrfLayer::with_rejection_response`](CsrfLayer::with_rejection_response)
+//! to replace the rejection response with a custom builder.
 //!
 //! # Deployment caveat
 //!
@@ -92,11 +94,13 @@ use http::{Method, Uri};
 
 mod future;
 mod layer;
+mod response;
 mod service;
 mod url;
 
 pub use self::future::ResponseFuture;
 pub use self::layer::CsrfLayer;
+pub use self::response::{DefaultResponseForProtectionError, ResponseForProtectionError};
 pub use self::service::Csrf;
 
 /// Errors that can occur while configuring [`CsrfLayer`].
@@ -306,6 +310,32 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_service_uses_custom_rejection_response() {
+        let svc = CsrfLayer::new()
+            .with_rejection_response(|_err: ProtectionError| {
+                let mut res = Response::new(Body::from("denied"));
+                *res.status_mut() = StatusCode::IM_A_TEAPOT;
+                res
+            })
+            .layer(echo_service());
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/bar")
+            .header("origin", "https://malicious.example")
+            .body(Body::empty())
+            .unwrap();
+
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::IM_A_TEAPOT);
+        assert!(res.extensions().get::<ProtectionError>().is_none());
+
+        let body = to_bytes(res.into_body()).await.unwrap();
+        assert_eq!(&body[..], b"denied");
+    }
+
     #[test]
     fn test_layer_add_trusted_origin() {
         // Smoke check that the layer threads parse_origin's Ok and Err
@@ -408,14 +438,14 @@ mod tests {
 
         assert_eq!(
             format!("{:?}", middleware),
-            "Csrf { inner: (), insecure_bypass: Some(<fn>), trusted_origins: Origins({}) }"
+            "Csrf { inner: (), insecure_bypass: Some(<fn>), trusted_origins: Origins({}), rejection_response: <fn> }"
         );
 
         let middleware = layer.layer(());
 
         assert_eq!(
             format!("{:?}", middleware),
-            "Csrf { inner: (), insecure_bypass: None, trusted_origins: Origins({}) }"
+            "Csrf { inner: (), insecure_bypass: None, trusted_origins: Origins({}), rejection_response: <fn> }"
         );
     }
 

--- a/tower-http/src/csrf/mod.rs
+++ b/tower-http/src/csrf/mod.rs
@@ -215,10 +215,96 @@ impl Origins {
 
 #[cfg(test)]
 mod tests {
-    use http::Request;
+    use std::convert::Infallible;
+
+    use http::{Request, Response, StatusCode};
+    use tower::{service_fn, ServiceExt};
     use tower_layer::Layer;
 
     use super::*;
+    use crate::test_helpers::{to_bytes, Body};
+
+    fn echo_service() -> impl tower::Service<
+        Request<Body>,
+        Response = Response<Body>,
+        Error = Infallible,
+        Future = impl std::future::Future<Output = Result<Response<Body>, Infallible>>,
+    > + Clone {
+        service_fn(|req: Request<Body>| async move {
+            let body: Body = match req.uri().path() {
+                "/foo" => "foo".into(),
+                "/bar" => "bar".into(),
+                _ => Body::empty(),
+            };
+            Ok::<_, Infallible>(Response::new(body))
+        })
+    }
+
+    #[tokio::test]
+    async fn test_service_allows_safe_method() {
+        let svc = CsrfLayer::new()
+            .add_trusted_origin("https://example.com")
+            .unwrap()
+            .layer(echo_service());
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/foo")
+            .body(Body::empty())
+            .unwrap();
+
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body = to_bytes(res.into_body()).await.unwrap();
+        assert_eq!(&body[..], b"foo");
+    }
+
+    #[tokio::test]
+    async fn test_service_allows_post_from_trusted_origin() {
+        let svc = CsrfLayer::new()
+            .add_trusted_origin("https://example.com")
+            .unwrap()
+            .layer(echo_service());
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/bar")
+            .header("origin", "https://example.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body = to_bytes(res.into_body()).await.unwrap();
+        assert_eq!(&body[..], b"bar");
+    }
+
+    #[tokio::test]
+    async fn test_service_rejects_post_from_untrusted_origin() {
+        let svc = CsrfLayer::new()
+            .add_trusted_origin("https://example.com")
+            .unwrap()
+            .layer(echo_service());
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/bar")
+            .header("origin", "https://malicious.example")
+            .body(Body::empty())
+            .unwrap();
+
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            res.extensions().get::<ProtectionError>(),
+            Some(&ProtectionError::CrossOriginRequestFromOldBrowser),
+        );
+    }
 
     #[test]
     fn test_layer_add_trusted_origin() {

--- a/tower-http/src/csrf/mod.rs
+++ b/tower-http/src/csrf/mod.rs
@@ -31,11 +31,11 @@
 //! # Example
 //!
 //! ```
-//! use tower_http::csrf::CsrfLayer;
+//! use bytes::Bytes;
 //! use http::{Request, Response, StatusCode};
 //! use http_body_util::Full;
-//! use bytes::Bytes;
 //! use tower::{Service, ServiceExt, ServiceBuilder, service_fn, BoxError};
+//! use tower_http::csrf::CsrfLayer;
 //!
 //! async fn handle(_: Request<Full<Bytes>>) -> Result<Response<Full<Bytes>>, BoxError> {
 //!     Ok(Response::new(Full::default()))
@@ -56,7 +56,9 @@
 //!     .uri("/")
 //!     .body(Full::default())
 //!     .unwrap();
+//!
 //! let response = service.ready().await?.call(request).await?;
+//!
 //! assert_eq!(response.status(), StatusCode::OK);
 //!
 //! // Cross-site POSTs are blocked.
@@ -67,8 +69,11 @@
 //!     .header("sec-fetch-site", "cross-site")
 //!     .body(Full::default())
 //!     .unwrap();
+//!
 //! let response = service.ready().await?.call(request).await?;
+//!
 //! assert_eq!(response.status(), StatusCode::FORBIDDEN);
+//!
 //! # Ok(())
 //! # }
 //! ```

--- a/tower-http/src/csrf/mod.rs
+++ b/tower-http/src/csrf/mod.rs
@@ -8,10 +8,11 @@
 //! Requests are allowed if any of the following hold:
 //!
 //! 1. The method is `GET`, `HEAD`, or `OPTIONS`.
-//! 2. The `Origin` header matches an allow-listed trusted origin.
+//! 2. The `Origin` header byte-for-byte matches an allow-listed trusted origin.
 //! 3. `Sec-Fetch-Site` is `same-origin` or `none`.
 //! 4. Neither `Sec-Fetch-Site` nor `Origin` is present.
-//! 5. The `Origin` host (with effective port) matches the `Host` header.
+//! 5. The `Origin`'s authority (host and any port) matches the `Host` header
+//!    byte-for-byte.
 //!
 //! Rejected requests receive a `403 Forbidden` response. The originating
 //! [`ProtectionError`] is attached to the response's extensions so handlers can
@@ -204,16 +205,27 @@ impl Debug for DebugFn {
     }
 }
 
-#[derive(Clone, Debug, Default)]
-struct Origins(Arc<HashSet<String>>);
+#[derive(Clone, Default)]
+struct Origins(Arc<HashSet<Vec<u8>>>);
 
 impl Origins {
-    fn contains(&self, origin: &str) -> bool {
+    fn contains(&self, origin: &[u8]) -> bool {
         self.0.contains(origin)
     }
 
-    fn insert(&mut self, origin: impl Into<String>) {
+    fn insert(&mut self, origin: impl Into<Vec<u8>>) {
         Arc::make_mut(&mut self.0).insert(origin.into());
+    }
+}
+
+impl Debug for Origins {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        // render trusted origins as utf-h strings
+        write!(f, "Origins(")?;
+        f.debug_set()
+            .entries(self.0.iter().map(|o| String::from_utf8_lossy(o)))
+            .finish()?;
+        write!(f, ")")
     }
 }
 
@@ -521,18 +533,20 @@ mod tests {
                 result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
             },
             Test {
+                // Strict byte match: an explicit default port does not equal an
+                // implicit one (the reference does not normalize ports).
                 name: "origin has explicit default, host implicit",
                 uri: "/",
                 host: Some("example.com"),
                 origin: "https://example.com:443",
-                result: Ok(()),
+                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
             },
             Test {
                 name: "host has explicit default, origin implicit",
                 uri: "/",
                 host: Some("example.com:443"),
                 origin: "https://example.com",
-                result: Ok(()),
+                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
             },
             Test {
                 name: "host implicit, origin explicit non-default",
@@ -549,11 +563,14 @@ mod tests {
                 result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
             },
             Test {
-                name: "unparseable host falls back to uri authority",
+                // The Host header is compared verbatim when present (no fallback
+                // to the URI authority, no validation), so a malformed Host can
+                // never match a well-formed Origin authority.
+                name: "malformed host header compared verbatim",
                 uri: "https://example.com/path",
                 host: Some("not a valid authority"),
                 origin: "https://example.com",
-                result: Ok(()),
+                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
             },
             Test {
                 name: "missing host, uri carries authority (match)",
@@ -822,41 +839,47 @@ mod tests {
     }
 
     #[test]
-    fn test_middleware_trusted_origin_normalization() {
-        // Each row inserts a non-canonical form of the trusted origin and
-        // sends a request bearing the canonical browser-style Origin header;
-        // the test fails if canonicalization is dropped on either side.
+    fn test_middleware_trusted_origin_strict_byte_match() {
+        // Trusted origins are matched byte-for-byte against the request's Origin
+        // header (no canonicalization), mirroring the Go reference. Only an exact
+        // match is trusted; case- and port-form variants are not.
         struct Test {
             name: &'static str,
             trusted: &'static str,
             origin: &'static str,
+            result: Result<(), ProtectionError>,
         }
 
         let tests = [
             Test {
-                name: "scheme and host case folded",
-                trusted: "HTTPS://Example.COM",
+                name: "exact match trusted",
+                trusted: "https://example.com",
                 origin: "https://example.com",
+                result: Ok(()),
             },
             Test {
-                name: "trailing slash stripped",
-                trusted: "https://example.com/",
-                origin: "https://example.com",
-            },
-            Test {
-                name: "default https port stripped",
-                trusted: "https://example.com:443",
-                origin: "https://example.com",
-            },
-            Test {
-                name: "default http port stripped",
-                trusted: "http://example.com:80",
-                origin: "http://example.com",
-            },
-            Test {
-                name: "non-default port preserved",
+                name: "exact match with non-default port",
                 trusted: "https://example.com:8443",
                 origin: "https://example.com:8443",
+                result: Ok(()),
+            },
+            Test {
+                name: "host case mismatch not trusted",
+                trusted: "https://Example.COM",
+                origin: "https://example.com",
+                result: Err(ProtectionError::CrossOriginRequest),
+            },
+            Test {
+                name: "explicit default port not trusted against bare origin",
+                trusted: "https://example.com:443",
+                origin: "https://example.com",
+                result: Err(ProtectionError::CrossOriginRequest),
+            },
+            Test {
+                name: "bare trusted not matched by explicit-default-port origin",
+                trusted: "https://example.com",
+                origin: "https://example.com:443",
+                result: Err(ProtectionError::CrossOriginRequest),
             },
         ];
 
@@ -874,7 +897,7 @@ mod tests {
                 .body(())
                 .unwrap();
 
-            assert_eq!(middleware.verify(&req), Ok(()), "{}", test.name);
+            assert_eq!(middleware.verify(&req), test.result, "{}", test.name);
         }
     }
 }

--- a/tower-http/src/csrf/mod.rs
+++ b/tower-http/src/csrf/mod.rs
@@ -1,0 +1,729 @@
+//! Modern protection against [cross-site request forgery] (CSRF) attacks.
+//!
+//! This middleware implements the CSRF protection scheme [introduced in Go 1.25][go]
+//! and described in [Filippo Valsorda's blog post][filippo]. It relies on the
+//! [`Sec-Fetch-Site`] and [`Origin`] request headers and requires no
+//! per-request token state.
+//!
+//! Requests are allowed if any of the following hold:
+//!
+//! 1. The method is `GET`, `HEAD`, or `OPTIONS`.
+//! 2. The `Origin` header matches an allow-listed trusted origin.
+//! 3. `Sec-Fetch-Site` is `same-origin` or `none`.
+//! 4. Neither `Sec-Fetch-Site` nor `Origin` is present.
+//! 5. The `Origin` host (with effective port) matches the `Host` header.
+//!
+//! Rejected requests receive a `403 Forbidden` response. The originating
+//! [`ProtectionError`] is attached to the response's extensions so handlers can
+//! distinguish between explicit cross-origin rejections and conservative
+//! fallback rejections (e.g. requests from old browsers without
+//! `Sec-Fetch-Site`).
+//!
+//! # Deployment caveat
+//!
+//! The middleware trusts whatever `Origin` and `Host` reach it. Reverse proxies
+//! and load balancers that rewrite `Host` (e.g. to an internal hostname) or
+//! strip `Origin` silently degrade the protection: the `Origin`/`Host`
+//! fallback can no longer match, and `Sec-Fetch-Site` becomes the only
+//! remaining line of defense. Configure intermediaries to forward both headers
+//! unchanged.
+//!
+//! # Example
+//!
+//! ```
+//! use tower_http::csrf::CsrfLayer;
+//! use http::{Request, Response, StatusCode};
+//! use http_body_util::Full;
+//! use bytes::Bytes;
+//! use tower::{Service, ServiceExt, ServiceBuilder, service_fn, BoxError};
+//!
+//! async fn handle(_: Request<Full<Bytes>>) -> Result<Response<Full<Bytes>>, BoxError> {
+//!     Ok(Response::new(Full::default()))
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), BoxError> {
+//! let layer = CsrfLayer::new()
+//!     .add_trusted_origin("https://example.com")?;
+//!
+//! let mut service = ServiceBuilder::new()
+//!     .layer(layer)
+//!     .service_fn(handle);
+//!
+//! // Safe methods always pass.
+//! let request = Request::builder()
+//!     .method("GET")
+//!     .uri("/")
+//!     .body(Full::default())
+//!     .unwrap();
+//! let response = service.ready().await?.call(request).await?;
+//! assert_eq!(response.status(), StatusCode::OK);
+//!
+//! // Cross-site POSTs are blocked.
+//! let request = Request::builder()
+//!     .method("POST")
+//!     .uri("/")
+//!     .header("host", "example.com")
+//!     .header("sec-fetch-site", "cross-site")
+//!     .body(Full::default())
+//!     .unwrap();
+//! let response = service.ready().await?.call(request).await?;
+//! assert_eq!(response.status(), StatusCode::FORBIDDEN);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [cross-site request forgery]: https://developer.mozilla.org/en-US/docs/Glossary/CSRF
+//! [filippo]: https://words.filippo.io/csrf/
+//! [go]: https://pkg.go.dev/net/http#CrossOriginProtection
+//! [`Sec-Fetch-Site`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site
+//! [`Origin`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin
+
+use std::collections::HashSet;
+use std::fmt::{self, Debug, Formatter};
+use std::sync::Arc;
+
+use http::{Method, Uri};
+
+mod future;
+mod layer;
+mod service;
+mod url;
+
+pub use self::future::ResponseFuture;
+pub use self::layer::CsrfLayer;
+pub use self::service::Csrf;
+
+/// Errors that can occur while configuring [`CsrfLayer`].
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ConfigError {
+    /// The origin string could not be parsed as a URI.
+    InvalidOriginUrl {
+        /// The offending origin string.
+        origin: String,
+        /// The parser error message.
+        message: String,
+    },
+
+    /// An origin URL containing a path, query, or fragment was added as a
+    /// trusted origin.
+    InvalidOriginUrlComponents {
+        /// The offending origin string.
+        origin: String,
+    },
+
+    /// An origin with a scheme other than `http` or `https` (e.g. `file://`,
+    /// `mailto:`, or a bare host with no scheme) was added as a trusted
+    /// origin. Such origins can never match a browser-supplied request
+    /// `Origin`.
+    OpaqueOrigin {
+        /// The offending origin string.
+        origin: String,
+    },
+
+    /// A trusted origin contained non-ASCII characters. Browsers send IDN
+    /// hostnames in punycode form, so the configured value must use the
+    /// punycode form (e.g. `xn--exmple-cua.com`) to ever match.
+    NonAsciiHostname {
+        /// The offending origin string.
+        origin: String,
+    },
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ConfigError::InvalidOriginUrl { origin, message } => {
+                write!(f, "invalid origin {origin:?}: {message}")
+            }
+            ConfigError::InvalidOriginUrlComponents { origin } => write!(
+                f,
+                "invalid origin {origin:?}: path, query, and fragment are not allowed"
+            ),
+            ConfigError::OpaqueOrigin { origin } => write!(
+                f,
+                "invalid origin {origin:?}: scheme must be http or https"
+            ),
+            ConfigError::NonAsciiHostname { origin } => write!(
+                f,
+                "invalid origin {origin:?}: non-ASCII hostnames must be supplied in punycode (xn--…)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+/// Reason a request was rejected by [`Csrf`].
+///
+/// Attached to the `403 Forbidden` response's extensions so handlers can
+/// distinguish between explicit cross-origin rejections and conservative
+/// fallback rejections.
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ProtectionError {
+    /// A cross-origin request was detected via `Sec-Fetch-Site`.
+    CrossOriginRequest,
+
+    /// A request without `Sec-Fetch-Site` failed the `Origin`/`Host` fallback
+    /// check. Modern browsers always send `Sec-Fetch-Site`, so this typically
+    /// means the request came from an old browser or non-browser client.
+    CrossOriginRequestFromOldBrowser,
+}
+
+impl fmt::Display for ProtectionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ProtectionError::CrossOriginRequest => f.write_str("Cross-Origin request detected"),
+            ProtectionError::CrossOriginRequestFromOldBrowser => {
+                f.write_str("Cross-Origin request from old browser detected")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ProtectionError {}
+
+type BypassFn = dyn Fn(&Method, &Uri) -> bool + Send + Sync + 'static;
+
+struct DebugFn;
+
+impl Debug for DebugFn {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("<fn>")
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct Origins(Arc<HashSet<String>>);
+
+impl Origins {
+    fn contains(&self, origin: &str) -> bool {
+        self.0.contains(origin)
+    }
+
+    fn insert(&mut self, origin: impl Into<String>) {
+        Arc::make_mut(&mut self.0).insert(origin.into());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http::Request;
+    use tower_layer::Layer;
+
+    use super::*;
+
+    #[test]
+    fn test_layer_add_trusted_origin() {
+        // Smoke check that the layer threads parse_origin's Ok and Err
+        // through; the full validation matrix lives in url.rs.
+        assert!(CsrfLayer::new()
+            .add_trusted_origin("https://example.com")
+            .is_ok());
+        assert!(matches!(
+            CsrfLayer::new().add_trusted_origin("not a valid url"),
+            Err(ConfigError::InvalidOriginUrl { .. })
+        ));
+    }
+
+    #[test]
+    fn test_middleware_bypass() {
+        let layer = CsrfLayer::new()
+            .with_insecure_bypass(|_method, uri| -> bool { uri.path() == "/bypass" });
+
+        let middleware = layer.layer(());
+
+        struct Test {
+            name: &'static str,
+            path: &'static str,
+            sec_fetch_site: Option<&'static str>,
+            result: Result<(), ProtectionError>,
+        }
+
+        let tests = [
+            Test {
+                name: "bypass path without sec-fetch-site",
+                path: "/bypass",
+                sec_fetch_site: None,
+                result: Ok(()),
+            },
+            Test {
+                name: "bypass path with cross-site",
+                path: "/bypass",
+                sec_fetch_site: Some("cross-site"),
+                result: Ok(()),
+            },
+            Test {
+                name: "non-bypass path without sec-fetch-site",
+                path: "/api",
+                sec_fetch_site: None,
+                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+            },
+            Test {
+                name: "non-bypass path with cross-site",
+                path: "/api",
+                sec_fetch_site: Some("cross-site"),
+                result: Err(ProtectionError::CrossOriginRequest),
+            },
+        ];
+
+        for test in tests {
+            let mut req = Request::builder()
+                .method("POST")
+                .header("host", "example.com")
+                .header("origin", "https://attacker.example")
+                .uri(format!("https://example.com{}", test.path));
+
+            if let Some(sec_fetch_site) = test.sec_fetch_site {
+                req = req.header("sec-fetch-site", sec_fetch_site);
+            }
+
+            let req = req.body(()).unwrap();
+
+            assert_eq!(middleware.verify(&req), test.result, "{}", test.name);
+        }
+    }
+
+    #[test]
+    fn test_middleware_bypass_applies_when_origin_unparseable() {
+        let middleware = CsrfLayer::new()
+            .with_insecure_bypass(|_method, uri| uri.path() == "/bypass")
+            .layer(());
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("https://example.com/bypass")
+            .header("host", "example.com")
+            .header(
+                "origin",
+                http::HeaderValue::from_bytes(&[0xFF, 0xFE]).unwrap(),
+            )
+            .body(())
+            .unwrap();
+
+        assert_eq!(middleware.verify(&req), Ok(()));
+    }
+
+    #[test]
+    fn test_middleware_debug_trait() {
+        let layer = CsrfLayer::new();
+
+        let middleware = layer
+            .clone()
+            .with_insecure_bypass(|method, uri| method == Method::POST && uri.path() == "/bypass")
+            .layer(());
+
+        assert_eq!(
+            format!("{:?}", middleware),
+            "Csrf { inner: (), insecure_bypass: Some(<fn>), trusted_origins: Origins({}) }"
+        );
+
+        let middleware = layer.layer(());
+
+        assert_eq!(
+            format!("{:?}", middleware),
+            "Csrf { inner: (), insecure_bypass: None, trusted_origins: Origins({}) }"
+        );
+    }
+
+    #[test]
+    fn test_middleware_origin_host_port_match() {
+        let middleware: Csrf<()> = Default::default();
+
+        struct Test {
+            name: &'static str,
+            uri: &'static str,
+            host: Option<&'static str>,
+            origin: &'static str,
+            result: Result<(), ProtectionError>,
+        }
+
+        let tests = [
+            Test {
+                name: "default port both sides",
+                uri: "/",
+                host: Some("example.com"),
+                origin: "https://example.com",
+                result: Ok(()),
+            },
+            Test {
+                name: "same non-default port both sides",
+                uri: "/",
+                host: Some("example.com:8443"),
+                origin: "https://example.com:8443",
+                result: Ok(()),
+            },
+            Test {
+                name: "explicit default port both sides",
+                uri: "/",
+                host: Some("example.com:443"),
+                origin: "https://example.com:443",
+                result: Ok(()),
+            },
+            Test {
+                name: "mismatched non-default ports",
+                uri: "/",
+                host: Some("example.com:8443"),
+                origin: "https://example.com:8444",
+                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+            },
+            Test {
+                name: "origin has explicit default, host implicit",
+                uri: "/",
+                host: Some("example.com"),
+                origin: "https://example.com:443",
+                result: Ok(()),
+            },
+            Test {
+                name: "host has explicit default, origin implicit",
+                uri: "/",
+                host: Some("example.com:443"),
+                origin: "https://example.com",
+                result: Ok(()),
+            },
+            Test {
+                name: "host implicit, origin explicit non-default",
+                uri: "/",
+                host: Some("example.com"),
+                origin: "https://example.com:8443",
+                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+            },
+            Test {
+                name: "missing host, uri authority implicit, origin explicit non-default",
+                uri: "https://example.com/path",
+                host: None,
+                origin: "https://example.com:8443",
+                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+            },
+            Test {
+                name: "unparseable host falls back to uri authority",
+                uri: "https://example.com/path",
+                host: Some("not a valid authority"),
+                origin: "https://example.com",
+                result: Ok(()),
+            },
+            Test {
+                name: "missing host, uri carries authority (match)",
+                uri: "https://example.com/path",
+                host: None,
+                origin: "https://example.com",
+                result: Ok(()),
+            },
+            Test {
+                name: "missing host, uri authority mismatch",
+                uri: "https://other.example/path",
+                host: None,
+                origin: "https://example.com",
+                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+            },
+            Test {
+                name: "missing host and no uri authority",
+                uri: "/path",
+                host: None,
+                origin: "https://example.com",
+                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+            },
+            Test {
+                name: "scheme-less origin does not match host even if bytes agree",
+                uri: "/",
+                host: Some("example.com:8443"),
+                origin: "example.com:8443",
+                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+            },
+            Test {
+                name: "non-http origin scheme does not enter host fallback",
+                uri: "/",
+                host: Some("example.com:8443"),
+                origin: "ftp://example.com:8443",
+                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+            },
+        ];
+
+        for test in tests {
+            let mut req = Request::builder().method(Method::POST).uri(test.uri);
+
+            if let Some(host) = test.host {
+                req = req.header("host", host);
+            }
+
+            let req = req.header("origin", test.origin).body(()).unwrap();
+
+            assert_eq!(middleware.verify(&req), test.result, "{}", test.name);
+        }
+    }
+
+    #[test]
+    fn test_middleware_sec_fetch_site() {
+        let middleware: Csrf<()> = Default::default();
+
+        const NON_DECODABLE: &[u8] = &[0xFF, 0xFE];
+        assert!(
+            http::HeaderValue::from_bytes(NON_DECODABLE)
+                .expect("NON_DECODABLE must be a valid HeaderValue")
+                .to_str()
+                .is_err(),
+            "NON_DECODABLE must fail HeaderValue::to_str()"
+        );
+
+        struct Test {
+            name: &'static str,
+            method: http::Method,
+            sec_fetch_site: Option<&'static [u8]>,
+            origin: Option<&'static [u8]>,
+            result: Result<(), ProtectionError>,
+        }
+
+        let tests = [
+            Test {
+                name: "same-origin allowed",
+                method: Method::GET,
+                sec_fetch_site: Some(b"same-origin"),
+                origin: None,
+                result: Ok(()),
+            },
+            Test {
+                name: "none allowed",
+                method: Method::POST,
+                sec_fetch_site: Some(b"none"),
+                origin: None,
+                result: Ok(()),
+            },
+            Test {
+                name: "cross-site blocked",
+                method: Method::POST,
+                sec_fetch_site: Some(b"cross-site"),
+                origin: None,
+                result: Err(ProtectionError::CrossOriginRequest),
+            },
+            Test {
+                name: "same-site blocked",
+                method: Method::POST,
+                sec_fetch_site: Some(b"same-site"),
+                origin: None,
+                result: Err(ProtectionError::CrossOriginRequest),
+            },
+            Test {
+                name: "no header with no origin",
+                method: Method::POST,
+                sec_fetch_site: None,
+                origin: None,
+                result: Ok(()),
+            },
+            Test {
+                name: "no header with matching origin",
+                method: Method::POST,
+                sec_fetch_site: None,
+                origin: Some(b"https://example.com"),
+                result: Ok(()),
+            },
+            Test {
+                name: "no header with mismatched origin",
+                method: Method::POST,
+                sec_fetch_site: None,
+                origin: Some(b"https://attacker.example"),
+                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+            },
+            Test {
+                name: "no header with null origin",
+                method: Method::POST,
+                sec_fetch_site: None,
+                origin: Some(b"null"),
+                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+            },
+            Test {
+                name: "GET allowed",
+                method: Method::GET,
+                sec_fetch_site: Some(b"cross-site"),
+                origin: None,
+                result: Ok(()),
+            },
+            Test {
+                name: "HEAD allowed",
+                method: Method::HEAD,
+                sec_fetch_site: Some(b"cross-site"),
+                origin: None,
+                result: Ok(()),
+            },
+            Test {
+                name: "OPTIONS allowed",
+                method: Method::OPTIONS,
+                sec_fetch_site: Some(b"cross-site"),
+                origin: None,
+                result: Ok(()),
+            },
+            Test {
+                name: "PUT blocked",
+                method: Method::PUT,
+                sec_fetch_site: Some(b"cross-site"),
+                origin: None,
+                result: Err(ProtectionError::CrossOriginRequest),
+            },
+            Test {
+                name: "non-decodable origin without sec-fetch-site rejected",
+                method: Method::POST,
+                sec_fetch_site: None,
+                origin: Some(NON_DECODABLE),
+                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+            },
+            Test {
+                name: "non-decodable sec-fetch-site without origin rejected",
+                method: Method::POST,
+                sec_fetch_site: Some(NON_DECODABLE),
+                origin: None,
+                result: Err(ProtectionError::CrossOriginRequest),
+            },
+            Test {
+                name: "empty sec-fetch-site without origin allowed",
+                method: Method::POST,
+                sec_fetch_site: Some(b""),
+                origin: None,
+                result: Ok(()),
+            },
+            Test {
+                name: "empty origin without sec-fetch-site allowed",
+                method: Method::POST,
+                sec_fetch_site: None,
+                origin: Some(b""),
+                result: Ok(()),
+            },
+        ];
+
+        for test in tests {
+            let mut req = Request::builder()
+                .method(test.method)
+                .header("host", "example.com");
+
+            if let Some(sec_fetch_site) = test.sec_fetch_site {
+                req = req.header("sec-fetch-site", sec_fetch_site);
+            }
+
+            if let Some(origin) = test.origin {
+                req = req.header("origin", origin);
+            }
+
+            let req = req.body(()).unwrap();
+
+            assert_eq!(middleware.verify(&req), test.result, "{}", test.name);
+        }
+    }
+
+    #[test]
+    fn test_middleware_trusted_origin_bypass() {
+        let layer = CsrfLayer::new()
+            .add_trusted_origin("https://trusted.example")
+            .unwrap();
+
+        let middleware = layer.layer(());
+
+        struct Test {
+            name: &'static str,
+            sec_fetch_site: Option<&'static str>,
+            origin: Option<&'static str>,
+            result: Result<(), ProtectionError>,
+        }
+
+        let tests = [
+            Test {
+                name: "trusted origin without sec-fetch-site",
+                origin: Some("https://trusted.example"),
+                sec_fetch_site: None,
+                result: Ok(()),
+            },
+            Test {
+                name: "trusted origin with cross-site",
+                origin: Some("https://trusted.example"),
+                sec_fetch_site: Some("cross-site"),
+                result: Ok(()),
+            },
+            Test {
+                name: "untrusted origin without sec-fetch-site",
+                origin: Some("https://attacker.example"),
+                sec_fetch_site: None,
+                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+            },
+            Test {
+                name: "untrusted origin with cross-site",
+                origin: Some("https://attacker.example"),
+                sec_fetch_site: Some("cross-site"),
+                result: Err(ProtectionError::CrossOriginRequest),
+            },
+        ];
+
+        for test in tests {
+            let mut req = Request::builder()
+                .method("POST")
+                .header("host", "example.com");
+
+            if let Some(sec_fetch_site) = test.sec_fetch_site {
+                req = req.header("sec-fetch-site", sec_fetch_site);
+            }
+
+            if let Some(origin) = test.origin {
+                req = req.header("origin", origin);
+            }
+
+            let req = req.body(()).unwrap();
+
+            assert_eq!(middleware.verify(&req), test.result, "{}", test.name);
+        }
+    }
+
+    #[test]
+    fn test_middleware_trusted_origin_normalization() {
+        // Each row inserts a non-canonical form of the trusted origin and
+        // sends a request bearing the canonical browser-style Origin header;
+        // the test fails if canonicalization is dropped on either side.
+        struct Test {
+            name: &'static str,
+            trusted: &'static str,
+            origin: &'static str,
+        }
+
+        let tests = [
+            Test {
+                name: "scheme and host case folded",
+                trusted: "HTTPS://Example.COM",
+                origin: "https://example.com",
+            },
+            Test {
+                name: "trailing slash stripped",
+                trusted: "https://example.com/",
+                origin: "https://example.com",
+            },
+            Test {
+                name: "default https port stripped",
+                trusted: "https://example.com:443",
+                origin: "https://example.com",
+            },
+            Test {
+                name: "default http port stripped",
+                trusted: "http://example.com:80",
+                origin: "http://example.com",
+            },
+            Test {
+                name: "non-default port preserved",
+                trusted: "https://example.com:8443",
+                origin: "https://example.com:8443",
+            },
+        ];
+
+        for test in tests {
+            let middleware = CsrfLayer::new()
+                .add_trusted_origin(test.trusted)
+                .unwrap_or_else(|e| panic!("{}: add_trusted_origin failed: {e}", test.name))
+                .layer(());
+
+            let req = Request::builder()
+                .method("POST")
+                .header("host", "other.example")
+                .header("origin", test.origin)
+                .header("sec-fetch-site", "cross-site")
+                .body(())
+                .unwrap();
+
+            assert_eq!(middleware.verify(&req), Ok(()), "{}", test.name);
+        }
+    }
+}

--- a/tower-http/src/csrf/mod.rs
+++ b/tower-http/src/csrf/mod.rs
@@ -167,12 +167,47 @@ impl std::error::Error for ConfigError {}
 
 /// Reason a request was rejected by [`Csrf`].
 ///
-/// Attached to the `403 Forbidden` response's extensions so handlers can
-/// distinguish between explicit cross-origin rejections and conservative
-/// fallback rejections.
-#[derive(Clone, Debug, PartialEq)]
+/// Retrieve the category with [`ProtectionError::kind`]. Attached to the
+/// `403 Forbidden` response's extensions so handlers can distinguish explicit
+/// cross-origin rejections from conservative fallback rejections.
+///
+/// This is an opaque struct rather than an enum so future variants can carry
+/// additional context without a breaking change; match on [`kind`] instead.
+///
+/// [`kind`]: ProtectionError::kind
+#[derive(Clone, Debug)]
+pub struct ProtectionError {
+    kind: ProtectionErrorKind,
+}
+
+impl ProtectionError {
+    pub(crate) fn new(kind: ProtectionErrorKind) -> Self {
+        Self { kind }
+    }
+
+    /// The category of rejection.
+    pub fn kind(&self) -> ProtectionErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for ProtectionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self.kind {
+            ProtectionErrorKind::CrossOriginRequest => f.write_str("Cross-Origin request detected"),
+            ProtectionErrorKind::CrossOriginRequestFromOldBrowser => {
+                f.write_str("Cross-Origin request from old browser detected")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ProtectionError {}
+
+/// The category of a [`ProtectionError`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum ProtectionError {
+pub enum ProtectionErrorKind {
     /// A cross-origin request was detected via `Sec-Fetch-Site`.
     CrossOriginRequest,
 
@@ -181,19 +216,6 @@ pub enum ProtectionError {
     /// means the request came from an old browser or non-browser client.
     CrossOriginRequestFromOldBrowser,
 }
-
-impl fmt::Display for ProtectionError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            ProtectionError::CrossOriginRequest => f.write_str("Cross-Origin request detected"),
-            ProtectionError::CrossOriginRequestFromOldBrowser => {
-                f.write_str("Cross-Origin request from old browser detected")
-            }
-        }
-    }
-}
-
-impl std::error::Error for ProtectionError {}
 
 type BypassFn = dyn Fn(&Method, &Uri) -> bool + Send + Sync + 'static;
 
@@ -239,6 +261,12 @@ mod tests {
 
     use super::*;
     use crate::test_helpers::{to_bytes, Body};
+
+    impl PartialEq for super::ProtectionError {
+        fn eq(&self, other: &Self) -> bool {
+            self.kind == other.kind
+        }
+    }
 
     fn echo_service() -> impl tower::Service<
         Request<Body>,
@@ -318,7 +346,9 @@ mod tests {
         assert_eq!(res.status(), StatusCode::FORBIDDEN);
         assert_eq!(
             res.extensions().get::<ProtectionError>(),
-            Some(&ProtectionError::CrossOriginRequestFromOldBrowser),
+            Some(&ProtectionError::new(
+                ProtectionErrorKind::CrossOriginRequestFromOldBrowser
+            )),
         );
     }
 
@@ -422,13 +452,17 @@ mod tests {
                 name: "non-bypass path without sec-fetch-site",
                 path: "/api",
                 sec_fetch_site: None,
-                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+                )),
             },
             Test {
                 name: "non-bypass path with cross-site",
                 path: "/api",
                 sec_fetch_site: Some("cross-site"),
-                result: Err(ProtectionError::CrossOriginRequest),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequest,
+                )),
             },
         ];
 
@@ -530,7 +564,9 @@ mod tests {
                 uri: "/",
                 host: Some("example.com:8443"),
                 origin: "https://example.com:8444",
-                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+                )),
             },
             Test {
                 // Strict byte match: an explicit default port does not equal an
@@ -539,28 +575,36 @@ mod tests {
                 uri: "/",
                 host: Some("example.com"),
                 origin: "https://example.com:443",
-                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+                )),
             },
             Test {
                 name: "host has explicit default, origin implicit",
                 uri: "/",
                 host: Some("example.com:443"),
                 origin: "https://example.com",
-                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+                )),
             },
             Test {
                 name: "host implicit, origin explicit non-default",
                 uri: "/",
                 host: Some("example.com"),
                 origin: "https://example.com:8443",
-                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+                )),
             },
             Test {
                 name: "missing host, uri authority implicit, origin explicit non-default",
                 uri: "https://example.com/path",
                 host: None,
                 origin: "https://example.com:8443",
-                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+                )),
             },
             Test {
                 // The Host header is compared verbatim when present (no fallback
@@ -570,7 +614,9 @@ mod tests {
                 uri: "https://example.com/path",
                 host: Some("not a valid authority"),
                 origin: "https://example.com",
-                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+                )),
             },
             Test {
                 name: "missing host, uri carries authority (match)",
@@ -584,28 +630,36 @@ mod tests {
                 uri: "https://other.example/path",
                 host: None,
                 origin: "https://example.com",
-                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+                )),
             },
             Test {
                 name: "missing host and no uri authority",
                 uri: "/path",
                 host: None,
                 origin: "https://example.com",
-                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+                )),
             },
             Test {
                 name: "scheme-less origin does not match host even if bytes agree",
                 uri: "/",
                 host: Some("example.com:8443"),
                 origin: "example.com:8443",
-                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+                )),
             },
             Test {
                 name: "non-http origin scheme does not enter host fallback",
                 uri: "/",
                 host: Some("example.com:8443"),
                 origin: "ftp://example.com:8443",
-                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+                )),
             },
         ];
 
@@ -663,14 +717,18 @@ mod tests {
                 method: Method::POST,
                 sec_fetch_site: Some(b"cross-site"),
                 origin: None,
-                result: Err(ProtectionError::CrossOriginRequest),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequest,
+                )),
             },
             Test {
                 name: "same-site blocked",
                 method: Method::POST,
                 sec_fetch_site: Some(b"same-site"),
                 origin: None,
-                result: Err(ProtectionError::CrossOriginRequest),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequest,
+                )),
             },
             Test {
                 name: "no header with no origin",
@@ -691,14 +749,18 @@ mod tests {
                 method: Method::POST,
                 sec_fetch_site: None,
                 origin: Some(b"https://attacker.example"),
-                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+                )),
             },
             Test {
                 name: "no header with null origin",
                 method: Method::POST,
                 sec_fetch_site: None,
                 origin: Some(b"null"),
-                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+                )),
             },
             Test {
                 name: "GET allowed",
@@ -726,21 +788,27 @@ mod tests {
                 method: Method::PUT,
                 sec_fetch_site: Some(b"cross-site"),
                 origin: None,
-                result: Err(ProtectionError::CrossOriginRequest),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequest,
+                )),
             },
             Test {
                 name: "non-decodable origin without sec-fetch-site rejected",
                 method: Method::POST,
                 sec_fetch_site: None,
                 origin: Some(NON_DECODABLE),
-                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+                )),
             },
             Test {
                 name: "non-decodable sec-fetch-site without origin rejected",
                 method: Method::POST,
                 sec_fetch_site: Some(NON_DECODABLE),
                 origin: None,
-                result: Err(ProtectionError::CrossOriginRequest),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequest,
+                )),
             },
             Test {
                 name: "empty sec-fetch-site without origin allowed",
@@ -809,13 +877,17 @@ mod tests {
                 name: "untrusted origin without sec-fetch-site",
                 origin: Some("https://attacker.example"),
                 sec_fetch_site: None,
-                result: Err(ProtectionError::CrossOriginRequestFromOldBrowser),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+                )),
             },
             Test {
                 name: "untrusted origin with cross-site",
                 origin: Some("https://attacker.example"),
                 sec_fetch_site: Some("cross-site"),
-                result: Err(ProtectionError::CrossOriginRequest),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequest,
+                )),
             },
         ];
 
@@ -867,19 +939,25 @@ mod tests {
                 name: "host case mismatch not trusted",
                 trusted: "https://Example.COM",
                 origin: "https://example.com",
-                result: Err(ProtectionError::CrossOriginRequest),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequest,
+                )),
             },
             Test {
                 name: "explicit default port not trusted against bare origin",
                 trusted: "https://example.com:443",
                 origin: "https://example.com",
-                result: Err(ProtectionError::CrossOriginRequest),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequest,
+                )),
             },
             Test {
                 name: "bare trusted not matched by explicit-default-port origin",
                 trusted: "https://example.com",
                 origin: "https://example.com:443",
-                result: Err(ProtectionError::CrossOriginRequest),
+                result: Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequest,
+                )),
             },
         ];
 

--- a/tower-http/src/csrf/response.rs
+++ b/tower-http/src/csrf/response.rs
@@ -1,0 +1,44 @@
+use http::{Response, StatusCode};
+
+use super::ProtectionError;
+
+/// Builds the response returned by [`Csrf`] when a request fails CSRF protection.
+///
+/// Implemented for any `FnMut(ProtectionError) -> Response<B> + Clone`, so a
+/// closure can be passed directly to
+/// [`CsrfLayer::with_rejection_response`](super::CsrfLayer::with_rejection_response).
+///
+/// [`Csrf`]: super::Csrf
+pub trait ResponseForProtectionError<B>: Clone {
+    /// Builds the response from the rejection error.
+    fn response_for_protection_error(&mut self, error: ProtectionError) -> Response<B>;
+}
+
+impl<F, B> ResponseForProtectionError<B> for F
+where
+    F: FnMut(ProtectionError) -> Response<B> + Clone,
+{
+    fn response_for_protection_error(&mut self, error: ProtectionError) -> Response<B> {
+        self(error)
+    }
+}
+
+/// Default [`ResponseForProtectionError`] used by
+/// [`CsrfLayer::new`](super::CsrfLayer::new).
+///
+/// Produces a `403 Forbidden` response with an empty body and the originating
+/// [`ProtectionError`] attached to the response's extensions.
+#[derive(Clone, Copy, Debug, Default)]
+#[non_exhaustive]
+pub struct DefaultResponseForProtectionError;
+
+impl<B: Default> ResponseForProtectionError<B> for DefaultResponseForProtectionError {
+    fn response_for_protection_error(&mut self, error: ProtectionError) -> Response<B> {
+        let mut response = Response::new(B::default());
+        *response.status_mut() = StatusCode::FORBIDDEN;
+
+        response.extensions_mut().insert(error);
+
+        response
+    }
+}

--- a/tower-http/src/csrf/response.rs
+++ b/tower-http/src/csrf/response.rs
@@ -26,18 +26,19 @@ where
 /// Default [`ResponseForProtectionError`] used by
 /// [`CsrfLayer::new`](super::CsrfLayer::new).
 ///
-/// Produces a `403 Forbidden` response with an empty body and the originating
-/// [`ProtectionError`] attached to the response's extensions.
+/// Produces a `403 Forbidden` response with an empty body. The originating
+/// [`ProtectionError`] is attached to the response's extensions by [`Csrf`]
+/// itself, so it is present regardless of which builder produced the response.
+///
+/// [`Csrf`]: super::Csrf
 #[derive(Clone, Copy, Debug, Default)]
 #[non_exhaustive]
 pub struct DefaultResponseForProtectionError;
 
 impl<B: Default> ResponseForProtectionError<B> for DefaultResponseForProtectionError {
-    fn response_for_protection_error(&mut self, error: ProtectionError) -> Response<B> {
+    fn response_for_protection_error(&mut self, _error: ProtectionError) -> Response<B> {
         let mut response = Response::new(B::default());
         *response.status_mut() = StatusCode::FORBIDDEN;
-
-        response.extensions_mut().insert(error);
 
         response
     }

--- a/tower-http/src/csrf/service.rs
+++ b/tower-http/src/csrf/service.rs
@@ -1,5 +1,5 @@
+use std::convert::TryFrom;
 use std::fmt::{self, Debug, Formatter};
-use std::str;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
@@ -7,7 +7,6 @@ use http::{Method, Request, Response, Uri};
 use tower_service::Service;
 
 use super::future::ResponseFuture;
-use super::url::UriExt;
 use super::{
     BypassFn, DebugFn, DefaultResponseForProtectionError, Origins, ProtectionError,
     ResponseForProtectionError,
@@ -56,8 +55,7 @@ impl<S, T> Csrf<S, T> {
 
         let origin_uri = origin
             .filter(|b| !b.is_empty())
-            .and_then(|b| str::from_utf8(b).ok())
-            .and_then(|s| s.parse::<Uri>().ok())
+            .and_then(|b| Uri::try_from(b).ok())
             .filter(|u| matches!(u.scheme_str(), Some("http" | "https")));
 
         let sec_fetch_site = req.headers().get("sec-fetch-site").map(|h| h.as_bytes());
@@ -74,10 +72,9 @@ impl<S, T> Csrf<S, T> {
                 return true;
             }
 
-            let trusted = origin_uri
-                .as_ref()
-                .and_then(|u| u.canonical())
-                .map_or(false, |s| self.trusted_origins.contains(&s));
+            // Strict byte match of the raw Origin header against the registered
+            // set, mirroring the Go reference's `trustedOrigins[Origin]`.
+            let trusted = origin.map_or(false, |b| self.trusted_origins.contains(b));
 
             if trusted {
                 #[cfg(feature = "tracing")]
@@ -108,30 +105,18 @@ impl<S, T> Csrf<S, T> {
 
         let host = req.headers().get("host").map(|h| h.as_bytes());
 
-        if let Some(uri) = &origin_uri {
-            // compare effective ports (scheme default when implicit). Host has no scheme, so http→https can't be detected here; fail open per HSTS.
-            let authority = host
-                .and_then(|b| str::from_utf8(b).ok())
-                .and_then(|s| s.parse::<http::uri::Authority>().ok());
+        // The reference compares `url.Parse(origin).Host == req.Host`: the Origin's
+        // authority (scheme stripped) against req.Host, which is the Host header or
+        // the URI authority (HTTP/2 `:authority`) when the header is absent. The
+        // comparison is byte-exact. The Host carries no scheme, so an http→https
+        // mismatch can't be detected here; we fail open, mitigable with HSTS.
+        let effective_host = host.or_else(|| req.uri().authority().map(|a| a.as_str().as_bytes()));
 
-            // fall back to the request URI when the Host header is missing or unparseable
-            let (host_name, port_host) = match authority.as_ref() {
-                Some(a) => (Some(a.host()), a.port_u16()),
-                None => (req.uri().host(), req.uri().port_u16()),
-            };
-
-            if let (Some(origin_host), Some(host_name)) = (uri.host(), host_name) {
-                let port_origin = uri.effective_port();
-                // Host carries no scheme of its own; assume Origin's scheme so an implicit
-                // Host port resolves to Origin's scheme default (443/80) rather than
-                // silently inheriting Origin's explicit port.
-                let port_host = port_host.or_else(|| uri.scheme_default_port());
-
-                if origin_host.eq_ignore_ascii_case(host_name) && port_origin == port_host {
-                    #[cfg(feature = "tracing")]
-                    tracing::trace!(uri = %req.uri().path(), "request passed: origin is same as host");
-                    return Ok(());
-                }
+        if let (Some(uri), Some(effective_host)) = (&origin_uri, effective_host) {
+            if uri.authority().map(|a| a.as_str().as_bytes()) == Some(effective_host) {
+                #[cfg(feature = "tracing")]
+                tracing::trace!(uri = %req.uri().path(), "request passed: origin is same as host");
+                return Ok(());
             }
         }
 

--- a/tower-http/src/csrf/service.rs
+++ b/tower-http/src/csrf/service.rs
@@ -40,7 +40,7 @@ impl<S> Csrf<S> {
             .map_or(false, |p| p(method, uri))
         {
             #[cfg(feature = "tracing")]
-            tracing::trace!(uri = %uri, "request passed: bypassed");
+            tracing::trace!(uri = %uri.path(), "request passed: bypassed");
             return true;
         }
 
@@ -50,7 +50,7 @@ impl<S> Csrf<S> {
 
         if trusted {
             #[cfg(feature = "tracing")]
-            tracing::trace!(uri = %uri, "request passed: trusted origin");
+            tracing::trace!(uri = %uri.path(), "request passed: trusted origin");
             return true;
         }
 
@@ -63,7 +63,7 @@ impl<S> Csrf<S> {
             &Method::GET | &Method::HEAD | &Method::OPTIONS
         ) {
             #[cfg(feature = "tracing")]
-            tracing::trace!(uri = %req.uri(), "request passed: safe method");
+            tracing::trace!(uri = %req.uri().path(), "request passed: safe method");
             return Ok(());
         }
 
@@ -81,7 +81,7 @@ impl<S> Csrf<S> {
         match sec_fetch_site {
             Some(b"same-origin" | b"none") => {
                 #[cfg(feature = "tracing")]
-                tracing::trace!(uri = %req.uri(), "request passed: sec-fetch-site is same-origin or none");
+                tracing::trace!(uri = %req.uri().path(), "request passed: sec-fetch-site is same-origin or none");
                 return Ok(());
             }
             None | Some(b"") => {} // fall through to Origin check
@@ -93,7 +93,7 @@ impl<S> Csrf<S> {
 
         if matches!(origin, None | Some(b"")) {
             #[cfg(feature = "tracing")]
-            tracing::trace!(uri = %req.uri(), "request passed: neither sec-fetch-site nor origin header (same-origin or not a browser request)");
+            tracing::trace!(uri = %req.uri().path(), "request passed: neither sec-fetch-site nor origin header (same-origin or not a browser request)");
             return Ok(());
         }
 
@@ -120,7 +120,7 @@ impl<S> Csrf<S> {
 
                 if origin_host.eq_ignore_ascii_case(host_name) && port_origin == port_host {
                     #[cfg(feature = "tracing")]
-                    tracing::trace!(uri = %req.uri(), "request passed: origin is same as host");
+                    tracing::trace!(uri = %req.uri().path(), "request passed: origin is same as host");
                     return Ok(());
                 }
             }

--- a/tower-http/src/csrf/service.rs
+++ b/tower-http/src/csrf/service.rs
@@ -175,7 +175,11 @@ where
                 #[cfg(feature = "tracing")]
                 tracing::trace!(uri = %req.uri().path(), error = %err, "request rejected");
 
-                let response = self.rejection_response.response_for_protection_error(err);
+                let mut response = self
+                    .rejection_response
+                    .response_for_protection_error(err.clone());
+
+                response.extensions_mut().insert(err);
 
                 ResponseFuture::rejected(Ok(response))
             }

--- a/tower-http/src/csrf/service.rs
+++ b/tower-http/src/csrf/service.rs
@@ -105,12 +105,15 @@ impl<S, T> Csrf<S, T> {
 
         let host = req.headers().get("host").map(|h| h.as_bytes());
 
-        // The reference compares `url.Parse(origin).Host == req.Host`: the Origin's
-        // authority (scheme stripped) against req.Host, which is the Host header or
-        // the URI authority (HTTP/2 `:authority`) when the header is absent. The
-        // comparison is byte-exact. The Host carries no scheme, so an http→https
-        // mismatch can't be detected here; we fail open, mitigable with HSTS.
-        let effective_host = host.or_else(|| req.uri().authority().map(|a| a.as_str().as_bytes()));
+        // Mirrors the reference's `url.Parse(origin).Host == req.Host`. Per RFC 7230
+        // §5.3, req.Host is the request-target authority (absolute-form URI / HTTP/2
+        // `:authority`) if present, else the Host header. Byte-exact and scheme-blind,
+        // so an http→https mismatch can't be caught here — we fail open (HSTS helps).
+        let effective_host = req
+            .uri()
+            .authority()
+            .map(|a| a.as_str().as_bytes())
+            .or(host);
 
         if let (Some(uri), Some(effective_host)) = (&origin_uri, effective_host) {
             if uri.authority().map(|a| a.as_str().as_bytes()) == Some(effective_host) {

--- a/tower-http/src/csrf/service.rs
+++ b/tower-http/src/csrf/service.rs
@@ -94,7 +94,11 @@ impl<S, T> Csrf<S, T> {
             }
             None | Some(b"") => {} // fall through to Origin check
             Some(_) if is_exempt() => return Ok(()),
-            Some(_) => return Err(ProtectionError::new(ProtectionErrorKind::CrossOriginRequest)),
+            Some(_) => {
+                return Err(ProtectionError::new(
+                    ProtectionErrorKind::CrossOriginRequest,
+                ))
+            }
         }
 
         if matches!(origin, None | Some(b"")) {

--- a/tower-http/src/csrf/service.rs
+++ b/tower-http/src/csrf/service.rs
@@ -41,6 +41,8 @@ impl<S, T> Csrf<S, T> {
     }
 
     pub(super) fn verify<Body>(&self, req: &Request<Body>) -> Result<(), ProtectionError> {
+        // Deliberately not Method::is_safe: it also treats TRACE as safe, but the
+        // reference implementation only exempts GET/HEAD/OPTIONS, so we match it here.
         if matches!(
             req.method(),
             &Method::GET | &Method::HEAD | &Method::OPTIONS
@@ -195,5 +197,22 @@ where
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Guards the comment in `verify`: `Method::is_safe` exempts more than the
+    // GET/HEAD/OPTIONS set the reference implementation uses, so we can't rely on it.
+    #[test]
+    fn method_is_safe_covers_more_than_get_head_options() {
+        for method in [&Method::GET, &Method::HEAD, &Method::OPTIONS] {
+            assert!(method.is_safe());
+        }
+
+        // TRACE is "safe" per RFC 7231 but is not in the reference implementation's set.
+        assert!(Method::TRACE.is_safe());
     }
 }

--- a/tower-http/src/csrf/service.rs
+++ b/tower-http/src/csrf/service.rs
@@ -1,0 +1,179 @@
+use std::fmt::{self, Debug, Formatter};
+use std::str;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use http::{Method, Request, Response, Uri};
+use tower_service::Service;
+
+use super::future::ResponseFuture;
+use super::url::UriExt;
+use super::{BypassFn, DebugFn, Origins, ProtectionError};
+
+/// Middleware that enforces cross-origin request forgery (CSRF) protection.
+///
+/// See the [module docs](crate::csrf) for an example.
+#[derive(Clone)]
+pub struct Csrf<S> {
+    inner: S,
+    insecure_bypass: Option<Arc<BypassFn>>,
+    trusted_origins: Origins,
+}
+
+impl<S> Csrf<S> {
+    pub(super) fn new(
+        inner: S,
+        insecure_bypass: Option<Arc<BypassFn>>,
+        trusted_origins: Origins,
+    ) -> Self {
+        Self {
+            inner,
+            insecure_bypass,
+            trusted_origins,
+        }
+    }
+
+    fn is_exempt(&self, method: &Method, uri: &Uri, origin: Option<&Uri>) -> bool {
+        if self
+            .insecure_bypass
+            .as_ref()
+            .map_or(false, |p| p(method, uri))
+        {
+            #[cfg(feature = "tracing")]
+            tracing::trace!(uri = %uri, "request passed: bypassed");
+            return true;
+        }
+
+        let trusted = origin
+            .and_then(|u| u.canonical())
+            .map_or(false, |s| self.trusted_origins.contains(&s));
+
+        if trusted {
+            #[cfg(feature = "tracing")]
+            tracing::trace!(uri = %uri, "request passed: trusted origin");
+            return true;
+        }
+
+        false
+    }
+
+    pub(super) fn verify<Body>(&self, req: &Request<Body>) -> Result<(), ProtectionError> {
+        if matches!(
+            req.method(),
+            &Method::GET | &Method::HEAD | &Method::OPTIONS
+        ) {
+            #[cfg(feature = "tracing")]
+            tracing::trace!(uri = %req.uri(), "request passed: safe method");
+            return Ok(());
+        }
+
+        let origin = req.headers().get("origin").map(|h| h.as_bytes());
+
+        let origin_uri = origin
+            .filter(|b| !b.is_empty())
+            .and_then(|b| str::from_utf8(b).ok())
+            .and_then(|s| s.parse::<Uri>().ok())
+            .filter(|u| matches!(u.scheme_str(), Some("http" | "https")));
+
+        let sec_fetch_site = req.headers().get("sec-fetch-site").map(|h| h.as_bytes());
+
+        // Fetch spec mandates lowercase here; exact byte match is intentional.
+        match sec_fetch_site {
+            Some(b"same-origin" | b"none") => {
+                #[cfg(feature = "tracing")]
+                tracing::trace!(uri = %req.uri(), "request passed: sec-fetch-site is same-origin or none");
+                return Ok(());
+            }
+            None | Some(b"") => {} // fall through to Origin check
+            Some(_) if self.is_exempt(req.method(), req.uri(), origin_uri.as_ref()) => {
+                return Ok(())
+            }
+            Some(_) => return Err(ProtectionError::CrossOriginRequest),
+        }
+
+        if matches!(origin, None | Some(b"")) {
+            #[cfg(feature = "tracing")]
+            tracing::trace!(uri = %req.uri(), "request passed: neither sec-fetch-site nor origin header (same-origin or not a browser request)");
+            return Ok(());
+        }
+
+        let host = req.headers().get("host").map(|h| h.as_bytes());
+
+        if let Some(uri) = &origin_uri {
+            // compare effective ports (scheme default when implicit). Host has no scheme, so http→https can't be detected here; fail open per HSTS.
+            let authority = host
+                .and_then(|b| str::from_utf8(b).ok())
+                .and_then(|s| s.parse::<http::uri::Authority>().ok());
+
+            // fall back to the request URI when the Host header is missing or unparseable
+            let (host_name, port_host) = match authority.as_ref() {
+                Some(a) => (Some(a.host()), a.port_u16()),
+                None => (req.uri().host(), req.uri().port_u16()),
+            };
+
+            if let (Some(origin_host), Some(host_name)) = (uri.host(), host_name) {
+                let port_origin = uri.effective_port();
+                // Host carries no scheme of its own; assume Origin's scheme so an implicit
+                // Host port resolves to Origin's scheme default (443/80) rather than
+                // silently inheriting Origin's explicit port.
+                let port_host = port_host.or_else(|| uri.scheme_default_port());
+
+                if origin_host.eq_ignore_ascii_case(host_name) && port_origin == port_host {
+                    #[cfg(feature = "tracing")]
+                    tracing::trace!(uri = %req.uri(), "request passed: origin is same as host");
+                    return Ok(());
+                }
+            }
+        }
+
+        if self.is_exempt(req.method(), req.uri(), origin_uri.as_ref()) {
+            return Ok(());
+        }
+
+        Err(ProtectionError::CrossOriginRequestFromOldBrowser)
+    }
+}
+
+impl<S: Default> Default for Csrf<S> {
+    fn default() -> Self {
+        Self {
+            inner: S::default(),
+            insecure_bypass: None,
+            trusted_origins: Origins::default(),
+        }
+    }
+}
+
+impl<S: Debug> Debug for Csrf<S> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Csrf")
+            .field("inner", &self.inner)
+            .field(
+                "insecure_bypass",
+                &self.insecure_bypass.as_ref().map(|_| DebugFn),
+            )
+            .field("trusted_origins", &self.trusted_origins)
+            .finish()
+    }
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for Csrf<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    ResBody: Default,
+{
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future, ResBody>;
+    type Response = Response<ResBody>;
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        match self.verify(&req) {
+            Ok(_) => ResponseFuture::future(self.inner.call(req)),
+            Err(err) => ResponseFuture::rejected(err),
+        }
+    }
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+}

--- a/tower-http/src/csrf/service.rs
+++ b/tower-http/src/csrf/service.rs
@@ -14,6 +14,7 @@ use super::{BypassFn, DebugFn, Origins, ProtectionError};
 ///
 /// See the [module docs](crate::csrf) for an example.
 #[derive(Clone)]
+#[must_use]
 pub struct Csrf<S> {
     inner: S,
     insecure_bypass: Option<Arc<BypassFn>>,

--- a/tower-http/src/csrf/service.rs
+++ b/tower-http/src/csrf/service.rs
@@ -34,30 +34,6 @@ impl<S> Csrf<S> {
         }
     }
 
-    fn is_exempt(&self, method: &Method, uri: &Uri, origin: Option<&Uri>) -> bool {
-        if self
-            .insecure_bypass
-            .as_ref()
-            .map_or(false, |p| p(method, uri))
-        {
-            #[cfg(feature = "tracing")]
-            tracing::trace!(uri = %uri.path(), "request passed: bypassed");
-            return true;
-        }
-
-        let trusted = origin
-            .and_then(|u| u.canonical())
-            .map_or(false, |s| self.trusted_origins.contains(&s));
-
-        if trusted {
-            #[cfg(feature = "tracing")]
-            tracing::trace!(uri = %uri.path(), "request passed: trusted origin");
-            return true;
-        }
-
-        false
-    }
-
     pub(super) fn verify<Body>(&self, req: &Request<Body>) -> Result<(), ProtectionError> {
         if matches!(
             req.method(),
@@ -78,6 +54,32 @@ impl<S> Csrf<S> {
 
         let sec_fetch_site = req.headers().get("sec-fetch-site").map(|h| h.as_bytes());
 
+        let is_exempt = || -> bool {
+            let bypass = self
+                .insecure_bypass
+                .as_ref()
+                .map_or(false, |bypass| bypass(req.method(), req.uri()));
+
+            if bypass {
+                #[cfg(feature = "tracing")]
+                tracing::trace!(uri = %req.uri().path(), "request passed: bypassed");
+                return true;
+            }
+
+            let trusted = origin_uri
+                .as_ref()
+                .and_then(|u| u.canonical())
+                .map_or(false, |s| self.trusted_origins.contains(&s));
+
+            if trusted {
+                #[cfg(feature = "tracing")]
+                tracing::trace!(uri = %req.uri().path(), "request passed: trusted origin");
+                return true;
+            }
+
+            false
+        };
+
         // Fetch spec mandates lowercase here; exact byte match is intentional.
         match sec_fetch_site {
             Some(b"same-origin" | b"none") => {
@@ -86,9 +88,7 @@ impl<S> Csrf<S> {
                 return Ok(());
             }
             None | Some(b"") => {} // fall through to Origin check
-            Some(_) if self.is_exempt(req.method(), req.uri(), origin_uri.as_ref()) => {
-                return Ok(())
-            }
+            Some(_) if is_exempt() => return Ok(()),
             Some(_) => return Err(ProtectionError::CrossOriginRequest),
         }
 
@@ -127,7 +127,7 @@ impl<S> Csrf<S> {
             }
         }
 
-        if self.is_exempt(req.method(), req.uri(), origin_uri.as_ref()) {
+        if is_exempt() {
             return Ok(());
         }
 

--- a/tower-http/src/csrf/service.rs
+++ b/tower-http/src/csrf/service.rs
@@ -9,7 +9,7 @@ use tower_service::Service;
 use super::future::ResponseFuture;
 use super::{
     BypassFn, DebugFn, DefaultResponseForProtectionError, Origins, ProtectionError,
-    ResponseForProtectionError,
+    ProtectionErrorKind, ResponseForProtectionError,
 };
 
 /// Middleware that enforces cross-origin request forgery (CSRF) protection.
@@ -94,7 +94,7 @@ impl<S, T> Csrf<S, T> {
             }
             None | Some(b"") => {} // fall through to Origin check
             Some(_) if is_exempt() => return Ok(()),
-            Some(_) => return Err(ProtectionError::CrossOriginRequest),
+            Some(_) => return Err(ProtectionError::new(ProtectionErrorKind::CrossOriginRequest)),
         }
 
         if matches!(origin, None | Some(b"")) {
@@ -124,7 +124,9 @@ impl<S, T> Csrf<S, T> {
             return Ok(());
         }
 
-        Err(ProtectionError::CrossOriginRequestFromOldBrowser)
+        Err(ProtectionError::new(
+            ProtectionErrorKind::CrossOriginRequestFromOldBrowser,
+        ))
     }
 }
 

--- a/tower-http/src/csrf/service.rs
+++ b/tower-http/src/csrf/service.rs
@@ -8,28 +8,34 @@ use tower_service::Service;
 
 use super::future::ResponseFuture;
 use super::url::UriExt;
-use super::{BypassFn, DebugFn, Origins, ProtectionError};
+use super::{
+    BypassFn, DebugFn, DefaultResponseForProtectionError, Origins, ProtectionError,
+    ResponseForProtectionError,
+};
 
 /// Middleware that enforces cross-origin request forgery (CSRF) protection.
 ///
 /// See the [module docs](crate::csrf) for an example.
 #[derive(Clone)]
 #[must_use]
-pub struct Csrf<S> {
+pub struct Csrf<S, T = DefaultResponseForProtectionError> {
     inner: S,
     insecure_bypass: Option<Arc<BypassFn>>,
+    rejection_response: T,
     trusted_origins: Origins,
 }
 
-impl<S> Csrf<S> {
+impl<S, T> Csrf<S, T> {
     pub(super) fn new(
         inner: S,
         insecure_bypass: Option<Arc<BypassFn>>,
+        rejection_response: T,
         trusted_origins: Origins,
     ) -> Self {
         Self {
             inner,
             insecure_bypass,
+            rejection_response,
             trusted_origins,
         }
     }
@@ -135,17 +141,22 @@ impl<S> Csrf<S> {
     }
 }
 
-impl<S: Default> Default for Csrf<S> {
+impl<S, T> Default for Csrf<S, T>
+where
+    S: Default,
+    T: Default,
+{
     fn default() -> Self {
         Self {
             inner: S::default(),
             insecure_bypass: None,
+            rejection_response: T::default(),
             trusted_origins: Origins::default(),
         }
     }
 }
 
-impl<S: Debug> Debug for Csrf<S> {
+impl<S: Debug, T> Debug for Csrf<S, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("Csrf")
             .field("inner", &self.inner)
@@ -154,23 +165,31 @@ impl<S: Debug> Debug for Csrf<S> {
                 &self.insecure_bypass.as_ref().map(|_| DebugFn),
             )
             .field("trusted_origins", &self.trusted_origins)
+            .field("rejection_response", &DebugFn)
             .finish()
     }
 }
 
-impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for Csrf<S>
+impl<S, T, ReqBody, ResBody> Service<Request<ReqBody>> for Csrf<S, T>
 where
     S: Service<Request<ReqBody>, Response = Response<ResBody>>,
-    ResBody: Default,
+    T: ResponseForProtectionError<ResBody>,
 {
     type Error = S::Error;
-    type Future = ResponseFuture<S::Future, ResBody>;
+    type Future = ResponseFuture<S::Future>;
     type Response = Response<ResBody>;
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
         match self.verify(&req) {
             Ok(_) => ResponseFuture::future(self.inner.call(req)),
-            Err(err) => ResponseFuture::rejected(err),
+            Err(err) => {
+                #[cfg(feature = "tracing")]
+                tracing::trace!(uri = %req.uri().path(), error = %err, "request rejected");
+
+                let response = self.rejection_response.response_for_protection_error(err);
+
+                ResponseFuture::rejected(Ok(response))
+            }
         }
     }
 

--- a/tower-http/src/csrf/url.rs
+++ b/tower-http/src/csrf/url.rs
@@ -2,61 +2,9 @@ use http::Uri;
 
 use super::ConfigError;
 
-/// A validated, canonicalized trusted-origin string.
-///
-/// Wraps the output of [`UriExt::parse_origin`] + [`UriExt::canonical`] so the
-/// canonical string can be carried around the type system without re-validation.
-/// Construct via [`TrustedOrigin::parse`]; unwrap the inner string with
-/// [`TrustedOrigin::into_canonical`].
-pub(crate) struct TrustedOrigin(String);
-
-impl TrustedOrigin {
-    /// Parses and canonicalizes `input` as a trusted origin.
-    ///
-    /// Forwards validation to [`UriExt::parse_origin`] (see that method for the
-    /// rejected forms) and then runs [`UriExt::canonical`] on the result.
-    pub(crate) fn parse(input: &str) -> Result<Self, ConfigError> {
-        let uri = Uri::parse_origin(input)?;
-
-        Ok(Self(
-            uri.canonical()
-                .expect("parse_origin validates scheme and host"),
-        ))
-    }
-
-    /// Consumes the wrapper and returns the canonical `scheme://host[:port]`
-    /// string.
-    pub(crate) fn into_canonical(self) -> String {
-        self.0
-    }
-}
-
 /// Internal extension methods on [`http::Uri`] used by the CSRF middleware to
-/// normalize and compare browser-supplied `Origin` values.
+/// validate trusted-origin strings.
 pub(crate) trait UriExt: Sized {
-    /// Returns the canonical `scheme://host[:port]` representation, or `None`
-    /// for URIs that can't appear in a browser `Origin` header.
-    ///
-    /// Normalization:
-    ///
-    /// - scheme is `http` or `https` (otherwise `None`);
-    /// - host is non-empty and ASCII-lowercased;
-    /// - default ports (`80` for `http`, `443` for `https`) are stripped;
-    /// - non-default ports are preserved verbatim.
-    ///
-    /// Used on both sides of the trusted-origin and `Origin`/`Host`
-    /// comparisons so that incidental form differences (case, explicit default
-    /// ports) don't cause a legitimate request to be rejected.
-    fn canonical(&self) -> Option<String>;
-
-    /// Returns the URI's explicit port if present, otherwise the IANA default
-    /// for its scheme. Returns `None` for schemes without a known default.
-    fn effective_port(&self) -> Option<u16>;
-
-    /// Returns the IANA default port for the URI's scheme (`80` for `http`,
-    /// `443` for `https`), or `None` for any other scheme.
-    fn scheme_default_port(&self) -> Option<u16>;
-
     /// Parses a trusted-origin string of the form `scheme://host[:port]`.
     ///
     /// Rejects inputs that can't represent a browser `Origin`:
@@ -64,44 +12,17 @@ pub(crate) trait UriExt: Sized {
     /// - unparseable URIs ([`ConfigError::InvalidOriginUrl`]);
     /// - non-`http`/`https` schemes or missing host ([`ConfigError::OpaqueOrigin`]);
     /// - any path, query, or fragment component
-    ///   ([`ConfigError::InvalidOriginUrlComponents`] — including fragments
-    ///   that `http::Uri` would otherwise silently strip);
+    ///   ([`ConfigError::InvalidOriginUrlComponents`] — including a bare trailing
+    ///   `/` and fragments that `http::Uri` would otherwise silently strip);
     /// - non-ASCII hostnames ([`ConfigError::NonAsciiHostname`] — IDN hosts
     ///   must be supplied in punycode, since that's what browsers send).
     ///
-    /// The returned [`Uri`] is parsed but not canonicalized; callers should
-    /// run [`UriExt::canonical`] before storing or comparing it.
+    /// The returned [`Uri`] is parsed but not normalized; the origin is matched
+    /// against the request's `Origin` header byte-for-byte.
     fn parse_origin(input: &str) -> Result<Self, ConfigError>;
 }
 
 impl UriExt for Uri {
-    fn canonical(&self) -> Option<String> {
-        let scheme = match self.scheme_str()? {
-            s @ ("http" | "https") => s,
-            _ => return None,
-        };
-
-        let host = self.host().filter(|h| !h.is_empty())?.to_ascii_lowercase();
-        let default: u16 = if scheme == "https" { 443 } else { 80 };
-
-        Some(match self.port_u16() {
-            Some(p) if p != default => format!("{scheme}://{host}:{p}"),
-            _ => format!("{scheme}://{host}"),
-        })
-    }
-
-    fn effective_port(&self) -> Option<u16> {
-        self.port_u16().or_else(|| self.scheme_default_port())
-    }
-
-    fn scheme_default_port(&self) -> Option<u16> {
-        match self.scheme_str() {
-            Some("https") => Some(443),
-            Some("http") => Some(80),
-            _ => None,
-        }
-    }
-
     fn parse_origin(input: &str) -> Result<Self, ConfigError> {
         if input.contains('#') {
             return Err(ConfigError::InvalidOriginUrlComponents {
@@ -132,9 +53,13 @@ impl UriExt for Uri {
             });
         }
 
-        let path = uri.path();
+        // Reject any path/query (fragments are rejected above). `http::Uri`
+        // reports `path()` as "/" for both `scheme://host` and `scheme://host/`,
+        // so detect a path from the raw input (everything after "://") to reach
+        // parity with Go, which rejects a non-empty path — including a bare "/".
+        let after_scheme = input.split_once("://").map_or("", |(_, rest)| rest);
 
-        if (path != "/" && !path.is_empty()) || uri.query().is_some() {
+        if after_scheme.contains('/') || uri.query().is_some() {
             return Err(ConfigError::InvalidOriginUrlComponents {
                 origin: input.to_owned(),
             });
@@ -148,99 +73,6 @@ impl UriExt for Uri {
 mod tests {
     use super::*;
 
-    fn uri(s: &str) -> Uri {
-        s.parse()
-            .unwrap_or_else(|e| panic!("{:?} failed to parse: {}", s, e))
-    }
-
-    #[test]
-    fn test_canonical() {
-        struct Test {
-            input: &'static str,
-            expected: Option<&'static str>,
-        }
-
-        let tests = [
-            Test {
-                input: "https://example.com",
-                expected: Some("https://example.com"),
-            },
-            Test {
-                input: "http://example.com",
-                expected: Some("http://example.com"),
-            },
-            Test {
-                input: "HTTPS://Example.COM",
-                expected: Some("https://example.com"),
-            },
-            Test {
-                input: "https://example.com:443",
-                expected: Some("https://example.com"),
-            },
-            Test {
-                input: "http://example.com:80",
-                expected: Some("http://example.com"),
-            },
-            Test {
-                input: "https://example.com:8443",
-                expected: Some("https://example.com:8443"),
-            },
-            Test {
-                input: "ftp://example.com",
-                expected: None,
-            },
-        ];
-
-        for test in tests {
-            assert_eq!(
-                uri(test.input).canonical().as_deref(),
-                test.expected,
-                "{}",
-                test.input
-            );
-        }
-    }
-
-    #[test]
-    fn test_effective_port() {
-        struct Test {
-            input: &'static str,
-            expected: Option<u16>,
-        }
-
-        let tests = [
-            Test {
-                input: "https://example.com",
-                expected: Some(443),
-            },
-            Test {
-                input: "http://example.com",
-                expected: Some(80),
-            },
-            Test {
-                input: "https://example.com:443",
-                expected: Some(443),
-            },
-            Test {
-                input: "https://example.com:8443",
-                expected: Some(8443),
-            },
-            Test {
-                input: "ftp://example.com",
-                expected: None,
-            },
-        ];
-
-        for test in tests {
-            assert_eq!(
-                uri(test.input).effective_port(),
-                test.expected,
-                "{}",
-                test.input
-            );
-        }
-    }
-
     #[test]
     fn test_parse_origin_accepts() {
         for input in [
@@ -248,7 +80,6 @@ mod tests {
             "http://example.com",
             "https://example.com:8443",
             "HTTPS://Example.COM",
-            "https://example.com/",
         ] {
             assert!(
                 Uri::parse_origin(input).is_ok(),
@@ -288,7 +119,11 @@ mod tests {
             ("javascript:alert(1)", |e| {
                 matches!(e, ConfigError::OpaqueOrigin { .. })
             }),
-            // Path/query/fragment not allowed on a trusted origin.
+            // Path/query/fragment not allowed on a trusted origin. A bare
+            // trailing slash is a (non-empty) path too — rejected, matching Go.
+            ("https://example.com/", |e| {
+                matches!(e, ConfigError::InvalidOriginUrlComponents { .. })
+            }),
             ("https://example.com/path", |e| {
                 matches!(e, ConfigError::InvalidOriginUrlComponents { .. })
             }),

--- a/tower-http/src/csrf/url.rs
+++ b/tower-http/src/csrf/url.rs
@@ -1,0 +1,278 @@
+use http::Uri;
+
+use super::ConfigError;
+
+pub(crate) struct TrustedOrigin(String);
+
+impl TrustedOrigin {
+    pub(crate) fn parse(input: &str) -> Result<Self, ConfigError> {
+        let uri = Uri::parse_origin(input)?;
+
+        Ok(Self(
+            uri.canonical()
+                .expect("parse_origin validates scheme and host"),
+        ))
+    }
+
+    pub(crate) fn into_canonical(self) -> String {
+        self.0
+    }
+}
+
+pub(crate) trait UriExt: Sized {
+    fn canonical(&self) -> Option<String>;
+
+    fn effective_port(&self) -> Option<u16>;
+
+    fn scheme_default_port(&self) -> Option<u16>;
+
+    fn parse_origin(input: &str) -> Result<Self, ConfigError>;
+}
+
+impl UriExt for Uri {
+    fn canonical(&self) -> Option<String> {
+        let scheme = match self.scheme_str()? {
+            s @ ("http" | "https") => s,
+            _ => return None,
+        };
+        let host = self.host().filter(|h| !h.is_empty())?.to_ascii_lowercase();
+        let default: u16 = if scheme == "https" { 443 } else { 80 };
+        Some(match self.port_u16() {
+            Some(p) if p != default => format!("{scheme}://{host}:{p}"),
+            _ => format!("{scheme}://{host}"),
+        })
+    }
+
+    fn effective_port(&self) -> Option<u16> {
+        self.port_u16().or_else(|| self.scheme_default_port())
+    }
+
+    fn scheme_default_port(&self) -> Option<u16> {
+        match self.scheme_str() {
+            Some("https") => Some(443),
+            Some("http") => Some(80),
+            _ => None,
+        }
+    }
+
+    fn parse_origin(input: &str) -> Result<Self, ConfigError> {
+        if input.contains('#') {
+            return Err(ConfigError::InvalidOriginUrlComponents {
+                origin: input.to_owned(),
+            });
+        }
+
+        // browsers will send punycode anyways
+        if !input.is_ascii() {
+            return Err(ConfigError::NonAsciiHostname {
+                origin: input.to_owned(),
+            });
+        }
+
+        let uri: Uri =
+            input
+                .parse()
+                .map_err(|e: http::uri::InvalidUri| ConfigError::InvalidOriginUrl {
+                    origin: input.to_owned(),
+                    message: e.to_string(),
+                })?;
+
+        if !matches!(uri.scheme_str(), Some("http" | "https"))
+            || uri.host().map_or(true, |h| h.is_empty())
+        {
+            return Err(ConfigError::OpaqueOrigin {
+                origin: input.to_owned(),
+            });
+        }
+
+        let path = uri.path();
+
+        if (path != "/" && !path.is_empty()) || uri.query().is_some() {
+            return Err(ConfigError::InvalidOriginUrlComponents {
+                origin: input.to_owned(),
+            });
+        }
+
+        Ok(uri)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uri(s: &str) -> Uri {
+        s.parse()
+            .unwrap_or_else(|e| panic!("{:?} failed to parse: {}", s, e))
+    }
+
+    #[test]
+    fn test_canonical() {
+        struct Test {
+            input: &'static str,
+            expected: Option<&'static str>,
+        }
+
+        let tests = [
+            Test {
+                input: "https://example.com",
+                expected: Some("https://example.com"),
+            },
+            Test {
+                input: "http://example.com",
+                expected: Some("http://example.com"),
+            },
+            Test {
+                input: "HTTPS://Example.COM",
+                expected: Some("https://example.com"),
+            },
+            Test {
+                input: "https://example.com:443",
+                expected: Some("https://example.com"),
+            },
+            Test {
+                input: "http://example.com:80",
+                expected: Some("http://example.com"),
+            },
+            Test {
+                input: "https://example.com:8443",
+                expected: Some("https://example.com:8443"),
+            },
+            Test {
+                input: "ftp://example.com",
+                expected: None,
+            },
+        ];
+
+        for test in tests {
+            assert_eq!(
+                uri(test.input).canonical().as_deref(),
+                test.expected,
+                "{}",
+                test.input
+            );
+        }
+    }
+
+    #[test]
+    fn test_effective_port() {
+        struct Test {
+            input: &'static str,
+            expected: Option<u16>,
+        }
+
+        let tests = [
+            Test {
+                input: "https://example.com",
+                expected: Some(443),
+            },
+            Test {
+                input: "http://example.com",
+                expected: Some(80),
+            },
+            Test {
+                input: "https://example.com:443",
+                expected: Some(443),
+            },
+            Test {
+                input: "https://example.com:8443",
+                expected: Some(8443),
+            },
+            Test {
+                input: "ftp://example.com",
+                expected: None,
+            },
+        ];
+
+        for test in tests {
+            assert_eq!(
+                uri(test.input).effective_port(),
+                test.expected,
+                "{}",
+                test.input
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_origin_accepts() {
+        for input in [
+            "https://example.com",
+            "http://example.com",
+            "https://example.com:8443",
+            "HTTPS://Example.COM",
+            "https://example.com/",
+        ] {
+            assert!(
+                Uri::parse_origin(input).is_ok(),
+                "expected Ok for {input:?}, got {:?}",
+                Uri::parse_origin(input)
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_origin_rejects() {
+        // Each row maps an input to the expected ConfigError variant.
+        // Marker functions over closures because PartialEq on the enum already
+        // makes equality the easy assertion shape.
+        type Check = fn(&ConfigError) -> bool;
+        let cases: &[(&str, Check)] = &[
+            // http::Uri rejects these outright at parse time.
+            ("not a valid url", |e| {
+                matches!(e, ConfigError::InvalidOriginUrl { .. })
+            }),
+            ("https://", |e| {
+                matches!(e, ConfigError::InvalidOriginUrl { .. })
+            }),
+            ("file:///", |e| {
+                matches!(e, ConfigError::InvalidOriginUrl { .. })
+            }),
+            // Parse OK but scheme is not http/https (or absent).
+            ("example.com", |e| {
+                matches!(e, ConfigError::OpaqueOrigin { .. })
+            }),
+            ("file://host/path", |e| {
+                matches!(e, ConfigError::OpaqueOrigin { .. })
+            }),
+            ("mailto:x@y.z", |e| {
+                matches!(e, ConfigError::OpaqueOrigin { .. })
+            }),
+            ("javascript:alert(1)", |e| {
+                matches!(e, ConfigError::OpaqueOrigin { .. })
+            }),
+            // Path/query/fragment not allowed on a trusted origin.
+            ("https://example.com/path", |e| {
+                matches!(e, ConfigError::InvalidOriginUrlComponents { .. })
+            }),
+            ("https://example.com/path?query=value", |e| {
+                matches!(e, ConfigError::InvalidOriginUrlComponents { .. })
+            }),
+            ("https://example.com/path#fragment", |e| {
+                matches!(e, ConfigError::InvalidOriginUrlComponents { .. })
+            }),
+            // http::Uri silently strips fragments; the `contains('#')` pre-check
+            // surfaces these as component errors instead of letting them slip in.
+            ("https://example.com#fragment", |e| {
+                matches!(e, ConfigError::InvalidOriginUrlComponents { .. })
+            }),
+            ("https://example.com/#fragment", |e| {
+                matches!(e, ConfigError::InvalidOriginUrlComponents { .. })
+            }),
+            // IDN hosts must be supplied in punycode.
+            ("https://ümlaut.de", |e| {
+                matches!(e, ConfigError::NonAsciiHostname { .. })
+            }),
+            ("https://日本.jp", |e| {
+                matches!(e, ConfigError::NonAsciiHostname { .. })
+            }),
+        ];
+
+        for (input, predicate) in cases {
+            match Uri::parse_origin(input) {
+                Err(e) if predicate(&e) => {}
+                other => panic!("unexpected result for {:?}: {:?}", input, other),
+            }
+        }
+    }
+}

--- a/tower-http/src/csrf/url.rs
+++ b/tower-http/src/csrf/url.rs
@@ -2,9 +2,19 @@ use http::Uri;
 
 use super::ConfigError;
 
+/// A validated, canonicalized trusted-origin string.
+///
+/// Wraps the output of [`UriExt::parse_origin`] + [`UriExt::canonical`] so the
+/// canonical string can be carried around the type system without re-validation.
+/// Construct via [`TrustedOrigin::parse`]; unwrap the inner string with
+/// [`TrustedOrigin::into_canonical`].
 pub(crate) struct TrustedOrigin(String);
 
 impl TrustedOrigin {
+    /// Parses and canonicalizes `input` as a trusted origin.
+    ///
+    /// Forwards validation to [`UriExt::parse_origin`] (see that method for the
+    /// rejected forms) and then runs [`UriExt::canonical`] on the result.
     pub(crate) fn parse(input: &str) -> Result<Self, ConfigError> {
         let uri = Uri::parse_origin(input)?;
 
@@ -14,18 +24,53 @@ impl TrustedOrigin {
         ))
     }
 
+    /// Consumes the wrapper and returns the canonical `scheme://host[:port]`
+    /// string.
     pub(crate) fn into_canonical(self) -> String {
         self.0
     }
 }
 
+/// Internal extension methods on [`http::Uri`] used by the CSRF middleware to
+/// normalize and compare browser-supplied `Origin` values.
 pub(crate) trait UriExt: Sized {
+    /// Returns the canonical `scheme://host[:port]` representation, or `None`
+    /// for URIs that can't appear in a browser `Origin` header.
+    ///
+    /// Normalization:
+    ///
+    /// - scheme is `http` or `https` (otherwise `None`);
+    /// - host is non-empty and ASCII-lowercased;
+    /// - default ports (`80` for `http`, `443` for `https`) are stripped;
+    /// - non-default ports are preserved verbatim.
+    ///
+    /// Used on both sides of the trusted-origin and `Origin`/`Host`
+    /// comparisons so that incidental form differences (case, explicit default
+    /// ports) don't cause a legitimate request to be rejected.
     fn canonical(&self) -> Option<String>;
 
+    /// Returns the URI's explicit port if present, otherwise the IANA default
+    /// for its scheme. Returns `None` for schemes without a known default.
     fn effective_port(&self) -> Option<u16>;
 
+    /// Returns the IANA default port for the URI's scheme (`80` for `http`,
+    /// `443` for `https`), or `None` for any other scheme.
     fn scheme_default_port(&self) -> Option<u16>;
 
+    /// Parses a trusted-origin string of the form `scheme://host[:port]`.
+    ///
+    /// Rejects inputs that can't represent a browser `Origin`:
+    ///
+    /// - unparseable URIs ([`ConfigError::InvalidOriginUrl`]);
+    /// - non-`http`/`https` schemes or missing host ([`ConfigError::OpaqueOrigin`]);
+    /// - any path, query, or fragment component
+    ///   ([`ConfigError::InvalidOriginUrlComponents`] — including fragments
+    ///   that `http::Uri` would otherwise silently strip);
+    /// - non-ASCII hostnames ([`ConfigError::NonAsciiHostname`] — IDN hosts
+    ///   must be supplied in punycode, since that's what browsers send).
+    ///
+    /// The returned [`Uri`] is parsed but not canonicalized; callers should
+    /// run [`UriExt::canonical`] before storing or comparing it.
     fn parse_origin(input: &str) -> Result<Self, ConfigError>;
 }
 
@@ -35,8 +80,10 @@ impl UriExt for Uri {
             s @ ("http" | "https") => s,
             _ => return None,
         };
+
         let host = self.host().filter(|h| !h.is_empty())?.to_ascii_lowercase();
         let default: u16 = if scheme == "https" { 443 } else { 80 };
+
         Some(match self.port_u16() {
             Some(p) if p != default => format!("{scheme}://{host}:{p}"),
             _ => format!("{scheme}://{host}"),

--- a/tower-http/src/lib.rs
+++ b/tower-http/src/lib.rs
@@ -296,6 +296,9 @@ pub mod metrics;
 #[cfg(feature = "cors")]
 pub mod cors;
 
+#[cfg(feature = "csrf")]
+pub mod csrf;
+
 #[cfg(feature = "request-id")]
 pub mod request_id;
 


### PR DESCRIPTION
Ports the CSRF protection scheme introduced in Go 1.25 (described in Filippo Valsorda's blog post) as a new optional `csrf` feature. The middleware combines `Sec-Fetch-Site`, an `Origin` allow-list, and an `Origin`/`Host` fallback to reject cross-origin state-changing requests without per-request token state.

See #656 for context.