### PR TITLE
docs: fix typos in ServeDir, ServeFile, and conditional headers

### DIFF
--- a/tower-http/src/services/fs/serve_dir/headers.rs
+++ b/tower-http/src/services/fs/serve_dir/headers.rs
@@ -18,7 +18,7 @@ impl IfModifiedSince {
         self.0 < last_modified.0
     }
 
-    /// convert a header value into a IfModifiedSince, invalid values are silentely ignored
+    /// Convert a header value into a IfModifiedSince. Invalid values are silently ignored
     pub(super) fn from_header_value(value: &HeaderValue) -> Option<IfModifiedSince> {
         std::str::from_utf8(value.as_bytes())
             .ok()
@@ -35,7 +35,7 @@ impl IfUnmodifiedSince {
         self.0 >= last_modified.0
     }
 
-    /// Convert a header value into a IfModifiedSince, invalid values are silentely ignored
+    /// Convert a header value into a IfUnmodifiedSince. Invalid values are silently ignored
     pub(super) fn from_header_value(value: &HeaderValue) -> Option<IfUnmodifiedSince> {
         std::str::from_utf8(value.as_bytes())
             .ok()

--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -54,7 +54,7 @@ pub struct ServeDir<F = DefaultServeDirFallback> {
     base: PathBuf,
     buf_chunk_size: usize,
     precompressed_variants: Option<PrecompressedVariants>,
-    // This is used to specialise implementation for
+    // This is used to specialize implementation for
     // single files
     variant: ServeVariant,
     fallback: Option<F>,
@@ -296,7 +296,7 @@ impl<F> ServeDir<F> {
     ///     let mut service = ServeDir::new("assets");
     ///
     ///     // You only need to worry about backpressure, and thus call `ServiceExt::ready`, if
-    ///     // your adding a fallback to `ServeDir` that cares about backpressure.
+    ///     // you are adding a fallback to `ServeDir` that cares about backpressure.
     ///     //
     ///     // Its shown here for demonstration but you can do `service.try_call(request)`
     ///     // otherwise

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -75,7 +75,7 @@ async fn head_request() {
 }
 
 #[tokio::test]
-async fn precompresed_head_request() {
+async fn precompressed_head_request() {
     let svc = ServeDir::new(TEST_FILES_DIR).precompressed_gzip();
 
     let req = Request::builder()

--- a/tower-http/src/services/fs/serve_file.rs
+++ b/tower-http/src/services/fs/serve_file.rs
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn precompresed_head_request() {
+    async fn precompressed_head_request() {
         let svc =
             ServeFile::new(format!("{TEST_FILES_DIR}/precompressed.txt")).precompressed_gzip();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

This PR fixes minor typographical, grammatical, and formatting errors found across the file-serving modules and documentation comments. 

## Solution

* **`ServeFile`**: Fixed a typo in a test name (`precompresed` -> `precompressed`).
* **Header Utils (`LastModified` / `IfModifiedSince`)**: 
  * Fixed typo `silentely` -> `silently`.
  * Corrected typo where `IfUnmodifiedSince` documentation incorrectly referred to `IfModifiedSince`.
  * Capitalized standard doc comments for consistency.
* **`ServeDir`**:
  * Fixed grammar in `try_call` doc example (`your adding` -> `you are adding`).
  * Updated `specialise` to `specialize` to match standard US English naming conventions used elsewhere in the crate (`Customize`).