### PR TITLE
fix: Make SetMultiple*Header Clone for !Clone http bodies

### DIFF
--- a/tower-http/src/set_header/mod.rs
+++ b/tower-http/src/set_header/mod.rs
@@ -157,12 +157,21 @@ impl<T> fmt::Debug for BoxedMakeHeaderValue<T> {
 }
 
 /// Metadata describing a request or response header to be set.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct HeaderMetadata<T> {
     /// The name of the header to set.
     header_name: HeaderName,
     /// The value or value factory for the header.
     make: BoxedMakeHeaderValue<T>,
+}
+
+impl<T> Clone for HeaderMetadata<T> {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            make: self.make.clone(),
+        }
+    }
 }
 
 impl<T> HeaderMetadata<T> {

--- a/tower-http/src/set_header/request/multiple_headers.rs
+++ b/tower-http/src/set_header/request/multiple_headers.rs
@@ -15,9 +15,16 @@ use crate::set_header::{HeaderInsertionConfig, HeaderMetadata, InsertHeaderMode}
 /// Layer that applies [`SetMultipleRequestHeader`] which adds multiple request headers.
 ///
 /// See [`SetMultipleRequestHeader`] for more details.
-#[derive(Clone)]
 pub struct SetMultipleRequestHeadersLayer<M> {
     headers: Vec<HeaderInsertionConfig<M>>,
+}
+
+impl<M> Clone for SetMultipleRequestHeadersLayer<M> {
+    fn clone(&self) -> Self {
+        Self {
+            headers: self.headers.clone(),
+        }
+    }
 }
 
 impl<M> fmt::Debug for SetMultipleRequestHeadersLayer<M> {
@@ -84,10 +91,21 @@ impl<S, M> Layer<S> for SetMultipleRequestHeadersLayer<M> {
 }
 
 /// Middleware that sets multiple headers on the request.
-#[derive(Clone)]
 pub struct SetMultipleRequestHeader<S, M> {
     inner: S,
     headers: Vec<HeaderInsertionConfig<M>>,
+}
+
+impl<S, M> Clone for SetMultipleRequestHeader<S, M>
+where
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            headers: self.headers.clone(),
+        }
+    }
 }
 
 impl<S, M> SetMultipleRequestHeader<S, M> {
@@ -360,5 +378,19 @@ mod tests {
         let layer = SetMultipleRequestHeadersLayer::overriding(vec![meta]);
         let debug_str = format!("{:?}", layer);
         assert!(debug_str.contains("SetMultipleRequestHeadersLayer"));
+    }
+
+    #[test]
+    fn test_service_clone() {
+        struct NonCloneBody;
+        let svc = tower::ServiceBuilder::new()
+            .layer(SetMultipleRequestHeadersLayer::<Request<NonCloneBody>>::overriding(vec![]))
+            .check_clone()
+            .service(service_fn(|_: Request<NonCloneBody>| async move {
+                Ok::<_, Infallible>(Response::new(NonCloneBody))
+            }));
+
+        fn check_service_and_clone<T: Service<Request<NonCloneBody>> + Clone>(_: T) {}
+        check_service_and_clone(svc);
     }
 }


### PR DESCRIPTION
Replace some derived `Clone` implementations with manual ones.

## Motivation

For a couple structs, `Clone` was previously derived, creating a `Clone` bound
on the http request and therefore the request body. This meant that it wasn't
possible to use `SetMultipleRequestHeader` and `SetMultipleResponseHeader` for, for example, tonic.

## Solution

Manually implement `Clone` for the relevant types, to avoid the 
`impl<M: Clone> Clone for T<M>` bounds that caused the resulting service to not be Clone.

