### PR TITLE
feat(compression)!: upgrade SizeAbove threshold from u16 to u64

### DIFF
--- a/tower-http/src/compression/predicate.rs
+++ b/tower-http/src/compression/predicate.rs
@@ -146,17 +146,17 @@ impl Predicate for DefaultPredicate {
 
 /// [`Predicate`] that will only allow compression of responses above a certain size.
 #[derive(Clone, Copy, Debug)]
-pub struct SizeAbove(u16);
+pub struct SizeAbove(u64);
 
 impl SizeAbove {
-    pub(crate) const DEFAULT_MIN_SIZE: u16 = 32;
+    pub(crate) const DEFAULT_MIN_SIZE: u64 = 32;
 
     /// Create a new `SizeAbove` predicate that will only compress responses larger than
     /// `min_size_bytes`.
     ///
     /// The response will be compressed if the exact size cannot be determined through either the
     /// `content-length` header or [`Body::size_hint`].
-    pub const fn new(min_size_bytes: u16) -> Self {
+    pub const fn new(min_size_bytes: u64) -> Self {
         Self(min_size_bytes)
     }
 }
@@ -181,7 +181,7 @@ impl Predicate for SizeAbove {
         });
 
         match content_size {
-            Some(size) => size >= (self.0 as u64),
+            Some(size) => size >= self.0,
             _ => true,
         }
     }


### PR DESCRIPTION
## Motivation

I was looking through some older issues and noticed this issue #525 that have been stale for awhile now.

Right now, `SizeAbove` uses a `u16` internally to hold the byte threshold for response compression. Because of that, the absolute maximum limit anyone can configure is about 64 KiB. 

While that works great for tiny payloads, 64 KiB is pretty small for modern high-speed connections. If a service is heavily CPU-bound and wants to skip compressing payloads under 1 MB or 2 MB to save processing power, they're kind of stuck. They have to completely copy-paste and reimplement `SizeAbove` just to change the integer type, which feels a bit redundant since the rest of the predicate ecosystem here is so nice to use.

## Solution

* Bumped `SizeAbove(u16)` to `SizeAbove(u64)`.
* Updated `DEFAULT_MIN_SIZE` and the `new` function to expect a `u64`.
* Cleaned up the `Predicate` implementation for `SizeAbove` by removing the `self.0 as u64` cast, since the types natively match up now.

### Question

I wanted to ask from a maintainer's perspective. is there a drawback to doing this that I'm completely missing? I was trying to figure out if `u16` was originally picked for a specific reason. Since these predicates are usually created once and live for the lifetime of the server, I figured the extra bytes wouldn't hurt anything, but I'd love to know if there's any historical context or edge cases I should learn about!