### PR TITLE
Add Windows drive-prefix path regression test

### DIFF
--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -1117,31 +1117,42 @@ fn test_build_and_validate_path_reserved_dos_names() {
     }
 }
 
-#[test]
-fn test_build_and_validate_path_windows_drive_prefixes() {
-    use super::ServeVariant;
-    use std::path::Path;
+// Regression test for the Windows directory-traversal fix in #204 (tracked by #251):
+// a drive-letter prefix such as `C:` must not be served as an absolute path.
+#[tokio::test]
+async fn reject_windows_drive_prefixed_path() {
+    let svc = ServeDir::new(TEST_FILES_DIR);
 
-    let variant = ServeVariant::Directory {
-        append_index_html_on_directories: true,
-        html_as_default_extension: false,
-    };
-    let base = Path::new("/base");
+    let req = Request::builder()
+        .uri("/C:/windows/win.ini")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
 
-    let paths = [
-        "/anypath/c:/windows/win.ini",
-        "/anypath/C:/windows/win.ini",
-        "/anypath/d:/windows/web/screen/img101.png",
-    ];
+    assert_eq!(
+        res.status(),
+        StatusCode::NOT_FOUND,
+        "drive-prefixed path should be rejected, not served"
+    );
+}
 
-    for path in paths {
-        let result = variant.build_and_validate_path(base, path);
-        if cfg!(windows) {
-            assert!(result.is_none(), "Expected None for path: {}", path);
-        } else {
-            assert!(result.is_some(), "Expected Some for path: {}", path);
-        }
-    }
+// As above, but with the `:` percent-encoded (`%3A`) to confirm the drive prefix
+// is still rejected *after* URL decoding.
+#[tokio::test]
+async fn reject_percent_encoded_windows_drive_prefixed_path() {
+    let svc = ServeDir::new(TEST_FILES_DIR);
+
+    let req = Request::builder()
+        .uri("/anypath/c%3A/windows/win.ini")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(
+        res.status(),
+        StatusCode::NOT_FOUND,
+        "percent-encoded drive prefix should be rejected after decoding"
+    );
 }
 
 // Regression test for https://github.com/tower-rs/tower-http/issues/664

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -1117,6 +1117,33 @@ fn test_build_and_validate_path_reserved_dos_names() {
     }
 }
 
+#[test]
+fn test_build_and_validate_path_windows_drive_prefixes() {
+    use super::ServeVariant;
+    use std::path::Path;
+
+    let variant = ServeVariant::Directory {
+        append_index_html_on_directories: true,
+        html_as_default_extension: false,
+    };
+    let base = Path::new("/base");
+
+    let paths = [
+        "/anypath/c:/windows/win.ini",
+        "/anypath/C:/windows/win.ini",
+        "/anypath/d:/windows/web/screen/img101.png",
+    ];
+
+    for path in paths {
+        let result = variant.build_and_validate_path(base, path);
+        if cfg!(windows) {
+            assert!(result.is_none(), "Expected None for path: {}", path);
+        } else {
+            assert!(result.is_some(), "Expected Some for path: {}", path);
+        }
+    }
+}
+
 // Regression test for https://github.com/tower-rs/tower-http/issues/664
 // Accept-Encoding: identity should not cause extension stripping
 #[tokio::test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tower-rs/tower-http/blob/master/CONTRIBUTING.md
-->

## Motivation

#251 notes that #204 fixed a Windows directory traversal issue without adding a regression test.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Add a regression test for Windows drive-prefix path components in `ServeDir` path validation. (#251)


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
