### PR TITLE
feat(follow_redirect)!: preserve request extensions across redirects

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -39,6 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Opt out with `FollowRedirectLayer::preserve_extensions(false)`; keep specific
   types with `FilterCredentials::allow_extension::<T>()` or all of them with
   `keep_all_extensions()`. ([#581])
+- **breaking:** `follow-redirect`: header and extension filtering is now
+  cumulative. A value a policy drops on one hop is no longer replayed on later
+  hops, so `FilterCredentials` no longer re-sends `Cookie`/`Authorization` to a
+  same-origin target reached after a cross-origin hop. Custom `Policy::on_request`
+  impls now see the previous hop's filtered request, not the original. ([#581])
 
 [#215]: https://github.com/tower-rs/tower-http/issues/215
 [#360]: https://github.com/tower-rs/tower-http/pull/360

--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -33,9 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by the features that need them (e.g. `compression-gzip`, `fs`, `timeout`).
   ([#628])
 - MSRV bumped from 1.64 to 1.65.
+- **breaking:** `follow-redirect`: `FollowRedirect` now forwards request
+  `Extensions` to redirected requests instead of dropping them. The `Standard`
+  policy drops extensions on cross-origin redirections (same-origin keeps them).
+  Opt out with `FollowRedirectLayer::preserve_extensions(false)`; keep specific
+  types with `FilterCredentials::allow_extension::<T>()` or all of them with
+  `keep_all_extensions()`. ([#581])
 
 [#215]: https://github.com/tower-rs/tower-http/issues/215
 [#360]: https://github.com/tower-rs/tower-http/pull/360
+[#581]: https://github.com/tower-rs/tower-http/pull/581
 [#628]: https://github.com/tower-rs/tower-http/pull/628
 [#642]: https://github.com/tower-rs/tower-http/pull/642
 

--- a/tower-http/src/follow_redirect/mod.rs
+++ b/tower-http/src/follow_redirect/mod.rs
@@ -6,11 +6,14 @@
 //! redirections.
 //!
 //! The middleware tries to clone the original [`Request`] when making a redirected request.
-//! However, since [`Extensions`][http::Extensions] are `!Clone`, any extensions set by outer
-//! middleware will be discarded. Also, the request body cannot always be cloned. When the
-//! original body is known to be empty by [`Body::size_hint`], the middleware uses `Default`
-//! implementation of the body type to create a new request body. If you know that the body can be
-//! cloned in some way, you can tell the middleware to clone it by configuring a [`policy`].
+//! Request headers and [`Extensions`] set by outer middleware are carried over to redirected
+//! requests by default; the configured [`policy`] decides whether they survive a given redirection
+//! via [`Policy::on_request`] (the [`Standard`] policy drops credential headers and all extensions
+//! on cross-origin redirections), and [`FollowRedirectLayer::preserve_extensions`] can disable
+//! extension forwarding entirely. The request body cannot always be cloned. When the original
+//! body is known to be empty by [`Body::size_hint`], the middleware uses `Default` implementation
+//! of the body type to create a new request body. If you know that the body can be cloned in some
+//! way, you can tell the middleware to clone it by configuring a [`policy`].
 //!
 //! # Examples
 //!
@@ -98,8 +101,8 @@ use self::policy::{Action, Attempt, Policy, Standard};
 use futures_util::future::Either;
 use http::{
     header::CONTENT_ENCODING, header::CONTENT_LENGTH, header::CONTENT_TYPE, header::LOCATION,
-    header::TRANSFER_ENCODING, HeaderMap, HeaderValue, Method, Request, Response, StatusCode, Uri,
-    Version,
+    header::TRANSFER_ENCODING, Extensions, HeaderMap, HeaderValue, Method, Request, Response,
+    StatusCode, Uri, Version,
 };
 use http_body::Body;
 use pin_project_lite::pin_project;
@@ -119,9 +122,10 @@ use url::Url;
 /// [`Layer`] for retrying requests with a [`Service`] to follow redirection responses.
 ///
 /// See the [module docs](self) for more details.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug)]
 pub struct FollowRedirectLayer<P = Standard> {
     policy: P,
+    preserve_extensions: bool,
 }
 
 impl FollowRedirectLayer {
@@ -134,7 +138,31 @@ impl FollowRedirectLayer {
 impl<P> FollowRedirectLayer<P> {
     /// Create a new [`FollowRedirectLayer`] with the given redirection [`Policy`].
     pub fn with_policy(policy: P) -> Self {
-        FollowRedirectLayer { policy }
+        FollowRedirectLayer {
+            policy,
+            preserve_extensions: true,
+        }
+    }
+
+    /// Configure whether request [`Extensions`] are carried over to redirected
+    /// requests.
+    ///
+    /// Defaults to `true`. Set this to `false` to drop all extensions on every redirected request,
+    /// restoring the behavior from before extensions were cloneable.
+    ///
+    /// Even when extensions are preserved, the [`Policy`] still gets to filter them in
+    /// [`Policy::on_request`]. The [`Standard`] policy drops extensions on cross-origin
+    /// redirections by default; see [`FilterCredentials`][policy::FilterCredentials] to customize
+    /// that.
+    pub fn preserve_extensions(mut self, preserve: bool) -> Self {
+        self.preserve_extensions = preserve;
+        self
+    }
+}
+
+impl<P: Default> Default for FollowRedirectLayer<P> {
+    fn default() -> Self {
+        FollowRedirectLayer::with_policy(P::default())
     }
 }
 
@@ -147,6 +175,7 @@ where
 
     fn layer(&self, inner: S) -> Self::Service {
         FollowRedirect::with_policy(inner, self.policy.clone())
+            .preserve_extensions(self.preserve_extensions)
     }
 }
 
@@ -157,6 +186,7 @@ where
 pub struct FollowRedirect<S, P = Standard> {
     inner: S,
     policy: P,
+    preserve_extensions: bool,
 }
 
 impl<S> FollowRedirect<S> {
@@ -179,7 +209,11 @@ where
 {
     /// Create a new [`FollowRedirect`] with the given redirection [`Policy`].
     pub fn with_policy(inner: S, policy: P) -> Self {
-        FollowRedirect { inner, policy }
+        FollowRedirect {
+            inner,
+            policy,
+            preserve_extensions: true,
+        }
     }
 
     /// Returns a new [`Layer`] that wraps services with a `FollowRedirect` middleware
@@ -191,6 +225,17 @@ where
     }
 
     define_inner_service_accessors!();
+}
+
+impl<S, P> FollowRedirect<S, P> {
+    /// Configure whether request [`Extensions`] are carried over to redirected
+    /// requests.
+    ///
+    /// See [`FollowRedirectLayer::preserve_extensions`] for details.
+    pub fn preserve_extensions(mut self, preserve: bool) -> Self {
+        self.preserve_extensions = preserve;
+        self
+    }
 }
 
 impl<ReqBody, ResBody, S, P> Service<Request<ReqBody>> for FollowRedirect<S, P>
@@ -214,11 +259,18 @@ where
         let mut body = BodyRepr::None;
         body.try_clone_from(req.body(), &policy);
         policy.on_request(&mut req);
+        // Snapshot the extensions to replay on redirected requests (empty when not preserving).
+        let extensions = if self.preserve_extensions {
+            req.extensions().clone()
+        } else {
+            Extensions::new()
+        };
         ResponseFuture {
             method: req.method().clone(),
             uri: req.uri().clone(),
             version: req.version(),
             headers: req.headers().clone(),
+            extensions,
             body,
             future: Either::Left(service.call(req)),
             service,
@@ -242,6 +294,7 @@ pin_project! {
         uri: Uri,
         version: Version,
         headers: HeaderMap<HeaderValue>,
+        extensions: Extensions,
         body: BodyRepr<B>,
     }
 }
@@ -325,6 +378,7 @@ where
                 *req.method_mut() = this.method.clone();
                 *req.version_mut() = *this.version;
                 *req.headers_mut() = this.headers.clone();
+                *req.extensions_mut() = this.extensions.clone();
                 this.policy.on_request(&mut req);
                 this.future
                     .set(Either::Right(Oneshot::new(this.service.clone(), req)));
@@ -337,7 +391,7 @@ where
     }
 }
 
-/// Response [`Extensions`][http::Extensions] value that represents the effective request URI of
+/// Response [`Extensions`] value that represents the effective request URI of
 /// a response returned by a [`FollowRedirect`] middleware.
 ///
 /// The value differs from the original request's effective URI if the middleware has followed
@@ -463,8 +517,100 @@ mod tests {
         );
     }
 
+    #[derive(Clone, Debug, PartialEq)]
+    struct Marker(u32);
+
+    #[tokio::test]
+    async fn preserves_extensions() {
+        let svc = ServiceBuilder::new()
+            .layer(FollowRedirectLayer::new())
+            .buffer(1)
+            .service_fn(handle);
+        let mut req = Request::builder()
+            .uri("http://example.com/42")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(Marker(7));
+        let res = svc.oneshot(req).await.unwrap();
+        // The same-origin redirect chain should carry the extension through to the final request.
+        assert_eq!(res.extensions().get::<Marker>(), Some(&Marker(7)));
+    }
+
+    #[tokio::test]
+    async fn preserve_extensions_opt_out() {
+        let svc = ServiceBuilder::new()
+            .layer(FollowRedirectLayer::new().preserve_extensions(false))
+            .buffer(1)
+            .service_fn(handle);
+        let mut req = Request::builder()
+            .uri("http://example.com/42")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(Marker(7));
+        let res = svc.oneshot(req).await.unwrap();
+        assert!(res.extensions().get::<Marker>().is_none());
+    }
+
+    #[tokio::test]
+    async fn drops_extensions_cross_origin() {
+        let svc = ServiceBuilder::new()
+            .layer(FollowRedirectLayer::new())
+            .buffer(1)
+            .service_fn(cross_origin);
+        let mut req = Request::builder()
+            .uri("http://a.example.com/")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(Marker(7));
+        let res = svc.oneshot(req).await.unwrap();
+        // The Standard policy treats the cross-origin hop as blocked and drops the extension.
+        assert!(res.extensions().get::<Marker>().is_none());
+        assert_eq!(
+            res.extensions().get::<RequestUri>().unwrap().0,
+            "http://b.example.com/"
+        );
+    }
+
+    #[tokio::test]
+    async fn allowlisted_extension_survives_cross_origin() {
+        #[derive(Clone, Debug, PartialEq)]
+        struct Allowed(u32);
+
+        let svc = ServiceBuilder::new()
+            .layer(FollowRedirectLayer::with_policy(
+                FilterCredentials::new().allow_extension::<Allowed>(),
+            ))
+            .buffer(1)
+            .service_fn(cross_origin);
+        let mut req = Request::builder()
+            .uri("http://a.example.com/")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(Marker(7));
+        req.extensions_mut().insert(Allowed(9));
+        let res = svc.oneshot(req).await.unwrap();
+        assert!(res.extensions().get::<Marker>().is_none());
+        assert_eq!(res.extensions().get::<Allowed>(), Some(&Allowed(9)));
+    }
+
+    /// Redirects `a.example.com` to `b.example.com` once, then echoes the final request's
+    /// extensions back on the response.
+    async fn cross_origin<B>(req: Request<B>) -> Result<Response<u64>, Infallible> {
+        let mut res = Response::builder();
+        if req.uri().host() == Some("a.example.com") {
+            res = res
+                .status(StatusCode::MOVED_PERMANENTLY)
+                .header(LOCATION, "http://b.example.com/");
+        }
+        if let Some(extensions) = res.extensions_mut() {
+            *extensions = req.extensions().clone();
+        }
+        Ok::<_, Infallible>(res.body(0).unwrap())
+    }
+
     /// A server with an endpoint `/{n}` which redirects to `/{n-1}` unless `n` equals zero,
-    /// returning `n` as the response body.
+    /// returning `n` as the response body. The request's extensions are echoed back on the
+    /// response so tests can observe which extensions reached the final request.
     async fn handle<B>(req: Request<B>) -> Result<Response<u64>, Infallible> {
         let n: u64 = req.uri().path()[1..].parse().unwrap();
         let mut res = Response::builder();
@@ -472,6 +618,9 @@ mod tests {
             res = res
                 .status(StatusCode::MOVED_PERMANENTLY)
                 .header(LOCATION, format!("/{}", n - 1));
+        }
+        if let Some(extensions) = res.extensions_mut() {
+            *extensions = req.extensions().clone();
         }
         Ok::<_, Infallible>(res.body(n).unwrap())
     }

--- a/tower-http/src/follow_redirect/mod.rs
+++ b/tower-http/src/follow_redirect/mod.rs
@@ -10,10 +10,12 @@
 //! requests by default; the configured [`policy`] decides whether they survive a given redirection
 //! via [`Policy::on_request`] (the [`Standard`] policy drops credential headers and all extensions
 //! on cross-origin redirections), and [`FollowRedirectLayer::preserve_extensions`] can disable
-//! extension forwarding entirely. The request body cannot always be cloned. When the original
-//! body is known to be empty by [`Body::size_hint`], the middleware uses `Default` implementation
-//! of the body type to create a new request body. If you know that the body can be cloned in some
-//! way, you can tell the middleware to clone it by configuring a [`policy`].
+//! extension forwarding entirely. Filtering is cumulative: a header or extension dropped on one
+//! hop is not replayed on later hops, so it cannot reappear after a cross-origin redirection. The
+//! request body cannot always be cloned. When the original body is known to be empty by
+//! [`Body::size_hint`], the middleware uses `Default` implementation of the body type to create a
+//! new request body. If you know that the body can be cloned in some way, you can tell the
+//! middleware to clone it by configuring a [`policy`].
 //!
 //! # Examples
 //!
@@ -380,6 +382,10 @@ where
                 *req.headers_mut() = this.headers.clone();
                 *req.extensions_mut() = this.extensions.clone();
                 this.policy.on_request(&mut req);
+                // Carry the filtered headers and extensions forward so anything dropped on this
+                // hop stays dropped on the next one (e.g. credentials after a cross-origin hop).
+                *this.headers = req.headers().clone();
+                *this.extensions = req.extensions().clone();
                 this.future
                     .set(Either::Right(Oneshot::new(this.service.clone(), req)));
 
@@ -593,6 +599,30 @@ mod tests {
         assert_eq!(res.extensions().get::<Allowed>(), Some(&Allowed(9)));
     }
 
+    #[tokio::test]
+    async fn headers_and_extensions_do_not_resurrect_after_cross_origin() {
+        let svc = ServiceBuilder::new()
+            .layer(FollowRedirectLayer::new())
+            .buffer(1)
+            .service_fn(resurrection_chain);
+        let mut req = Request::builder()
+            .uri("http://a.example.com/")
+            .header(http::header::COOKIE, "secret")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(Marker(7));
+        let res = svc.oneshot(req).await.unwrap();
+        // The chain is a.example.com -> b.example.com/second (cross-origin, both dropped) ->
+        // b.example.com/final (same-origin). Neither the cookie nor the extension may reappear on
+        // the final, same-origin request just because the original snapshot is replayed.
+        assert_eq!(
+            res.extensions().get::<RequestUri>().unwrap().0,
+            "http://b.example.com/final"
+        );
+        assert!(res.extensions().get::<Marker>().is_none());
+        assert!(!res.headers().contains_key("x-saw-cookie"));
+    }
+
     /// Redirects `a.example.com` to `b.example.com` once, then echoes the final request's
     /// extensions back on the response.
     async fn cross_origin<B>(req: Request<B>) -> Result<Response<u64>, Infallible> {
@@ -606,6 +636,35 @@ mod tests {
             *extensions = req.extensions().clone();
         }
         Ok::<_, Infallible>(res.body(0).unwrap())
+    }
+
+    /// A three-hop chain: `a.example.com` redirects cross-origin to `b.example.com/second`, which
+    /// redirects same-origin to `b.example.com/final`. Each response echoes the request's
+    /// extensions and flags (via the `x-saw-cookie` response header) whether the request still
+    /// carried a `Cookie`, so a test can detect credentials or extensions reappearing after the
+    /// cross-origin hop.
+    async fn resurrection_chain<B>(req: Request<B>) -> Result<Response<u64>, Infallible> {
+        let location = match (req.uri().host(), req.uri().path()) {
+            (Some("a.example.com"), _) => Some("http://b.example.com/second"),
+            (Some("b.example.com"), "/second") => Some("http://b.example.com/final"),
+            _ => None,
+        };
+        let saw_cookie = req.headers().contains_key(http::header::COOKIE);
+        let mut builder = Response::builder();
+        if let Some(location) = location {
+            builder = builder
+                .status(StatusCode::TEMPORARY_REDIRECT)
+                .header(LOCATION, location);
+        }
+        if let Some(extensions) = builder.extensions_mut() {
+            *extensions = req.extensions().clone();
+        }
+        let mut res = builder.body(0).unwrap();
+        if saw_cookie {
+            res.headers_mut()
+                .insert("x-saw-cookie", HeaderValue::from_static("yes"));
+        }
+        Ok::<_, Infallible>(res)
     }
 
     /// A server with an endpoint `/{n}` which redirects to `/{n-1}` unless `n` equals zero,

--- a/tower-http/src/follow_redirect/mod.rs
+++ b/tower-http/src/follow_redirect/mod.rs
@@ -6,16 +6,16 @@
 //! redirections.
 //!
 //! The middleware tries to clone the original [`Request`] when making a redirected request.
-//! Request headers and [`Extensions`] set by outer middleware are carried over to redirected
-//! requests by default; the configured [`policy`] decides whether they survive a given redirection
-//! via [`Policy::on_request`] (the [`Standard`] policy drops credential headers and all extensions
-//! on cross-origin redirections), and [`FollowRedirectLayer::preserve_extensions`] can disable
-//! extension forwarding entirely. Filtering is cumulative: a header or extension dropped on one
-//! hop is not replayed on later hops, so it cannot reappear after a cross-origin redirection. The
-//! request body cannot always be cloned. When the original body is known to be empty by
-//! [`Body::size_hint`], the middleware uses `Default` implementation of the body type to create a
-//! new request body. If you know that the body can be cloned in some way, you can tell the
-//! middleware to clone it by configuring a [`policy`].
+//! Request headers and [`Extensions`] are carried over to redirected requests; the [`policy`]
+//! decides which survive each hop (the [`Standard`] policy drops credential headers and all
+//! extensions cross-origin), and filtering is cumulative, so a dropped value never reappears later
+//! in the chain. Extension forwarding can be disabled with
+//! [`FollowRedirectLayer::preserve_extensions`].
+//!
+//! The request body cannot always be cloned. When the original body is known to be empty by
+//! [`Body::size_hint`], the middleware uses the `Default` implementation of the body type. If the
+//! body can be cloned in some way, you can tell the middleware to clone it by configuring a
+//! [`policy`].
 //!
 //! # Examples
 //!
@@ -146,16 +146,11 @@ impl<P> FollowRedirectLayer<P> {
         }
     }
 
-    /// Configure whether request [`Extensions`] are carried over to redirected
-    /// requests.
+    /// Whether request [`Extensions`] are carried over to redirected requests. Defaults to `true`.
     ///
-    /// Defaults to `true`. Set this to `false` to drop all extensions on every redirected request,
-    /// restoring the behavior from before extensions were cloneable.
-    ///
-    /// Even when extensions are preserved, the [`Policy`] still gets to filter them in
-    /// [`Policy::on_request`]. The [`Standard`] policy drops extensions on cross-origin
-    /// redirections by default; see [`FilterCredentials`][policy::FilterCredentials] to customize
-    /// that.
+    /// Setting this to `false` drops all extensions on redirected requests. When preserved, the
+    /// [`policy`] still filters them via [`Policy::on_request`]; the [`Standard`] policy drops
+    /// extensions cross-origin (see [`FilterCredentials`][policy::FilterCredentials]).
     pub fn preserve_extensions(mut self, preserve: bool) -> Self {
         self.preserve_extensions = preserve;
         self
@@ -230,10 +225,9 @@ where
 }
 
 impl<S, P> FollowRedirect<S, P> {
-    /// Configure whether request [`Extensions`] are carried over to redirected
-    /// requests.
+    /// Whether request [`Extensions`] are carried over to redirected requests. Defaults to `true`.
     ///
-    /// See [`FollowRedirectLayer::preserve_extensions`] for details.
+    /// See [`FollowRedirectLayer::preserve_extensions`].
     pub fn preserve_extensions(mut self, preserve: bool) -> Self {
         self.preserve_extensions = preserve;
         self

--- a/tower-http/src/follow_redirect/policy/filter_credentials.rs
+++ b/tower-http/src/follow_redirect/policy/filter_credentials.rs
@@ -6,14 +6,11 @@ use http::{
 
 /// A redirection [`Policy`] that removes credentials from requests in redirections.
 ///
-/// In addition to request headers, this policy also filters request
-/// [`Extensions`] in "blocked" redirections. Because extensions are keyed by
-/// arbitrary user types, there is no built-in blocklist of sensitive extensions to mirror the
-/// header blocklist. Instead, blocked redirections drop *all* extensions by default, and callers
-/// opt specific types back in with [`allow_extension`][Self::allow_extension].
+/// Besides headers, it filters request [`Extensions`] on "blocked" redirections. Extensions are
+/// keyed by arbitrary types with no blocklist to mirror the header one, so blocked redirections
+/// drop *all* extensions by default; re-admit types with [`allow_extension`][Self::allow_extension].
 ///
-/// Filtering is cumulative: a header or extension removed on a blocked redirection is not
-/// reintroduced on later redirections, including same-origin ones.
+/// Filtering is cumulative: a value removed on one hop is not reintroduced on later hops.
 #[derive(Clone)]
 pub struct FilterCredentials {
     block_cross_origin: bool,
@@ -105,31 +102,26 @@ impl FilterCredentials {
         self.remove_blocklisted(false)
     }
 
-    /// Configure `self` to remove all request extensions in "blocked" redirections, except for
-    /// types added to the allowlist with [`allow_extension`][Self::allow_extension].
+    /// Remove all non-allowlisted extensions on "blocked" redirections. This is the default.
     ///
-    /// This is the default. Because the library cannot know which extension types carry sensitive
-    /// data, blocked redirections (cross-origin by default) drop every extension unless it has
-    /// been explicitly allowed.
+    /// Re-admit specific types with [`allow_extension`][Self::allow_extension].
     pub fn remove_all_extensions(mut self) -> Self {
         self.remove_all_extensions = true;
         self
     }
 
-    /// Configure `self` to keep all request extensions in "blocked" redirections.
+    /// Keep all request extensions on "blocked" redirections.
     ///
-    /// This forwards every extension across the redirection boundary, including cross-origin ones.
-    /// Only use this when the extensions are known not to carry sensitive, origin-scoped data.
+    /// Forwards every extension, including cross-origin. Use only when no extension carries
+    /// sensitive, origin-scoped data.
     pub fn keep_all_extensions(mut self) -> Self {
         self.remove_all_extensions = false;
         self
     }
 
-    /// Add the extension type `T` to the allowlist, keeping it in "blocked" redirections even when
-    /// other extensions are removed.
+    /// Keep extension type `T` on "blocked" redirections even when other extensions are removed.
     ///
-    /// This has no effect if extension removal has been disabled with
-    /// [`keep_all_extensions`][Self::keep_all_extensions].
+    /// No effect under [`keep_all_extensions`][Self::keep_all_extensions].
     pub fn allow_extension<T>(mut self) -> Self
     where
         T: Clone + Send + Sync + 'static,

--- a/tower-http/src/follow_redirect/policy/filter_credentials.rs
+++ b/tower-http/src/follow_redirect/policy/filter_credentials.rs
@@ -14,7 +14,7 @@ use http::{
 ///
 /// Filtering is cumulative: a header or extension removed on a blocked redirection is not
 /// reintroduced on later redirections, including same-origin ones.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct FilterCredentials {
     block_cross_origin: bool,
     block_any: bool,
@@ -23,6 +23,23 @@ pub struct FilterCredentials {
     remove_all_extensions: bool,
     extension_allowlist: Vec<fn(&mut Extensions, &mut Extensions)>,
     blocked: bool,
+}
+
+// `Debug` is implemented by hand rather than derived: deriving it would require `Debug` for the
+// higher-ranked `fn` pointers in `extension_allowlist`, which does not hold on older compilers
+// (and would only print opaque addresses anyway). The allowlist is summarized by its length.
+impl std::fmt::Debug for FilterCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FilterCredentials")
+            .field("block_cross_origin", &self.block_cross_origin)
+            .field("block_any", &self.block_any)
+            .field("remove_blocklisted", &self.remove_blocklisted)
+            .field("remove_all", &self.remove_all)
+            .field("remove_all_extensions", &self.remove_all_extensions)
+            .field("allowed_extensions", &self.extension_allowlist.len())
+            .field("blocked", &self.blocked)
+            .finish()
+    }
 }
 
 const BLOCKLIST: &[HeaderName] = &[

--- a/tower-http/src/follow_redirect/policy/filter_credentials.rs
+++ b/tower-http/src/follow_redirect/policy/filter_credentials.rs
@@ -1,16 +1,24 @@
 use super::{eq_origin, Action, Attempt, Policy};
 use http::{
     header::{self, HeaderName},
-    Request,
+    Extensions, Request,
 };
 
 /// A redirection [`Policy`] that removes credentials from requests in redirections.
+///
+/// In addition to request headers, this policy also filters request
+/// [`Extensions`] in "blocked" redirections. Because extensions are keyed by
+/// arbitrary user types, there is no built-in blocklist of sensitive extensions to mirror the
+/// header blocklist. Instead, blocked redirections drop *all* extensions by default, and callers
+/// opt specific types back in with [`allow_extension`][Self::allow_extension].
 #[derive(Clone, Debug)]
 pub struct FilterCredentials {
     block_cross_origin: bool,
     block_any: bool,
     remove_blocklisted: bool,
     remove_all: bool,
+    remove_all_extensions: bool,
+    extension_allowlist: Vec<fn(&mut Extensions, &mut Extensions)>,
     blocked: bool,
 }
 
@@ -29,6 +37,8 @@ impl FilterCredentials {
             block_any: false,
             remove_blocklisted: true,
             remove_all: false,
+            remove_all_extensions: true,
+            extension_allowlist: Vec::new(),
             blocked: false,
         }
     }
@@ -74,6 +84,43 @@ impl FilterCredentials {
         self.remove_all = false;
         self.remove_blocklisted(false)
     }
+
+    /// Configure `self` to remove all request extensions in "blocked" redirections, except for
+    /// types added to the allowlist with [`allow_extension`][Self::allow_extension].
+    ///
+    /// This is the default. Because the library cannot know which extension types carry sensitive
+    /// data, blocked redirections (cross-origin by default) drop every extension unless it has
+    /// been explicitly allowed.
+    pub fn remove_all_extensions(mut self) -> Self {
+        self.remove_all_extensions = true;
+        self
+    }
+
+    /// Configure `self` to keep all request extensions in "blocked" redirections.
+    ///
+    /// This forwards every extension across the redirection boundary, including cross-origin ones.
+    /// Only use this when the extensions are known not to carry sensitive, origin-scoped data.
+    pub fn keep_all_extensions(mut self) -> Self {
+        self.remove_all_extensions = false;
+        self
+    }
+
+    /// Add the extension type `T` to the allowlist, keeping it in "blocked" redirections even when
+    /// other extensions are removed.
+    ///
+    /// This has no effect if extension removal has been disabled with
+    /// [`keep_all_extensions`][Self::keep_all_extensions].
+    pub fn allow_extension<T>(mut self) -> Self
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        self.extension_allowlist.push(|from, to| {
+            if let Some(value) = from.remove::<T>() {
+                to.insert(value);
+            }
+        });
+        self
+    }
 }
 
 impl Default for FilterCredentials {
@@ -97,6 +144,19 @@ impl<B, E> Policy<B, E> for FilterCredentials {
             } else if self.remove_blocklisted {
                 for key in BLOCKLIST {
                     headers.remove(key);
+                }
+            }
+
+            if self.remove_all_extensions {
+                let extensions = request.extensions_mut();
+                if self.extension_allowlist.is_empty() {
+                    extensions.clear();
+                } else {
+                    let mut allowed = Extensions::new();
+                    for transfer in &self.extension_allowlist {
+                        transfer(extensions, &mut allowed);
+                    }
+                    *extensions = allowed;
                 }
             }
         }
@@ -161,5 +221,107 @@ mod tests {
             .unwrap();
         Policy::<(), ()>::on_request(&mut policy, &mut request);
         assert!(!request.headers().contains_key(header::COOKIE));
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct Kept(u32);
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct Dropped(u32);
+
+    fn cross_origin_attempt<'a>(previous: &'a Uri, location: &'a Uri) -> Attempt<'a> {
+        Attempt {
+            status: Default::default(),
+            method: &Method::GET,
+            location,
+            previous_method: &Method::GET,
+            previous,
+        }
+    }
+
+    #[test]
+    fn extensions_are_kept_same_origin_and_dropped_cross_origin() {
+        let initial = Uri::from_static("http://example.com/old");
+        let same_origin = Uri::from_static("http://example.com/new");
+        let cross_origin = Uri::from_static("https://example.com/new");
+
+        let mut policy = FilterCredentials::default();
+
+        let attempt = cross_origin_attempt(&initial, &same_origin);
+        assert!(Policy::<(), ()>::redirect(&mut policy, &attempt)
+            .unwrap()
+            .is_follow());
+        let mut request = Request::builder().uri(&same_origin).body(()).unwrap();
+        request.extensions_mut().insert(Kept(42));
+        Policy::<(), ()>::on_request(&mut policy, &mut request);
+        assert_eq!(request.extensions().get::<Kept>(), Some(&Kept(42)));
+
+        let attempt = cross_origin_attempt(&same_origin, &cross_origin);
+        assert!(Policy::<(), ()>::redirect(&mut policy, &attempt)
+            .unwrap()
+            .is_follow());
+        let mut request = Request::builder().uri(&cross_origin).body(()).unwrap();
+        request.extensions_mut().insert(Kept(42));
+        Policy::<(), ()>::on_request(&mut policy, &mut request);
+        assert!(request.extensions().get::<Kept>().is_none());
+    }
+
+    #[test]
+    fn allowlisted_extensions_survive_cross_origin() {
+        let initial = Uri::from_static("http://example.com/old");
+        let cross_origin = Uri::from_static("https://example.com/new");
+
+        let mut policy = FilterCredentials::default().allow_extension::<Kept>();
+        let attempt = cross_origin_attempt(&initial, &cross_origin);
+        assert!(Policy::<(), ()>::redirect(&mut policy, &attempt)
+            .unwrap()
+            .is_follow());
+
+        let mut request = Request::builder().uri(&cross_origin).body(()).unwrap();
+        request.extensions_mut().insert(Kept(1));
+        request.extensions_mut().insert(Dropped(2));
+        Policy::<(), ()>::on_request(&mut policy, &mut request);
+        assert_eq!(request.extensions().get::<Kept>(), Some(&Kept(1)));
+        assert!(request.extensions().get::<Dropped>().is_none());
+    }
+
+    #[test]
+    fn keep_all_extensions_forwards_cross_origin() {
+        let initial = Uri::from_static("http://example.com/old");
+        let cross_origin = Uri::from_static("https://example.com/new");
+
+        let mut policy = FilterCredentials::default().keep_all_extensions();
+        let attempt = cross_origin_attempt(&initial, &cross_origin);
+        assert!(Policy::<(), ()>::redirect(&mut policy, &attempt)
+            .unwrap()
+            .is_follow());
+
+        let mut request = Request::builder().uri(&cross_origin).body(()).unwrap();
+        request.extensions_mut().insert(Kept(1));
+        Policy::<(), ()>::on_request(&mut policy, &mut request);
+        assert_eq!(request.extensions().get::<Kept>(), Some(&Kept(1)));
+    }
+
+    #[test]
+    fn allow_extension_is_ignored_when_keeping_all() {
+        let initial = Uri::from_static("http://example.com/old");
+        let cross_origin = Uri::from_static("https://example.com/new");
+
+        // The allowlist only takes effect while extensions are being removed; keep_all disables
+        // removal, so everything is forwarded regardless of the allowlist.
+        let mut policy = FilterCredentials::default()
+            .keep_all_extensions()
+            .allow_extension::<Kept>();
+        let attempt = cross_origin_attempt(&initial, &cross_origin);
+        assert!(Policy::<(), ()>::redirect(&mut policy, &attempt)
+            .unwrap()
+            .is_follow());
+
+        let mut request = Request::builder().uri(&cross_origin).body(()).unwrap();
+        request.extensions_mut().insert(Kept(1));
+        request.extensions_mut().insert(Dropped(2));
+        Policy::<(), ()>::on_request(&mut policy, &mut request);
+        assert_eq!(request.extensions().get::<Kept>(), Some(&Kept(1)));
+        assert_eq!(request.extensions().get::<Dropped>(), Some(&Dropped(2)));
     }
 }

--- a/tower-http/src/follow_redirect/policy/filter_credentials.rs
+++ b/tower-http/src/follow_redirect/policy/filter_credentials.rs
@@ -11,6 +11,9 @@ use http::{
 /// arbitrary user types, there is no built-in blocklist of sensitive extensions to mirror the
 /// header blocklist. Instead, blocked redirections drop *all* extensions by default, and callers
 /// opt specific types back in with [`allow_extension`][Self::allow_extension].
+///
+/// Filtering is cumulative: a header or extension removed on a blocked redirection is not
+/// reintroduced on later redirections, including same-origin ones.
 #[derive(Clone, Debug)]
 pub struct FilterCredentials {
     block_cross_origin: bool,

--- a/tower-http/src/follow_redirect/policy/mod.rs
+++ b/tower-http/src/follow_redirect/policy/mod.rs
@@ -60,9 +60,8 @@ pub trait Policy<B, E> {
     /// This can for example be used to remove sensitive headers from the request
     /// or prepare the request in other ways.
     ///
-    /// On a redirected request the headers and [`Extensions`][http::Extensions] are replayed from
-    /// the previous hop before this runs, and whatever this method leaves on the request becomes
-    /// the baseline for the next hop: a value removed here stays removed for the rest of the chain.
+    /// On a redirected request, whatever this method leaves on the request becomes the baseline for
+    /// the next hop, so a value removed here stays removed for the rest of the chain.
     ///
     /// The default implementation does nothing.
     fn on_request(&mut self, _request: &mut Request<B>) {}

--- a/tower-http/src/follow_redirect/policy/mod.rs
+++ b/tower-http/src/follow_redirect/policy/mod.rs
@@ -60,6 +60,10 @@ pub trait Policy<B, E> {
     /// This can for example be used to remove sensitive headers from the request
     /// or prepare the request in other ways.
     ///
+    /// On a redirected request the headers and [`Extensions`][http::Extensions] are replayed from
+    /// the previous hop before this runs, and whatever this method leaves on the request becomes
+    /// the baseline for the next hop: a value removed here stays removed for the rest of the chain.
+    ///
     /// The default implementation does nothing.
     fn on_request(&mut self, _request: &mut Request<B>) {}
 


### PR DESCRIPTION
Supersedes #581 and #638.

## Motivation

We currently clone and keep headers across redirects, but drop extensions, because `http` 0.x made `Extensions` `!Clone`. With `http` 1.0 they are `Clone`, so we have the opportunity to preserve them.

While we are at it, I also fixed a bug for the header preservation: header removals were not remembered across hops. Each hop re-derives the request from the original snapshot and re-decides per hop.

This means that:
`origin 1 -> origin 2 (drop all) -> origin 1`
would result in `origin 1`'s headers.

Instead, we want to accumulate removals.

## Solution

We key extensions by their `TypeId`. We drop all extensions on cross-origin by default. This is unlike headers, where we preserve by default cross-origin minus a blocklist. We do not have a good blocklist for arbitrary `TypeId`s, so we are stuck with an allowlist.

Here's the API:
```rust
use tower::ServiceBuilder;
use tower_http::follow_redirect::{
    policy::{FilterCredentials, Limited, PolicyExt},
    FollowRedirectLayer,
};

#[derive(Clone)]
struct RequestId(u64);

let default = ServiceBuilder::new()
    .layer(FollowRedirectLayer::new()) // default: preserve all same-origin, drop all cross-origin
    .service(inner.clone());

let no_extensions = ServiceBuilder::new()
    .layer(FollowRedirectLayer::new().preserve_extensions(false)) // opt out: drop extensions on every redirect
    .service(inner.clone());

let allow_one = ServiceBuilder::new()
    .layer(FollowRedirectLayer::with_policy(
        Limited::new(10).and::<_, (), _>(
            FilterCredentials::new().allow_extension::<RequestId>(), // keep RequestId cross-origin, drop the rest
        ),
    ))
    .service(inner.clone());

let keep_all = ServiceBuilder::new()
    .layer(FollowRedirectLayer::with_policy(
        FilterCredentials::new().keep_all_extensions(), // forward every extension cross-origin
    ))
    .service(inner);
```

It's not perfect, I'm not thrilled about the turbofish syntax. Alternatives welcome.

## Testing

All the tests you'd expect: same-origin keep, cross-origin drop, the `preserve_extensions(false)` opt-out, the allowlist and keep-all paths, plus a multi-hop regression test proving a cookie or extension dropped on a cross-origin hop does not reappear on a later same-origin hop.

## Breaking Changes

This is a breaking behavioral change, in two ways:
- preserve extensions on same-origin by default
- accumulate header (and extension) removals across redirect hops

We document this clearly, and provide a simple opt out to the more significant one (preserving extensions):
```rust
ServiceBuilder::new().layer(FollowRedirectLayer::new().preserve_extensions(false));
```
