### PR TITLE
docs(example)/custom future with multiple bodies

### DIFF
--- a/examples/custom-future-multiple-bodies/Cargo.toml
+++ b/examples/custom-future-multiple-bodies/Cargo.toml
@@ -9,8 +9,8 @@ license = "MIT"
 [dependencies]
 bytes = "1.12.0"
 http = "1.4.2"
+http-body = "1.0.0"
 http-body-util = "0.1.3"
-hyper = "1.10.1"
 pin-project-lite = "0.2.17"
 tokio = { version = "1.32.0", features = ["full"] }
 tower = { version = "0.5", features = ["full"] }

--- a/examples/custom-future-multiple-bodies/Cargo.toml
+++ b/examples/custom-future-multiple-bodies/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "custom-future-multiple-bodies"
+version = "0.1.0"
+authors = ["Tower Maintainers <team@tower-rs.com>"]
+edition = "2021"
+publish = false
+license = "MIT"
+
+[dependencies]
+bytes = "1.12.0"
+pin-project-lite = "0.2.17"
+hyper = "1.10.1" 
+http = "1.4.2"
+http-body-util = "0.1.3"
+tokio = { version = "1.32.0", features = ["full"] }
+tower = { version = "0.5", features = ["full"] }

--- a/examples/custom-future-multiple-bodies/Cargo.toml
+++ b/examples/custom-future-multiple-bodies/Cargo.toml
@@ -8,9 +8,9 @@ license = "MIT"
 
 [dependencies]
 bytes = "1.12.0"
-pin-project-lite = "0.2.17"
-hyper = "1.10.1" 
 http = "1.4.2"
 http-body-util = "0.1.3"
+hyper = "1.10.1"
+pin-project-lite = "0.2.17"
 tokio = { version = "1.32.0", features = ["full"] }
 tower = { version = "0.5", features = ["full"] }

--- a/examples/custom-future-multiple-bodies/README.md
+++ b/examples/custom-future-multiple-bodies/README.md
@@ -8,7 +8,7 @@ This requires wrapping the response body if the user wishes to leave the inner
 service's body untouched.
 
 This solution is geared towards application code, library author's should
-consider studying [tower_http/limit's body and future implementation](https://github.com/tower-rs/tower-http/tree/main/tower-http/src/limit).
+consider studying [tower_http/limit's body and future implementations instead](https://github.com/tower-rs/tower-http/tree/main/tower-http/src/limit).
 
 ## Running the example
 

--- a/examples/custom-future-multiple-bodies/README.md
+++ b/examples/custom-future-multiple-bodies/README.md
@@ -1,0 +1,14 @@
+# Custom future with multiple bodies
+
+This example serves to demonstrate how to build a service that returns a
+response in case of an event (in this instance, a missing HTTP header) while
+leaving the inner service's response untouched.
+
+This requires wrapping the response body if the user wishes to leave inner
+sevice's body untouched.
+
+## Running the example
+
+```
+cargo run -p custom-future-multiple-bodies
+```

--- a/examples/custom-future-multiple-bodies/README.md
+++ b/examples/custom-future-multiple-bodies/README.md
@@ -4,8 +4,8 @@ This example serves to demonstrate how to build a service that returns a
 response in case of an event (in this instance, a missing HTTP header) while
 leaving the inner service's response untouched.
 
-This requires wrapping the response body if the user wishes to leave inner
-sevice's body untouched.
+This requires wrapping the response body if the user wishes to leave the inner
+service's body untouched.
 
 ## Running the example
 

--- a/examples/custom-future-multiple-bodies/README.md
+++ b/examples/custom-future-multiple-bodies/README.md
@@ -1,11 +1,14 @@
 # Custom future with multiple bodies
 
-This example serves to demonstrate how to build a service that returns a
-response in case of an event (in this instance, a missing HTTP header) while
-leaving the inner service's response untouched.
+This example serves to demonstrate how to build a middleware service that
+returns a concrete response in case of an event (in this instance, a missing
+HTTP header) while leaving the inner service's response untouched.
 
 This requires wrapping the response body if the user wishes to leave the inner
 service's body untouched.
+
+This solution is geared towards application code, library author's should
+consider studying [tower_http/limit's body and future implementation](https://github.com/tower-rs/tower-http/tree/main/tower-http/src/limit).
 
 ## Running the example
 

--- a/examples/custom-future-multiple-bodies/README.md
+++ b/examples/custom-future-multiple-bodies/README.md
@@ -8,7 +8,7 @@ This requires wrapping the response body if the user wishes to leave the inner
 service's body untouched.
 
 This solution is geared towards application code, library author's should
-consider studying [tower_http/limit's body and future implementations instead](https://github.com/tower-rs/tower-http/tree/main/tower-http/src/limit).
+consider studying [tower_http/limit's implementation instead](https://github.com/tower-rs/tower-http/tree/main/tower-http/src/limit), since `Either` erases the error type.
 
 ## Running the example
 

--- a/examples/custom-future-multiple-bodies/src/main.rs
+++ b/examples/custom-future-multiple-bodies/src/main.rs
@@ -62,6 +62,7 @@ where
 }
 
 pin_project! {
+    /// consider encapsulating the inner types for added semver safety, see https://github.com/tower-rs/tower-http/tree/main/tower-http/src/limit/future.rs
     #[project = ResFutProj]
     pub enum RequireHeaderFuture<F> {
         Future{ #[pin] future: F },

--- a/examples/custom-future-multiple-bodies/src/main.rs
+++ b/examples/custom-future-multiple-bodies/src/main.rs
@@ -9,9 +9,9 @@ use std::{
 };
 use tower::Service;
 
+use http_body_util::BodyExt;
 use std::error::Error;
 use tower::ServiceBuilder;
-use http_body_util::BodyExt;
 use tower::ServiceExt;
 
 // think of Either as an enum that implements Body if both arms implement Body
@@ -120,5 +120,3 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
-
-

--- a/examples/custom-future-multiple-bodies/src/main.rs
+++ b/examples/custom-future-multiple-bodies/src/main.rs
@@ -1,0 +1,124 @@
+use bytes::Bytes;
+use http::{Request, Response, StatusCode};
+use http_body_util::{Either, Full};
+use pin_project_lite::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+use tower::Service;
+
+use std::error::Error;
+use tower::ServiceBuilder;
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+// think of Either as an enum that implements Body if both arms implement Body
+// this allows us to combine multple bodies
+type ResponseBody<B> = Either<B, Full<Bytes>>;
+
+// some helper to go along with it
+fn map_resp<B>(resp: Response<B>) -> Response<ResponseBody<B>> {
+    resp.map(|body| Either::Left(body))
+}
+
+fn new_err_resp<B>(status: StatusCode, body: &'static str) -> Response<ResponseBody<B>> {
+    Response::builder()
+        .status(status)
+        .body(Either::Right(Full::from(body)))
+        .unwrap()
+}
+
+#[derive(Clone)]
+pub struct RequireHeader<S> {
+    inner: S,
+    header_name: &'static str,
+}
+
+impl<S> RequireHeader<S> {
+    pub fn new(inner: S, header_name: &'static str) -> Self {
+        Self { inner, header_name }
+    }
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for RequireHeader<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = Response<ResponseBody<ResBody>>;
+    type Error = S::Error;
+    type Future = RequireHeaderFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        if !req.headers().contains_key(self.header_name) {
+            return RequireHeaderFuture::HeaderNotFound;
+        }
+        RequireHeaderFuture::Ok {
+            fut: self.inner.call(req),
+        }
+    }
+}
+
+pin_project! {
+    #[project = EnumProj]
+    pub enum RequireHeaderFuture<F> {
+        Ok{ #[pin] fut: F },
+        HeaderNotFound,
+    }
+}
+
+impl<F, E, ResBody> Future for RequireHeaderFuture<F>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+{
+    type Output = Result<Response<ResponseBody<ResBody>>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project() {
+            EnumProj::Ok { fut } => {
+                let res = ready!(fut.poll(cx));
+
+                // we use our helper to unify the response body types
+                // its also possible to return a custom error response here if the inner service failed
+                Poll::Ready(res.map(|resp| map_resp(resp)))
+            }
+            EnumProj::HeaderNotFound => {
+                Poll::Ready(Ok(new_err_resp(StatusCode::BAD_REQUEST, "missing header")))
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let inner_service = tower::service_fn(|_req: Request<Full<Bytes>>| async {
+        Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from("Hello, World!"))))
+    });
+
+    let mut service = ServiceBuilder::new()
+        .layer_fn(|inner| RequireHeader::new(inner, "x-api-key"))
+        .service(inner_service);
+
+    let req_bad = Request::builder().body(Full::<Bytes>::default()).unwrap();
+    let res_bad = service.ready().await?.call(req_bad).await?;
+    assert_eq!(res_bad.status(), StatusCode::BAD_REQUEST);
+
+    let body = res_bad.into_body().collect().await.unwrap();
+    assert_eq!(body.to_bytes(), "missing header");
+
+    let req_good = Request::builder()
+        .header("x-api-key", "secret")
+        .body(Full::<Bytes>::default())
+        .unwrap();
+    let res_good = service.ready().await?.call(req_good).await?;
+    assert_eq!(res_good.status(), StatusCode::OK);
+
+    Ok(())
+}
+
+

--- a/examples/custom-future-multiple-bodies/src/main.rs
+++ b/examples/custom-future-multiple-bodies/src/main.rs
@@ -10,7 +10,6 @@ use std::{
 use tower::Service;
 
 use http_body_util::BodyExt;
-use std::error::Error;
 use tower::ServiceBuilder;
 use tower::ServiceExt;
 
@@ -18,12 +17,8 @@ use tower::ServiceExt;
 // this allows us to combine multple bodies
 type ResponseBody<B> = Either<B, Full<Bytes>>;
 
-// some helper to go along with it
-fn map_resp<B>(resp: Response<B>) -> Response<ResponseBody<B>> {
-    resp.map(|body| Either::Left(body))
-}
-
-fn new_err_resp<B>(status: StatusCode, body: &'static str) -> Response<ResponseBody<B>> {
+// helper to construct an error response
+fn rejection<B>(status: StatusCode, body: &'static str) -> Response<ResponseBody<B>> {
     Response::builder()
         .status(status)
         .body(Either::Right(Full::from(body)))
@@ -45,6 +40,8 @@ impl<S> RequireHeader<S> {
 impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for RequireHeader<S>
 where
     S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    // Either requires both bodies to use the same underlying buffer type
+    ResBody: http_body::Body<Data = Bytes>,
 {
     type Response = Response<ResponseBody<ResBody>>;
     type Error = S::Error;
@@ -56,19 +53,19 @@ where
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
         if !req.headers().contains_key(self.header_name) {
-            return RequireHeaderFuture::HeaderNotFound;
+            return RequireHeaderFuture::MissingHeader;
         }
-        RequireHeaderFuture::Ok {
-            fut: self.inner.call(req),
+        RequireHeaderFuture::Future {
+            future: self.inner.call(req),
         }
     }
 }
 
 pin_project! {
-    #[project = EnumProj]
+    #[project = ResFutProj]
     pub enum RequireHeaderFuture<F> {
-        Ok{ #[pin] fut: F },
-        HeaderNotFound,
+        Future{ #[pin] future: F },
+        MissingHeader,
     }
 }
 
@@ -79,44 +76,109 @@ where
     type Output = Result<Response<ResponseBody<ResBody>>, E>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.project() {
-            EnumProj::Ok { fut } => {
-                let res = ready!(fut.poll(cx));
+        let res = match self.project() {
+            // `?` propagates an inner-service error. to turn it into a response
+            // instead, replace `?` with
+            //     .unwrap_or_else(|_| rejection(StatusCode::BAD_GATEWAY, "..."))
+            // to convert every error, or `.or_else(..)` to convert only some and
+            // keep propagating the rest.
+            ResFutProj::Future { future } => ready!(future.poll(cx))?.map(Either::Left),
+            ResFutProj::MissingHeader => rejection(StatusCode::BAD_REQUEST, "missing header"),
+        };
 
-                // we use our helper to unify the response body types
-                // its also possible to return a custom error response here if the inner service failed
-                Poll::Ready(res.map(|resp| map_resp(resp)))
-            }
-            EnumProj::HeaderNotFound => {
-                Poll::Ready(Ok(new_err_resp(StatusCode::BAD_REQUEST, "missing header")))
-            }
-        }
+        Poll::Ready(Ok(res))
     }
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> Result<(), tower::BoxError> {
     let inner_service = tower::service_fn(|_req: Request<Full<Bytes>>| async {
         Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from("Hello, World!"))))
     });
 
+    let required_header = "x-api-key";
+
     let mut service = ServiceBuilder::new()
-        .layer_fn(|inner| RequireHeader::new(inner, "x-api-key"))
+        .layer_fn(|inner| RequireHeader::new(inner, required_header))
         .service(inner_service);
 
-    let req_bad = Request::builder().body(Full::<Bytes>::default()).unwrap();
-    let res_bad = service.ready().await?.call(req_bad).await?;
-    assert_eq!(res_bad.status(), StatusCode::BAD_REQUEST);
+    println!(
+        "calling the service without the required {} header",
+        required_header
+    );
 
-    let body = res_bad.into_body().collect().await.unwrap();
-    assert_eq!(body.to_bytes(), "missing header");
+    let req_bad = Request::builder().body(Full::<Bytes>::default())?;
+    let res_bad = service.ready().await?.call(req_bad).await?;
+
+    let res_code = res_bad.status();
+    let body = res_bad.into_body().collect().await?.to_bytes();
+
+    println!(
+        "response: {}, {}",
+        res_code.as_str(),
+        std::str::from_utf8(&body)?
+    );
+
+    println!(
+        "calling the service with the required {} header",
+        required_header
+    );
 
     let req_good = Request::builder()
         .header("x-api-key", "secret")
-        .body(Full::<Bytes>::default())
-        .unwrap();
+        .body(Full::<Bytes>::default())?;
+
     let res_good = service.ready().await?.call(req_good).await?;
-    assert_eq!(res_good.status(), StatusCode::OK);
+
+    let res_code = res_good.status();
+
+    println!("response: {}", res_code.as_str());
 
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn reject_missing_header() {
+        let inner_service = tower::service_fn(|_req: Request<Full<Bytes>>| async {
+            Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from(
+                "Hello, World!",
+            ))))
+        });
+
+        let mut service = ServiceBuilder::new()
+            .layer_fn(|inner| RequireHeader::new(inner, "x-api-key"))
+            .service(inner_service);
+
+        let req_bad = Request::builder().body(Full::<Bytes>::default()).unwrap();
+        let res_bad = service.ready().await.unwrap().call(req_bad).await.unwrap();
+        assert_eq!(res_bad.status(), StatusCode::BAD_REQUEST);
+
+        let body = res_bad.into_body().collect().await.unwrap();
+        assert_eq!(body.to_bytes(), "missing header");
+    }
+
+    #[tokio::test]
+    async fn accept_correct_header() {
+        let inner_service = tower::service_fn(|_req: Request<Full<Bytes>>| async {
+            Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from(
+                "Hello, World!",
+            ))))
+        });
+
+        let mut service = ServiceBuilder::new()
+            .layer_fn(|inner| RequireHeader::new(inner, "x-api-key"))
+            .service(inner_service);
+
+        let req_good = Request::builder()
+            .header("x-api-key", "secret")
+            .body(Full::<Bytes>::default())
+            .unwrap();
+
+        let res_good = service.ready().await.unwrap().call(req_good).await.unwrap();
+        assert_eq!(res_good.status(), StatusCode::OK);
+    }
 }


### PR DESCRIPTION
This PR builds on [this PR](https://github.com/tower-rs/tower-http/pull/709), which explores idomatic solutions to dealing with multiple HTTP bodies in tower services

## Motivation

@Isvane did a great job with his proposal, so i wanted to iterate on it by bringing it closer to how i solved this problem in my own project. Primarily, by introducing a custom future.

## Changes

- removed `BoxBody` alias
- removed some `service` trait bounds
- added helper functions
- replaced `Pin Box Future` with custom future.
- added asserts to `main()`

## Discussion

While i think this is a decently elegant solution, it could be argued its not idiomatic if you compare how this problem is solved in `tower-http/limit`. 

A potential foot gun im wondering about is the trait bound on `Either` which states that both arms need to have the same underlying `Data` type. Right now the example leaves the response body of the inner service entirely generic, but this could lead to a nasty compile error down the road should the `Data` types mismatch.

`tower-http/limit` imposes a `Body<Data = Bytes>` bound on its `Body` implementation for it's wrapper type and im wondering whether this example should include it too, and if so, where.