### PR TITLE
Remove Clone derivations from SetMultipleResponseHeader* types

### DIFF
--- a/tower-http/src/set_header/response/multiple_headers.rs
+++ b/tower-http/src/set_header/response/multiple_headers.rs
@@ -18,9 +18,16 @@ use crate::set_header::{HeaderInsertionConfig, HeaderMetadata, InsertHeaderMode}
 /// Layer that applies [`SetMultipleResponseHeader`] which adds multiple response headers.
 ///
 /// See [`SetMultipleResponseHeader`] for more details.
-#[derive(Clone)]
 pub struct SetMultipleResponseHeadersLayer<M> {
     headers: Vec<HeaderInsertionConfig<M>>,
+}
+
+impl<M> Clone for SetMultipleResponseHeadersLayer<M> {
+    fn clone(&self) -> Self {
+        Self {
+            headers: self.headers.clone(),
+        }
+    }
 }
 
 impl<M> fmt::Debug for SetMultipleResponseHeadersLayer<M> {
@@ -86,11 +93,21 @@ impl<S, M> Layer<S> for SetMultipleResponseHeadersLayer<M> {
 }
 
 /// Middleware that sets multiple headers on the response.
-
-#[derive(Clone)]
 pub struct SetMultipleResponseHeader<S, M> {
     inner: S,
     headers: Vec<HeaderInsertionConfig<M>>,
+}
+
+impl<S, M> Clone for SetMultipleResponseHeader<S, M>
+where
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            headers: self.headers.clone(),
+        }
+    }
 }
 
 impl<S, M> SetMultipleResponseHeader<S, M> {
@@ -419,5 +436,19 @@ mod tests {
         let layer = SetMultipleResponseHeadersLayer::overriding(vec![meta]);
         let debug_str = format!("{:?}", layer);
         assert!(debug_str.contains("SetMultipleResponseHeadersLayer"));
+    }
+
+    #[test]
+    fn test_service_clone() {
+        struct NonCloneBody;
+        let svc = tower::ServiceBuilder::new()
+            .layer(SetMultipleResponseHeadersLayer::<Response<NonCloneBody>>::overriding(vec![]))
+            .check_clone()
+            .service(service_fn(|_: Request<NonCloneBody>| async move {
+                Ok::<_, Infallible>(Response::new(NonCloneBody))
+            }));
+
+        fn check_service_and_clone<T: Service<Request<NonCloneBody>> + Clone>(_: T) {}
+        check_service_and_clone(svc);
     }
 }


### PR DESCRIPTION
## Motivation

This allows downstream consumers to not be impacted by uneccesary Clone bounds.

Includes a regression test that simplifies the reproduction case, fails to compile without the fix, and succeeds with it.

## Solution

Apply the same fix as #703 to Response types as well, using the more narrow and accurate Clone definition vs the derived Clone one.

Fixes: #713
