### PR TITLE
feat(request-id): Allow request-id constructor in const context

### DIFF
--- a/tower-http/src/request_id.rs
+++ b/tower-http/src/request_id.rs
@@ -197,12 +197,12 @@ pub struct RequestId(HeaderValue);
 
 impl RequestId {
     /// Create a new `RequestId` from a [`HeaderValue`].
-    pub fn new(header_value: HeaderValue) -> Self {
+    pub const fn new(header_value: HeaderValue) -> Self {
         Self(header_value)
     }
 
     /// Gets a reference to the underlying [`HeaderValue`].
-    pub fn header_value(&self) -> &HeaderValue {
+    pub const fn header_value(&self) -> &HeaderValue {
         &self.0
     }
 
@@ -231,7 +231,7 @@ pub struct SetRequestIdLayer<M> {
 
 impl<M> SetRequestIdLayer<M> {
     /// Create a new `SetRequestIdLayer`.
-    pub fn new(header_name: HeaderName, make_request_id: M) -> Self
+    pub const fn new(header_name: HeaderName, make_request_id: M) -> Self
     where
         M: MakeRequestId,
     {
@@ -242,7 +242,7 @@ impl<M> SetRequestIdLayer<M> {
     }
 
     /// Create a new `SetRequestIdLayer` that uses `x-request-id` as the header name.
-    pub fn x_request_id(make_request_id: M) -> Self
+    pub const fn x_request_id(make_request_id: M) -> Self
     where
         M: MakeRequestId,
     {
@@ -283,7 +283,7 @@ pub struct SetRequestId<S, M> {
 
 impl<S, M> SetRequestId<S, M> {
     /// Create a new `SetRequestId`.
-    pub fn new(inner: S, header_name: HeaderName, make_request_id: M) -> Self
+    pub const fn new(inner: S, header_name: HeaderName, make_request_id: M) -> Self
     where
         M: MakeRequestId,
     {
@@ -295,7 +295,7 @@ impl<S, M> SetRequestId<S, M> {
     }
 
     /// Create a new `SetRequestId` that uses `x-request-id` as the header name.
-    pub fn x_request_id(inner: S, make_request_id: M) -> Self
+    pub const fn x_request_id(inner: S, make_request_id: M) -> Self
     where
         M: MakeRequestId,
     {
@@ -305,7 +305,7 @@ impl<S, M> SetRequestId<S, M> {
     define_inner_service_accessors!();
 
     /// Returns a new [`Layer`] that wraps services with a `SetRequestId` middleware.
-    pub fn layer(header_name: HeaderName, make_request_id: M) -> SetRequestIdLayer<M>
+    pub const fn layer(header_name: HeaderName, make_request_id: M) -> SetRequestIdLayer<M>
     where
         M: MakeRequestId,
     {
@@ -355,12 +355,12 @@ pub struct PropagateRequestIdLayer {
 
 impl PropagateRequestIdLayer {
     /// Create a new `PropagateRequestIdLayer`.
-    pub fn new(header_name: HeaderName) -> Self {
+    pub const fn new(header_name: HeaderName) -> Self {
         PropagateRequestIdLayer { header_name }
     }
 
     /// Create a new `PropagateRequestIdLayer` that uses `x-request-id` as the header name.
-    pub fn x_request_id() -> Self {
+    pub const fn x_request_id() -> Self {
         Self::new(X_REQUEST_ID)
     }
 }
@@ -387,19 +387,19 @@ pub struct PropagateRequestId<S> {
 
 impl<S> PropagateRequestId<S> {
     /// Create a new `PropagateRequestId`.
-    pub fn new(inner: S, header_name: HeaderName) -> Self {
+    pub const fn new(inner: S, header_name: HeaderName) -> Self {
         Self { inner, header_name }
     }
 
     /// Create a new `PropagateRequestId` that uses `x-request-id` as the header name.
-    pub fn x_request_id(inner: S) -> Self {
+    pub const fn x_request_id(inner: S) -> Self {
         Self::new(inner, X_REQUEST_ID)
     }
 
     define_inner_service_accessors!();
 
     /// Returns a new [`Layer`] that wraps services with a `PropagateRequestId` middleware.
-    pub fn layer(header_name: HeaderName) -> PropagateRequestIdLayer {
+    pub const fn layer(header_name: HeaderName) -> PropagateRequestIdLayer {
         PropagateRequestIdLayer::new(header_name)
     }
 }


### PR DESCRIPTION
Allows `request-id` constructors in `const` context.