### PR TITLE
Propagate ServeDir::try_call I/O errors

### DIFF
--- a/tower-http/CHANGELOG.md
+++ b/tower-http/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# Unreleased
+
+[Changes since 0.7.0](https://github.com/tower-rs/tower-http/compare/tower-http-0.7.0...HEAD)
+
+## Fixed
+
+- **breaking:** `fs`: make `ServeDir::try_call` propagate expected filesystem
+  I/O errors when no fallback is configured, as documented, instead of converting
+  them to `404 Not Found` responses ([#718])
+
+[#718]: https://github.com/tower-rs/tower-http/pull/718
+
 # 0.7.0
 
 [Changes since 0.6.11](https://github.com/tower-rs/tower-http/compare/tower-http-0.6.11...tower-http-0.7.0)

--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -144,24 +144,11 @@ where
                     }
 
                     Err(err) => {
-                        #[cfg(unix)]
-                        // 20 = libc::ENOTDIR => "not a directory
-                        // when `io_error_more` landed, this can be changed
-                        // to checking for `io::ErrorKind::NotADirectory`.
-                        // https://github.com/rust-lang/rust/issues/86442
-                        let error_is_not_a_directory = err.raw_os_error() == Some(20);
-                        #[cfg(not(unix))]
-                        let error_is_not_a_directory = false;
-
-                        if matches!(
-                            err.kind(),
-                            io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied
-                        ) || error_is_not_a_directory
-                        {
+                        if super::should_return_not_found(&err) {
                             if let Some((mut fallback, request)) = fallback_and_request.take() {
                                 call_fallback(&mut fallback, request)
                             } else {
-                                break Poll::Ready(Ok(not_found()));
+                                break Poll::Ready(Err(err));
                             }
                         } else {
                             break Poll::Ready(Err(err));

--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -323,9 +323,10 @@ impl<F, B: Backend> ServeDir<F, B> {
     ///
     /// By default `<ServeDir as Service<_>>::call` will handle IO errors and convert them into
     /// responses. It does that by converting [`std::io::ErrorKind::NotFound`] and
-    /// [`std::io::ErrorKind::PermissionDenied`] to `404 Not Found` and any other error to `500
-    /// Internal Server Error`. The error will also be logged with `tracing` in case the `tracing`
-    /// crate feature is enabled.
+    /// [`std::io::ErrorKind::PermissionDenied`] to `404 Not Found`. On Unix, errors indicating
+    /// that a path component is not a directory are also converted to `404 Not Found`. Any other
+    /// error is converted to `500 Internal Server Error` and will also be logged with `tracing` in
+    /// case the `tracing` crate feature is enabled.
     ///
     /// If you want to manually control how the error response is generated you can make a new
     /// service that wraps a `ServeDir` and calls `try_call` instead of `call`.
@@ -485,23 +486,42 @@ where
         let future = self
             .try_call(req)
             .map(|result: Result<_, _>| -> Result<_, Infallible> {
-                let response = result.unwrap_or_else(|_err| {
-                    #[cfg(feature = "tracing")]
-                    tracing::error!(error = %_err, "Failed to read file");
+                let response = result.unwrap_or_else(|err| {
+                    let status = if should_return_not_found(&err) {
+                        StatusCode::NOT_FOUND
+                    } else {
+                        #[cfg(feature = "tracing")]
+                        tracing::error!(error = %err, "Failed to read file");
+
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    };
 
                     let body = ResponseBody::new(UnsyncBoxBody::from_inner(
                         Empty::new().map_err(|err| match err {}).boxed_unsync(),
                     ));
-                    Response::builder()
-                        .status(StatusCode::INTERNAL_SERVER_ERROR)
-                        .body(body)
-                        .unwrap()
+                    Response::builder().status(status).body(body).unwrap()
                 });
                 Ok(response)
             } as _);
 
         InfallibleResponseFuture::new(future)
     }
+}
+
+fn should_return_not_found(err: &io::Error) -> bool {
+    #[cfg(unix)]
+    // 20 = libc::ENOTDIR => "not a directory".
+    // When `io_error_more` lands, this can be changed
+    // to checking for `io::ErrorKind::NotADirectory`.
+    // https://github.com/rust-lang/rust/issues/86442
+    let error_is_not_a_directory = err.raw_os_error() == Some(20);
+    #[cfg(not(unix))]
+    let error_is_not_a_directory = false;
+
+    matches!(
+        err.kind(),
+        io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied
+    ) || error_is_not_a_directory
 }
 
 opaque_future! {

--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -321,6 +321,11 @@ impl<F, B: Backend> ServeDir<F, B> {
     /// Call the service and get a future that contains any `std::io::Error` that might have
     /// happened.
     ///
+    /// This only returns I/O errors encountered while serving the request. Invalid request paths
+    /// and unsupported methods are represented as responses. When a fallback is configured,
+    /// errors that the default service would convert to `404 Not Found` call the fallback instead
+    /// of being returned.
+    ///
     /// By default `<ServeDir as Service<_>>::call` will handle IO errors and convert them into
     /// responses. It does that by converting [`std::io::ErrorKind::NotFound`] and
     /// [`std::io::ErrorKind::PermissionDenied`] to `404 Not Found`. On Unix, errors indicating
@@ -362,11 +367,20 @@ impl<F, B: Backend> ServeDir<F, B> {
     ///             Ok(response.map(|body| body.map_err(Into::into).boxed_unsync()))
     ///         }
     ///         Err(err) => {
-    ///             let body = Full::from("Something went wrong...")
+    ///             let not_found = matches!(
+    ///                 err.kind(),
+    ///                 io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied
+    ///             ) || cfg!(unix) && err.raw_os_error() == Some(20);
+    ///             let (status, message) = if not_found {
+    ///                 (StatusCode::NOT_FOUND, "Not found")
+    ///             } else {
+    ///                 (StatusCode::INTERNAL_SERVER_ERROR, "Something went wrong...")
+    ///             };
+    ///             let body = Full::from(message)
     ///                 .map_err(Into::into)
     ///                 .boxed_unsync();
     ///             let response = Response::builder()
-    ///                 .status(StatusCode::INTERNAL_SERVER_ERROR)
+    ///                 .status(status)
     ///                 .body(body)
     ///                 .unwrap();
     ///             Ok(response)

--- a/tower-http/src/services/fs/serve_dir/open_file.rs
+++ b/tower-http/src/services/fs/serve_dir/open_file.rs
@@ -108,7 +108,7 @@ pub(super) async fn open_file<B: Backend>(
                 html_as_default_extension,
                 &backend,
             )
-            .await
+            .await?
             {
                 return Ok(output);
             }
@@ -405,39 +405,39 @@ async fn maybe_redirect_or_append_path<B: Backend>(
     append_index_html_on_directories: bool,
     html_as_default_extension: bool,
     backend: &B,
-) -> Option<OpenFileOutput> {
+) -> io::Result<Option<OpenFileOutput>> {
     let uri_path = uri.path();
 
-    let is_directory = is_dir(path_to_file, backend).await;
+    let is_directory = is_dir(path_to_file, backend).await?;
 
     if uri_path.ends_with('/') && uri_path != "/" && is_directory != Some(true) {
-        return Some(OpenFileOutput::FileNotFound);
+        return Ok(Some(OpenFileOutput::FileNotFound));
     }
 
     // If the path has no extension and doesn't exist as a file, try appending .html
     if html_as_default_extension && is_directory.is_none() && path_to_file.extension().is_none() {
         path_to_file.set_extension("html");
-        return None;
+        return Ok(None);
     }
 
     if is_directory != Some(true) {
-        return None;
+        return Ok(None);
     }
 
     if !append_index_html_on_directories {
-        return Some(OpenFileOutput::FileNotFound);
+        return Ok(Some(OpenFileOutput::FileNotFound));
     }
 
     if uri_path.ends_with('/') {
         path_to_file.push("index.html");
-        None
+        Ok(None)
     } else {
         let uri = match append_slash_on_path(uri.clone(), redirect_path_prefix) {
             Ok(uri) => uri,
-            Err(err) => return Some(err),
+            Err(err) => return Ok(Some(err)),
         };
         let location = HeaderValue::from_str(&uri.to_string()).unwrap();
-        Some(OpenFileOutput::Redirect { location })
+        Ok(Some(OpenFileOutput::Redirect { location }))
     }
 }
 
@@ -451,12 +451,14 @@ fn try_parse_range(
     })
 }
 
-async fn is_dir<B: Backend>(path_to_file: &Path, backend: &B) -> Option<bool> {
-    backend
-        .metadata(path_to_file.to_owned())
-        .await
-        .ok()
-        .map(|meta_data| meta_data.is_dir())
+async fn is_dir<B: Backend>(path_to_file: &Path, backend: &B) -> io::Result<Option<bool>> {
+    match backend.metadata(path_to_file.to_owned()).await {
+        Ok(metadata) => Ok(Some(metadata.is_dir())),
+        Err(err) if err.kind() == io::ErrorKind::NotFound || is_invalid_filename_error(&err) => {
+            Ok(None)
+        }
+        Err(err) => Err(err),
+    }
 }
 
 fn append_slash_on_path(uri: Uri, redirect_path_prefix: &str) -> Result<Uri, OpenFileOutput> {

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -351,6 +351,22 @@ async fn not_found() {
     assert!(body.is_empty());
 }
 
+#[tokio::test]
+async fn try_call_returns_not_found_error() {
+    let mut svc = ServeDir::new(REPO_ROOT);
+
+    let req = Request::builder()
+        .uri("/not-found")
+        .body(Body::empty())
+        .unwrap();
+    let err = match svc.try_call(req).await {
+        Ok(_) => panic!("expected a missing file to return an error"),
+        Err(err) => err,
+    };
+
+    assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn not_found_when_not_a_directory() {

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -367,6 +367,39 @@ async fn try_call_returns_not_found_error() {
     assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
 }
 
+#[tokio::test]
+async fn try_call_uses_fallback_for_not_found_error() {
+    async fn fallback<B>(_: Request<B>) -> Result<Response<Body>, Infallible> {
+        Ok(Response::new(Body::from("fallback")))
+    }
+
+    let mut svc = ServeDir::new(REPO_ROOT).fallback(service_fn(fallback));
+    let req = Request::builder()
+        .uri("/not-found")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.try_call(req).await.unwrap();
+
+    assert_eq!(body_into_text(res.into_body()).await, "fallback");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn try_call_returns_not_a_directory_error() {
+    let mut svc = ServeDir::new(TEST_FILES_DIR);
+
+    let req = Request::builder()
+        .uri("/index.html/some_file")
+        .body(Body::empty())
+        .unwrap();
+    let err = match svc.try_call(req).await {
+        Ok(_) => panic!("expected a non-directory path component to return an error"),
+        Err(err) => err,
+    };
+
+    assert_eq!(err.raw_os_error(), Some(20));
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn not_found_when_not_a_directory() {
@@ -1775,6 +1808,8 @@ mod memory_backend {
     struct MemBackend {
         files: Arc<HashMap<PathBuf, Vec<u8>>>,
         dirs: Arc<Vec<PathBuf>>,
+        open_error: Option<io::ErrorKind>,
+        metadata_error: Option<io::ErrorKind>,
     }
 
     impl MemBackend {
@@ -1782,6 +1817,8 @@ mod memory_backend {
             Self {
                 files: Arc::new(HashMap::new()),
                 dirs: Arc::new(Vec::new()),
+                open_error: None,
+                metadata_error: None,
             }
         }
 
@@ -1796,6 +1833,16 @@ mod memory_backend {
             Arc::get_mut(&mut self.dirs).unwrap().push(path.into());
             self
         }
+
+        fn with_open_error(mut self, error: io::ErrorKind) -> Self {
+            self.open_error = Some(error);
+            self
+        }
+
+        fn with_metadata_error(mut self, error: io::ErrorKind) -> Self {
+            self.metadata_error = Some(error);
+            self
+        }
     }
 
     impl Backend for MemBackend {
@@ -1806,7 +1853,11 @@ mod memory_backend {
 
         fn open(&self, path: PathBuf) -> Self::OpenFuture {
             let files = self.files.clone();
+            let error = self.open_error;
             Box::pin(async move {
+                if let Some(error) = error {
+                    return Err(io::Error::new(error, "open failed"));
+                }
                 match files.get(&path) {
                     Some(data) => Ok(MemFile {
                         meta: MemMetadata {
@@ -1824,7 +1875,11 @@ mod memory_backend {
         fn metadata(&self, path: PathBuf) -> Self::MetadataFuture {
             let files = self.files.clone();
             let dirs = self.dirs.clone();
+            let error = self.metadata_error;
             Box::pin(async move {
+                if let Some(error) = error {
+                    return Err(io::Error::new(error, "metadata failed"));
+                }
                 if dirs.contains(&path) {
                     return Ok(MemMetadata {
                         is_dir: true,
@@ -1876,6 +1931,39 @@ mod memory_backend {
         let res = svc.oneshot(req).await.unwrap();
 
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn unexpected_open_error_returns_internal_server_error() {
+        let backend = MemBackend::new().with_open_error(io::ErrorKind::Other);
+
+        let svc = ServeDir::with_backend("assets", backend);
+        let req = Request::builder()
+            .uri("/broken.txt")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn try_call_returns_metadata_error() {
+        let backend = MemBackend::new()
+            .with_file("./assets/hello.txt", "Hello, world!")
+            .with_metadata_error(io::ErrorKind::PermissionDenied);
+
+        let mut svc = ServeDir::with_backend("assets", backend);
+        let req = Request::builder()
+            .uri("/hello.txt")
+            .body(Body::empty())
+            .unwrap();
+        let err = match svc.try_call(req).await {
+            Ok(_) => panic!("expected a metadata error"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

`ServeDir::try_call` documents that callers can handle I/O errors themselves, but expected filesystem errors are currently converted into `404 Not Found` responses before the caller can inspect them.

Fixes #412.

## Solution

- Propagate expected filesystem I/O errors from `try_call` when no fallback is configured.
- Keep existing fallback and invalid-path behavior unchanged.
- Let the infallible `Service::call` implementation convert NotFound, PermissionDenied, and Unix ENOTDIR errors to 404 responses, and other I/O errors to 500 responses.
- Preserve error-level tracing only for errors converted to 500 responses.

## Tests

- `cargo test --offline -p tower-http --all-features -- --test-threads=1`
- `cargo check --offline --workspace --all-features --all-targets`
- `cargo clippy --offline --workspace --all-features --lib --bins --examples -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`