### PR TITLE
fs: Use HeaderValue::is_empty to check for empty values

### DIFF
--- a/tower-http/src/services/fs/serve_dir/headers.rs
+++ b/tower-http/src/services/fs/serve_dir/headers.rs
@@ -55,7 +55,7 @@ pub(super) struct IfNoneMatch(HeaderValue);
 impl IfNoneMatch {
     pub(super) fn from_header_value(value: &HeaderValue) -> Option<Self> {
         // Reject empty values
-        if value.as_bytes().is_empty() {
+        if value.is_empty() {
             return None;
         }
         Some(IfNoneMatch(value.clone()))


### PR DESCRIPTION
`HeaderValue::is_empty()` could be used instead of `HeaderValue::as_bytes().is_empty()`.