### PR TITLE
fix(decompression): don't end the body on an empty data frame

### DIFF
--- a/tower-http/src/compression_utils.rs
+++ b/tower-http/src/compression_utils.rs
@@ -241,16 +241,24 @@ where
             Some(Ok(frame)) if frame.is_trailers() => Poll::Ready(Some(Ok(
                 frame.map_data(|mut data| data.copy_to_bytes(data.remaining()))
             ))),
-            Some(Ok(frame)) => {
-                if let Ok(bytes) = frame.into_data() {
-                    if bytes.has_remaining() {
-                        return Poll::Ready(Some(Err(
-                            "there are extra bytes after body has been decompressed".into(),
-                        )));
-                    }
+            Some(Ok(frame)) => match frame.into_data() {
+                // Payload after the decompressor reported end-of-stream means
+                // the body and the compressed stream disagree about where the
+                // content ends.
+                Ok(data) if data.has_remaining() => Poll::Ready(Some(Err(
+                    "there are extra bytes after body has been decompressed".into(),
+                ))),
+                // An empty data frame carries nothing, but it is not the end of
+                // the body: trailers may still follow it. Ending the stream here
+                // would strand them, and `Body`'s contract forbids polling once
+                // `None` has been returned, so they could never be recovered.
+                Ok(mut data) => {
+                    Poll::Ready(Some(Ok(Frame::data(data.copy_to_bytes(data.remaining())))))
                 }
-                Poll::Ready(None)
-            }
+                Err(frame) => Poll::Ready(Some(Ok(
+                    frame.map_data(|mut data| data.copy_to_bytes(data.remaining()))
+                ))),
+            },
             Some(Err(err)) => Poll::Ready(Some(Err(err.into()))),
             None => Poll::Ready(None),
         }

--- a/tower-http/src/decompression/mod.rs
+++ b/tower-http/src/decompression/mod.rs
@@ -301,4 +301,56 @@ mod tests {
             "there are extra bytes after body has been decompressed"
         );
     }
+
+    #[cfg(feature = "decompression-br")]
+    #[tokio::test]
+    async fn brotli_keeps_trailers_that_follow_an_empty_data_frame() {
+        let mut compressed = Vec::new();
+        {
+            let mut encoder = brotli::CompressorWriter::new(&mut compressed, 4096, 5, 20);
+            encoder.write_all(b"Hello, World!").unwrap();
+        }
+
+        let svc = service_fn(move |_req: Request<Body>| {
+            let compressed = compressed.clone();
+            async move {
+                // An empty data frame between the payload and the trailers is
+                // legal, and must not be read as the end of the body.
+                let stream = futures_util::stream::iter([
+                    Ok::<_, Infallible>(Bytes::from(compressed)),
+                    Ok(Bytes::new()),
+                ]);
+                let mut trailers = HeaderMap::new();
+                trailers.insert(HeaderName::from_static("foo"), "bar".parse().unwrap());
+
+                Ok::<_, Infallible>(
+                    Response::builder()
+                        .header("content-encoding", "br")
+                        .body(Body::from_stream(stream).with_trailers(trailers))
+                        .unwrap(),
+                )
+            }
+        });
+        let mut client = Decompression::new(svc);
+
+        let res = client
+            .ready()
+            .await
+            .unwrap()
+            .call(Request::new(Body::empty()))
+            .await
+            .unwrap();
+
+        let collected = res.into_body().collect().await.unwrap();
+        let trailers = collected
+            .trailers()
+            .cloned()
+            .expect("trailers following an empty data frame should still arrive");
+
+        assert_eq!(trailers["foo"], "bar");
+        assert_eq!(
+            String::from_utf8(collected.to_bytes().to_vec()).unwrap(),
+            "Hello, World!"
+        );
+    }
 }


### PR DESCRIPTION
Fixes the issue discussed in #719.

After the decompressor reports end-of-stream, #712 added an arm that errors when a following frame still carries bytes. A data frame with zero remaining bytes isn't caught by that check, so it fell through to `Poll::Ready(None)` and ended the body:

```rust
Some(Ok(frame)) => {
    if let Ok(bytes) = frame.into_data() {
        if bytes.has_remaining() {
            return Poll::Ready(Some(Err(/* extra bytes */)));
        }
    }
    Poll::Ready(None)   // <- empty data frame lands here
}
```

Trailers following such a frame were dropped. Because `Body`'s contract forbids polling once `None` has been returned, they couldn't be recovered either. Before #712 the frame was forwarded and polling continued.

This forwards the empty frame instead and keeps polling. The extra-bytes error from #712 is unchanged. Frames that are neither data nor trailers are now forwarded rather than swallowed, for the same reason.

Added `brotli_keeps_trailers_that_follow_an_empty_data_frame`, which yields the compressed payload, then `Frame::data(Bytes::new())`, then trailers, and asserts both the body and the trailers arrive. It fails on the current `main` with "trailers following an empty data frame should still arrive" and passes with this change.
