### PR TITLE
ci: Update to cargo-check-external-types 0.5.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -203,11 +203,11 @@ jobs:
     - uses: actions/checkout@v7
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2025-10-18
+        toolchain: nightly-2026-03-20
     - name: Install cargo-check-external-types
       uses: taiki-e/cache-cargo-install-action@v3
       with:
-        tool: cargo-check-external-types@0.4.0
+        tool: cargo-check-external-types@0.5.0
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
Updates to `cargo-check-external-types` 0.5.0.

https://github.com/awslabs/cargo-check-external-types/releases/tag/v0.5.0