### PR TITLE
Allow ignoring unsupported multi-range requests

### DIFF
--- a/tower-http/src/services/fs/serve_dir/future.rs
+++ b/tower-http/src/services/fs/serve_dir/future.rs
@@ -284,19 +284,29 @@ fn build_response(output: FileOpened) -> Response<ResponseBody> {
                 .unwrap()
         }
 
-        Some(Err(RangeError::MultipleRangesNotSupported)) => builder
-            .header(header::CONTENT_RANGE, format!("bytes */{}", size))
-            .status(StatusCode::RANGE_NOT_SATISFIABLE)
-            .body(body_from_bytes(Bytes::from(
-                "Cannot serve multipart range requests",
-            )))
-            .unwrap(),
+        Some(Err(RangeError::MultipleRangesNotSupported)) => {
+            let mut response = builder
+                .header(header::CONTENT_RANGE, format!("bytes */{}", size))
+                .status(StatusCode::RANGE_NOT_SATISFIABLE)
+                .body(body_from_bytes(Bytes::from(
+                    "Cannot serve multipart range requests",
+                )))
+                .unwrap();
+            response.headers_mut().remove(header::CONTENT_TYPE);
+            response.headers_mut().remove(header::CONTENT_ENCODING);
+            response
+        }
 
-        Some(Err(RangeError::Unsatisfiable)) => builder
-            .header(header::CONTENT_RANGE, format!("bytes */{}", size))
-            .status(StatusCode::RANGE_NOT_SATISFIABLE)
-            .body(empty_body())
-            .unwrap(),
+        Some(Err(RangeError::Unsatisfiable)) => {
+            let mut response = builder
+                .header(header::CONTENT_RANGE, format!("bytes */{}", size))
+                .status(StatusCode::RANGE_NOT_SATISFIABLE)
+                .body(empty_body())
+                .unwrap();
+            response.headers_mut().remove(header::CONTENT_TYPE);
+            response.headers_mut().remove(header::CONTENT_ENCODING);
+            response
+        }
 
         // Not a range request
         None => {

--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -57,6 +57,7 @@ pub struct ServeDir<F = DefaultServeDirFallback, B = TokioBackend> {
     base: PathBuf,
     redirect_path_prefix: String,
     buf_chunk_size: usize,
+    ignore_multi_range_requests: bool,
     precompressed_variants: Option<PrecompressedVariants>,
     // This is used to specialize implementation for
     // single files
@@ -79,6 +80,7 @@ impl ServeDir<DefaultServeDirFallback> {
             base,
             redirect_path_prefix: String::new(),
             buf_chunk_size: DEFAULT_CAPACITY,
+            ignore_multi_range_requests: false,
             precompressed_variants: None,
             variant: ServeVariant::Directory {
                 append_index_html_on_directories: true,
@@ -98,6 +100,7 @@ impl ServeDir<DefaultServeDirFallback> {
             base: path.as_ref().to_owned(),
             redirect_path_prefix: String::new(),
             buf_chunk_size: DEFAULT_CAPACITY,
+            ignore_multi_range_requests: false,
             precompressed_variants: None,
             variant: ServeVariant::SingleFile { mime },
             fallback: None,
@@ -121,6 +124,7 @@ impl<B: Backend> ServeDir<DefaultServeDirFallback, B> {
         ServeDir {
             base,
             buf_chunk_size: DEFAULT_CAPACITY,
+            ignore_multi_range_requests: false,
             precompressed_variants: None,
             variant: ServeVariant::Directory {
                 append_index_html_on_directories: true,
@@ -187,6 +191,20 @@ impl<F, B: Backend> ServeDir<F, B> {
     /// The default capacity is 64kb.
     pub fn with_buf_chunk_size(mut self, chunk_size: usize) -> Self {
         self.buf_chunk_size = chunk_size;
+        self
+    }
+
+    /// Configure whether syntactically valid multi-range requests should be ignored.
+    ///
+    /// When enabled, a request containing multiple byte ranges is served as a normal full
+    /// response with status `200 OK`, as if the `Range` header were absent. This check happens
+    /// before semantic range validation, so overlapping, reversed, or otherwise unsatisfiable
+    /// multi-range requests are also ignored. Malformed range headers and unsatisfiable
+    /// single-range requests still result in `416 Range Not Satisfiable`.
+    ///
+    /// Defaults to `false`.
+    pub fn ignore_multi_range_requests(mut self, ignore: bool) -> Self {
+        self.ignore_multi_range_requests = ignore;
         self
     }
 
@@ -281,6 +299,7 @@ impl<F, B: Backend> ServeDir<F, B> {
             redirect_path_prefix: self.redirect_path_prefix,
             base: self.base,
             buf_chunk_size: self.buf_chunk_size,
+            ignore_multi_range_requests: self.ignore_multi_range_requests,
             precompressed_variants: self.precompressed_variants,
             variant: self.variant,
             fallback: Some(new_fallback),
@@ -446,6 +465,7 @@ impl<F, B: Backend> ServeDir<F, B> {
         let redirect_path_prefix = self.redirect_path_prefix.clone();
 
         let buf_chunk_size = self.buf_chunk_size;
+        let ignore_multi_range_requests = self.ignore_multi_range_requests;
         let range_header = req
             .headers()
             .get(header::RANGE)
@@ -467,6 +487,7 @@ impl<F, B: Backend> ServeDir<F, B> {
             negotiated_encodings,
             range_header,
             buf_chunk_size,
+            ignore_multi_range_requests,
             precompression_configured,
             backend: self.backend.clone(),
         }));

--- a/tower-http/src/services/fs/serve_dir/open_file.rs
+++ b/tower-http/src/services/fs/serve_dir/open_file.rs
@@ -59,6 +59,7 @@ pub(super) struct OpenFileRequest<B> {
     pub(super) negotiated_encodings: Vec<(Encoding, QValue)>,
     pub(super) range_header: Option<String>,
     pub(super) buf_chunk_size: usize,
+    pub(super) ignore_multi_range_requests: bool,
     pub(super) precompression_configured: bool,
     pub(super) backend: B,
 }
@@ -74,6 +75,7 @@ pub(super) async fn open_file<B: Backend>(
         negotiated_encodings,
         range_header,
         buf_chunk_size,
+        ignore_multi_range_requests,
         precompression_configured,
         backend,
     } = request;
@@ -152,7 +154,11 @@ pub(super) async fn open_file<B: Backend>(
             return Ok(output);
         }
 
-        let maybe_range = try_parse_range(range_header.as_deref(), meta.len());
+        let maybe_range = try_parse_range(
+            range_header.as_deref(),
+            meta.len(),
+            ignore_multi_range_requests,
+        );
 
         Ok(OpenFileOutput::FileOpened(Box::new(FileOpened {
             extent: FileRequestExtent::Head(meta.len()),
@@ -198,7 +204,8 @@ pub(super) async fn open_file<B: Backend>(
         }
 
         let size = meta.len();
-        let maybe_range = try_parse_range(range_header.as_deref(), size);
+        let maybe_range =
+            try_parse_range(range_header.as_deref(), size, ignore_multi_range_requests);
         if let Some(Ok(range)) = maybe_range.as_ref() {
             file.seek(SeekFrom::Start(*range.start())).await?;
         }
@@ -444,23 +451,30 @@ async fn maybe_redirect_or_append_path<B: Backend>(
 fn try_parse_range(
     maybe_range_ref: Option<&str>,
     file_size: u64,
+    ignore_multi_range_requests: bool,
 ) -> Option<Result<RangeInclusive<u64>, RangeError>> {
-    maybe_range_ref.map(|header_value| {
-        let parsed = http_range_header::parse_range_header(header_value)
-            .map_err(|_| RangeError::Unsatisfiable)?;
+    let header_value = maybe_range_ref?;
+    let parsed = match http_range_header::parse_range_header(header_value) {
+        Ok(parsed) => parsed,
+        Err(_) => return Some(Err(RangeError::Unsatisfiable)),
+    };
 
-        if parsed.ranges.len() > 1 {
-            // ServeDir/ServeFile do not support multipart responses, so reject
-            // multi-range requests before validate() runs overlap checks.
-            return Err(RangeError::MultipleRangesNotSupported);
-        }
+    if parsed.ranges.len() > 1 {
+        // ServeDir/ServeFile do not support multipart responses. Optionally ignore
+        // the Range header before validate() runs semantic and overlap checks.
+        return if ignore_multi_range_requests {
+            None
+        } else {
+            Some(Err(RangeError::MultipleRangesNotSupported))
+        };
+    }
 
-        let mut ranges = parsed
+    Some(
+        parsed
             .validate(file_size)
-            .map_err(|_| RangeError::Unsatisfiable)?;
-
-        ranges.pop().ok_or(RangeError::Unsatisfiable)
-    })
+            .map_err(|_| RangeError::Unsatisfiable)
+            .and_then(|mut ranges| ranges.pop().ok_or(RangeError::Unsatisfiable)),
+    )
 }
 
 async fn is_dir<B: Backend>(path_to_file: &Path, backend: &B) -> io::Result<Option<bool>> {

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -736,6 +736,82 @@ async fn read_partial_errs_on_bad_range() {
 }
 
 #[tokio::test]
+async fn multipart_range_can_be_ignored() {
+    let svc = ServeDir::new(REPO_ROOT).ignore_multi_range_requests(true);
+    let req = Request::builder()
+        .uri("/README.md")
+        .header("Range", "bytes=0-0,2-2")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    let file_contents = std::fs::read(README_PATH).unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(
+        res.headers()["content-length"],
+        file_contents.len().to_string()
+    );
+    assert!(res.headers().get("content-range").is_none());
+    assert_eq!(to_bytes(res.into_body()).await.unwrap(), file_contents);
+}
+
+#[tokio::test]
+async fn multipart_range_ignore_is_consistent_for_head() {
+    let svc = ServeDir::new(REPO_ROOT).ignore_multi_range_requests(true);
+    let req = Request::builder()
+        .method(Method::HEAD)
+        .uri("/README.md")
+        .header("Range", "bytes=0-0,2-2")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    let file_contents = std::fs::read(README_PATH).unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(
+        res.headers()["content-length"],
+        file_contents.len().to_string()
+    );
+    assert!(res.headers().get("content-range").is_none());
+    assert!(to_bytes(res.into_body()).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn multipart_range_ignore_applies_before_semantic_validation() {
+    for range in ["bytes=0-2,1-3", "bytes=3-1,5-6"] {
+        let svc = ServeDir::new(REPO_ROOT).ignore_multi_range_requests(true);
+        let req = Request::builder()
+            .uri("/README.md")
+            .header("Range", range)
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK, "range: {range}");
+        assert!(res.headers().get("content-range").is_none());
+    }
+}
+
+#[tokio::test]
+async fn multipart_range_ignore_keeps_other_range_errors() {
+    for range in ["bad_format", "bytes=999999999-"] {
+        let svc = ServeDir::new(REPO_ROOT).ignore_multi_range_requests(true);
+        let req = Request::builder()
+            .uri("/README.md")
+            .header("Range", range)
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(
+            res.status(),
+            StatusCode::RANGE_NOT_SATISFIABLE,
+            "range: {range}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn multipart_range_valid_returns_multipart_error_body() {
     let svc = ServeDir::new(REPO_ROOT);
     let req = Request::builder()
@@ -751,9 +827,27 @@ async fn multipart_range_valid_returns_multipart_error_body() {
         res.headers()["content-range"],
         &format!("bytes */{}", file_contents.len())
     );
+    assert!(res.headers().get(header::CONTENT_TYPE).is_none());
+    assert!(res.headers().get(header::CONTENT_ENCODING).is_none());
 
     let body = body_into_text(res.into_body()).await;
     assert_eq!(body, "Cannot serve multipart range requests");
+}
+
+#[tokio::test]
+async fn range_error_does_not_keep_precompressed_representation_headers() {
+    let svc = ServeDir::new(TEST_FILES_DIR).precompressed_gzip();
+    let req = Request::builder()
+        .uri("/precompressed.txt")
+        .header(header::ACCEPT_ENCODING, "gzip")
+        .header(header::RANGE, "bad_format")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::RANGE_NOT_SATISFIABLE);
+    assert!(res.headers().get(header::CONTENT_TYPE).is_none());
+    assert!(res.headers().get(header::CONTENT_ENCODING).is_none());
 }
 
 #[tokio::test]

--- a/tower-http/src/services/fs/serve_file.rs
+++ b/tower-http/src/services/fs/serve_file.rs
@@ -105,6 +105,13 @@ impl ServeFile {
         Self(self.0.with_buf_chunk_size(chunk_size))
     }
 
+    /// Configure whether syntactically valid multi-range requests should be ignored.
+    ///
+    /// See [`ServeDir::ignore_multi_range_requests`] for details.
+    pub fn ignore_multi_range_requests(self, ignore: bool) -> Self {
+        Self(self.0.ignore_multi_range_requests(ignore))
+    }
+
     /// Call the service and get a future that contains any `std::io::Error` that might have
     /// happened.
     ///
@@ -189,6 +196,22 @@ mod tests {
         let body = String::from_utf8(body.to_vec()).unwrap();
 
         assert!(body.starts_with("# Tower HTTP"));
+    }
+
+    #[tokio::test]
+    async fn multipart_range_can_be_ignored() {
+        let svc = ServeFile::new(README_PATH).ignore_multi_range_requests(true);
+        let request = Request::builder()
+            .header(header::RANGE, "bytes=0-0,2-2")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.oneshot(request).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert!(res.headers().get(header::CONTENT_RANGE).is_none());
+
+        let body = res.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(body.as_ref(), std::fs::read(README_PATH).unwrap());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

`ServeDir` and `ServeFile` cannot produce multipart range responses. Returning `416` for a syntactically valid multi-range request is avoidable because RFC 9110 allows a server to ignore `Range` and serve the full representation.

Fixes #725.

## Solution

Add an opt-in `ignore_multi_range_requests` setting to `ServeDir` and `ServeFile`. When enabled, syntactically valid multi-range headers are ignored before semantic range validation and the full representation is returned with `200`; malformed headers and unsatisfiable single ranges keep returning `416`.

The default remains unchanged. GET and HEAD behavior is covered, as are overlapping/reversed multi-ranges. `416` responses also stop retaining the selected representation's `Content-Type` and `Content-Encoding`, including for precompressed files.
