### PR TITLE
feat(services): configure directory redirects

### DIFF
--- a/tower-http/src/services/fs/serve_dir/mod.rs
+++ b/tower-http/src/services/fs/serve_dir/mod.rs
@@ -82,6 +82,7 @@ impl ServeDir<DefaultServeDirFallback> {
             precompressed_variants: None,
             variant: ServeVariant::Directory {
                 append_index_html_on_directories: true,
+                redirect_to_trailing_slash: true,
                 html_as_default_extension: false,
             },
             fallback: None,
@@ -124,6 +125,7 @@ impl<B: Backend> ServeDir<DefaultServeDirFallback, B> {
             precompressed_variants: None,
             variant: ServeVariant::Directory {
                 append_index_html_on_directories: true,
+                redirect_to_trailing_slash: true,
                 html_as_default_extension: false,
             },
             fallback: None,
@@ -147,6 +149,26 @@ impl<F, B: Backend> ServeDir<F, B> {
                 ..
             } => {
                 *append_index_html_on_directories = append;
+                self
+            }
+            ServeVariant::SingleFile { mime: _ } => self,
+        }
+    }
+
+    /// Whether to redirect directory requests without a trailing slash.
+    ///
+    /// When enabled, a request to `/dir` redirects to `/dir/`. When disabled,
+    /// `/dir/index.html` is served directly at `/dir` if
+    /// [`append_index_html_on_directories`](Self::append_index_html_on_directories) is enabled.
+    ///
+    /// Defaults to `true`.
+    pub fn redirect_to_trailing_slash(mut self, redirect: bool) -> Self {
+        match &mut self.variant {
+            ServeVariant::Directory {
+                redirect_to_trailing_slash,
+                ..
+            } => {
+                *redirect_to_trailing_slash = redirect;
                 self
             }
             ServeVariant::SingleFile { mime: _ } => self,
@@ -553,6 +575,7 @@ opaque_future! {
 enum ServeVariant {
     Directory {
         append_index_html_on_directories: bool,
+        redirect_to_trailing_slash: bool,
         html_as_default_extension: bool,
     },
     SingleFile {
@@ -565,6 +588,7 @@ impl ServeVariant {
         match self {
             ServeVariant::Directory {
                 append_index_html_on_directories: _,
+                redirect_to_trailing_slash: _,
                 html_as_default_extension: _,
             } => {
                 let path = requested_path.trim_start_matches('/');

--- a/tower-http/src/services/fs/serve_dir/open_file.rs
+++ b/tower-http/src/services/fs/serve_dir/open_file.rs
@@ -99,6 +99,7 @@ pub(super) async fn open_file<B: Backend>(
     let mime = match variant {
         ServeVariant::Directory {
             append_index_html_on_directories,
+            redirect_to_trailing_slash,
             html_as_default_extension,
         } => {
             // Might already at this point know a redirect or not found result should be
@@ -109,6 +110,7 @@ pub(super) async fn open_file<B: Backend>(
                 &mut path_to_file,
                 req.uri(),
                 append_index_html_on_directories,
+                redirect_to_trailing_slash,
                 html_as_default_extension,
                 &backend,
             )
@@ -403,6 +405,7 @@ async fn maybe_redirect_or_append_path<B: Backend>(
     path_to_file: &mut PathBuf,
     uri: &Uri,
     append_index_html_on_directories: bool,
+    redirect_to_trailing_slash: bool,
     html_as_default_extension: bool,
     backend: &B,
 ) -> io::Result<Option<OpenFileOutput>> {
@@ -428,7 +431,7 @@ async fn maybe_redirect_or_append_path<B: Backend>(
         return Ok(Some(OpenFileOutput::FileNotFound));
     }
 
-    if uri_path.ends_with('/') {
+    if uri_path.ends_with('/') || !redirect_to_trailing_slash {
         path_to_file.push("index.html");
         Ok(None)
     } else {

--- a/tower-http/src/services/fs/serve_dir/tests.rs
+++ b/tower-http/src/services/fs/serve_dir/tests.rs
@@ -497,6 +497,32 @@ async fn redirect_to_trailing_slash_on_dir() {
 }
 
 #[tokio::test]
+async fn serve_directory_index_without_trailing_slash_redirect() {
+    let svc = ServeDir::new(TEST_FILES_DIR).redirect_to_trailing_slash(false);
+
+    let req = Request::builder().uri("/foo").body(Body::empty()).unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    assert!(res.headers().get(header::LOCATION).is_none());
+    assert_eq!(res.headers()[header::CONTENT_TYPE], "text/html");
+    let body = body_into_text(res.into_body()).await;
+    assert_eq!(body, "<b>HTML!</b>\n");
+}
+
+#[tokio::test]
+async fn no_trailing_slash_redirect_still_respects_disabled_directory_indexes() {
+    let svc = ServeDir::new(TEST_FILES_DIR)
+        .append_index_html_on_directories(false)
+        .redirect_to_trailing_slash(false);
+
+    let req = Request::builder().uri("/foo").body(Body::empty()).unwrap();
+    let res = svc.oneshot(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn redirect_to_trailing_slash_with_redirect_path_prefix() {
     let cases = [
         ("/foo", "/src", "/foo/src/"),
@@ -1237,6 +1263,7 @@ fn test_build_and_validate_path_reserved_dos_names() {
 
     let variant = ServeVariant::Directory {
         append_index_html_on_directories: true,
+        redirect_to_trailing_slash: true,
         html_as_default_extension: false,
     };
     let base = Path::new("/base");


### PR DESCRIPTION
## Motivation

`ServeDir` always redirects `/dir` to `/dir/`, so directory indexes cannot be served directly at no-slash paths. This is the use case in #542. @mversic had also prototyped the no-redirect behavior on their fork.

## Solution

Add `redirect_to_trailing_slash(bool)`, defaulting to `true`. When disabled, `/dir` serves `/dir/index.html` directly when directory indexes are enabled. Existing redirect and 404 behavior stays unchanged.

Tested with the workspace all-feature test suite, the CI clippy command, and rustfmt.

Fixes #542
